### PR TITLE
feat: MinerU, multimodal embeddings and FAISS behind swappable backends

### DIFF
--- a/.github/workflows/full-eval.yml
+++ b/.github/workflows/full-eval.yml
@@ -1,0 +1,65 @@
+name: Full eval gate
+
+# Full gate: runs the REAL pipeline (Ollama generation and embeddings, hybrid
+# BM25+semantic retrieval, Cross-Encoder reranking) against every case in
+# tests/eval/gold_cases.jsonl and fails the run if the pass rate drops below
+# tests/eval/baseline_min_pass_rate.txt. This is the "gate completo" required
+# by docs/design/2026-07-26-monkeygrab-v2.md sections 7.2/7.3 before a phase
+# merges to main -- the fast ci.yml gate never exercises the real model or
+# retrieval path, only the domain/application layer and the grader against
+# test doubles.
+#
+# THIS GATE REQUIRES A LOCAL OLLAMA SERVER AND A CUDA GPU. The models it
+# calls (gemma4:e2b, gemma4:e4b, qwen3.5:0.8b, embeddinggemma) and the
+# reranker CrossEncoder are not available on hosted GitHub runners, so this
+# workflow only runs on a self-hosted runner where those prerequisites are
+# already met, and it is never triggered automatically (workflow_dispatch
+# only) -- it is not meant to gate every PR the way ci.yml does, only a
+# deliberate "is this phase really green" check before merge.
+#
+# tests/eval/run_eval.py is otherwise self-sufficient: it downloads any
+# missing blind-set arXiv papers, indexes whatever is not already indexed,
+# and fails with an actionable message (not a false green) if a prerequisite
+# is missing -- see tests/eval/README.md for the ratchet mechanism.
+
+on:
+  workflow_dispatch:
+    inputs:
+      models:
+        description: "Space-separated Ollama generator models to evaluate"
+        required: false
+        default: "gemma4:e2b qwen3.5:0.8b"
+      update_baseline:
+        description: "Raise the pass-rate baseline if this run is green (never lowers it)"
+        type: boolean
+        required: false
+        default: false
+
+jobs:
+  full-eval:
+    name: Full eval gate (real pipeline, self-hosted)
+    # Label must match whatever self-hosted runner has Ollama + a CUDA GPU
+    # registered for this repository; adjust if that runner's labels change.
+    runs-on: [self-hosted, gpu]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run the gold-case eval gate
+        shell: pwsh
+        env:
+          PYTHONPATH: "."
+        run: |
+          $models = "${{ inputs.models }}" -split '\s+' | Where-Object { $_ }
+          $extraArgs = @()
+          if ("${{ inputs.update_baseline }}" -eq "true") {
+            $extraArgs += "--update-baseline"
+          }
+          python tests/eval/run_eval.py --models @models @extraArgs
+
+      - name: Upload dated results JSON
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: full-eval-results
+          path: tests/eval/runs/*.json
+          if-no-files-found: warn

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,11 @@ venv/
 
 rag/vector_db/**
 
+# Per-document MinerU extraction cache (MineruExtractor / MineruImageExtractor,
+# src/monkeygrab/adapters/extraction/mineru_extractor.py): reproducible from
+# the source PDF on demand, invalidated by cache version on adapter changes.
+/.mineru_cache/
+
 rag/debug_rag/
 
 # Retrieval-experiment artifacts: vector indexes and eval runs are regenerated

--- a/docs/handoff/2026-07-27-wire-multimodal-stack.md
+++ b/docs/handoff/2026-07-27-wire-multimodal-stack.md
@@ -1,0 +1,181 @@
+# Handoff: wire the multimodal stack and run the A/B
+
+Paste this whole file as the opening prompt. It is self-contained: everything you
+need is either here or in the repository.
+
+---
+
+## What this project is
+
+A local RAG system over PDFs: hybrid retrieval (semantic + BM25 fused with RRF),
+cross-encoder reranking, and generation through a local Ollama model. No cloud,
+no API keys. Interfaces: a CLI, a Flask + React web app, and a packaged Windows
+desktop app.
+
+The owner's goals, in his words and in priority order:
+
+1. **Better at tables and images.** This is the point of the whole exercise.
+2. **More efficient** retrieval.
+3. **Swappable everything** — any technology or model replaceable by
+   configuration, so future branches can compare them automatically.
+4. **Clean architecture, no half measures.** No silent fallbacks.
+5. **CI that verifies each stage** rather than looking green.
+6. **Minimal documentation.** He is explicit that documentation bloat annoys him.
+
+## Where the work stands
+
+A hexagonal core exists under `src/monkeygrab/`: domain entities, ports,
+application use cases, adapters, immutable config. `rag/engine/*` delegates its
+pure logic there while keeping its public API, and `rag/` holds the interfaces.
+The dependency rule is enforced per layer by an AST test.
+
+Three new adapters exist and are individually verified against real inputs:
+
+| Adapter | Verified |
+|---|---|
+| MinerU extractor | 15 pages in 83 s: 4 tables with HTML intact, 5 figures with captions |
+| jina-clip-v2 embedder | Figure vs. text describing it: 0.357. Vs. unrelated text: 0.055 |
+| FAISS store | Same vectors as Chroma return the same ids in the same order |
+
+Backends are selected by environment variable: `PDF_EXTRACTOR`
+(`pymupdf`|`mineru`), `VECTOR_STORE` (`chroma`|`faiss`), `EMBEDDER`
+(`ollama`|`jina_clip`). Unknown values raise at startup. `build_stack()` in
+`src/monkeygrab/composition.py` returns the three built adapters.
+
+**Nothing is wired.** The indexing use case still receives whatever its caller
+constructs by hand, and the current stack remains the default.
+
+## The measurement you are working against
+
+The gate runs 51 gold cases whose every answer was verified by reading the cited
+page of the source PDF. Current stack, with `gemma4:e2b`:
+
+| Case type | Pass |
+|---|---|
+| `factual_number` | 21/25 (84%) |
+| `factual_concept` | 8/11 (73%) |
+| `figure_retrieval` | 5/10 (50%) |
+| `table_retrieval` | **0/5 (0%)** |
+
+Overall 34/51 (66.7%). Baseline threshold: 0.61.
+
+Three of the papers (ResNet, BERT, ViT) are a **blind set**: the retrieval
+heuristics were tuned on "Attention is all you need", and the figure failures
+cluster in the blind set. Treat a gain that appears only on the development
+papers as suspect.
+
+## Environment
+
+- **Python interpreter for everything**: `C:\Users\nadiv\anaconda3\python.exe`.
+  Not the one on PATH — that one lacks the dependencies.
+- Tests: `C:\Users\nadiv\anaconda3\python.exe -m pytest -q --no-header`.
+  Currently **324 passed, 1 skipped**.
+- Lint: `C:\Users\nadiv\anaconda3\python.exe -m ruff check .` — currently clean.
+- Ollama runs locally with `gemma4:e4b`, `gemma4:e2b`, `qwen3.5:0.8b`,
+  `embeddinggemma:latest`. GPU: RTX 4060 Laptop, **8 GB** — one model at a time,
+  two generators at once will make Ollama return HTTP 500.
+- `.venv-mineru/Scripts/python.exe` is an isolated venv holding MinerU's CLI and
+  the only environment where jina-clip loads. The embedder adapter drives a
+  worker process there.
+
+## Hard constraints — do not violate these
+
+**Files you must not modify.** They are the only reason a green result means
+anything:
+
+- `tests/characterization/**` — pins the pipeline's current behaviour, bugs
+  included. If one fails, your change altered behaviour: fix your change.
+- `tests/eval/gold_cases.jsonl` — the questions and their verified answers.
+- `tests/eval/baseline_min_pass_rate.txt` — the regression threshold.
+
+If the gate fails, the answer is never to adjust the judge, lower the threshold,
+or drop hard cases. Report the number you got.
+
+**Decisions already made. Do not revisit them:**
+
+- **jina-clip-v2 cannot run in the main environment.** Under transformers 5.1 it
+  fails initializing weights; disabling lazy init and forcing CPU do not help. It
+  works under transformers 4.57, which is why it runs out of process. **Do not
+  fix this by downgrading transformers in the main environment** — it would
+  degrade every other project sharing that interpreter.
+- **MinerU is an external CLI**, never a Python dependency. Its pins conflict
+  with the product's.
+- **CUDA is required** for the multimodal embedder, deliberately: CPU embedding
+  measured ~100 s per document, so failing loudly beats degrading silently.
+- **Hard-fail everywhere.** No adapter degrades to a substitute. Two documented
+  exceptions exist (image extraction, and one explicit CUDA→CPU reranker retry);
+  do not add a third.
+- **You do not decide the default stack.** Run the A/B, report the numbers, stop.
+  The owner chooses.
+
+## Tasks
+
+Do them in order. Each has an acceptance criterion checkable by a command, not by
+your judgement.
+
+### 1. Point the indexing use case at the selected backends
+
+`IndexCorpus` receives its ports by constructor. Make the caller build them from
+configuration via `build_stack()` instead of hardcoding them. Do not change the
+public API of `rag/chat_pdfs.py`: the web layer imports from it, including three
+private symbols.
+
+**Accept when**: with no environment variables set, `pytest` still reports 324
+passed / 1 skipped and `tests/characterization/` shows an empty `git diff`.
+
+### 2. Index a corpus with the new stack
+
+```
+PDF_EXTRACTOR=mineru VECTOR_STORE=faiss EMBEDDER=jina_clip
+```
+
+The index path already carries a stack slug, so the new index cannot collide with
+the existing one. Expect this to be slow: MinerU is ~80 s per paper and the
+embedder needs ~28 s to load once.
+
+**Accept when**: the index exists and contains chunks whose format is `table` and
+whose format is `image`. If there are zero table chunks, stop and diagnose —
+that is the single most important signal in this whole task. Note that
+`_text_chunk_format` in `index_corpus.py` marks a chunk as a table when it
+contains HTML table markup; if MinerU's tables are not reaching it, the wiring is
+wrong.
+
+### 3. Run the A/B
+
+Run `tests/eval/run_eval.py` twice against the same 51 cases: once with the
+current stack, once with the new one. Same model (`gemma4:e2b`) both times.
+
+**Accept when**: two result JSONs exist under `tests/eval/runs/` and you can
+state, per case type, how each stack scored. A run reporting infrastructure
+errors is inconclusive and does not count — rerun it with nothing else using the
+GPU.
+
+### 4. Report
+
+Write the comparison into the pull request: the table by case type, both stacks
+side by side, and for every case that changed verdict, which one and why you
+think so. Say plainly if the new stack loses. Do not change the default.
+
+## How to work
+
+- Read the code before changing it. `src/monkeygrab/README.md` explains the
+  layers and how to add an adapter; `docs/design/2026-07-26-monkeygrab-v2.md` is
+  the design of record and outranks any other document.
+- Comments explain **why**, never mechanics, and never reference plan steps or
+  task numbers.
+- Work on a branch off `feat/multimodal-stack`. Do not commit to `main`.
+- If something contradicts these instructions, say so instead of guessing. One
+  instruction in this project was already wrong — it asked a store to raise on
+  absent ids, contradicting its port — and catching it was worth more than
+  complying.
+
+## Traps that have already cost time
+
+- **A perfectly extracted table indexed as prose is invisible.** Extraction was
+  only half the value; the chunk has to be marked as a table. This was the actual
+  cause of the 0/5, not MinerU's absence.
+- **Two Ollama models at once on 8 GB** kills a 36-minute eval run with an HTTP
+  500 halfway through.
+- **Local success does not imply CI success.** A dependency installed by hand
+  while developing will not exist on a runner, and some failures only reproduce
+  on Linux.

--- a/rag/requirements.txt
+++ b/rag/requirements.txt
@@ -11,13 +11,19 @@ python-dotenv>=1.0.0
 
 sentence-transformers>=2.2.0
 
-# The multimodal retrieval stack (jina-clip embeddings + FAISS) is deliberately
-# absent here. The spike validated it inside an isolated venv whose torch and
-# transformers are OLDER than the ones this project actually runs on, so
-# copying those pins would silently downgrade a working environment. The
-# versions get resolved against the real runtime when the multimodal adapters
-# land, not before.
+# FAISS backs the alternative vector store. It is a required dependency rather
+# than an optional one so the test proving FAISS and Chroma return identical
+# rankings runs on every build: a claim of interchangeability that CI never
+# exercises decays into a comment.
+faiss-cpu>=1.8
+
+# Two pieces of the multimodal stack are deliberately NOT here.
 #
-# MinerU is never a Python dependency of the product: it is an external CLI
-# invoked through subprocess, precisely so its own pins cannot collide with
-# ours.
+# MinerU is an external CLI, invoked through subprocess. Its own pins conflict
+# with these, and the adapter only needs the binary.
+#
+# jina-clip-v2 cannot run in this environment at all: under transformers 5.x it
+# fails initializing weights, and neither disabling lazy init nor forcing CPU
+# helps. It loads under transformers 4.57, so it lives in an isolated venv and
+# the adapter drives a worker process there. Pinning transformers down to suit
+# one model would degrade every other consumer of this file.

--- a/src/monkeygrab/README.md
+++ b/src/monkeygrab/README.md
@@ -41,6 +41,18 @@ The full use-case classes (`IndexCorpus`, `Retrieve`, `Answer`) exist and are
 independently unit-tested, but nothing in the CLI or web layer constructs or
 calls them yet — that wiring is future work. Don't document it as done.
 
+## Adapters whose dependencies collide with the product's
+
+`adapters/embedding/jina_clip_embedder.py` is the first adapter whose
+library doesn't fit the product's pinned stack at all: jina-clip-v2's remote
+code only loads under an older transformers than the one the product runs.
+Rather than downgrade the product environment for one model, the pattern is
+to run the dependency in its own isolated interpreter (here, `.venv-mineru`)
+as a persistent subprocess, speaking line-JSON over stdin/stdout
+(`jina_clip_worker.py`, never imported by product code). MinerU is expected
+to follow the same shape when it's added. The adapter itself stays pure
+stdlib either way, so its unit tests never need the isolated environment.
+
 ## Adding a new adapter (e.g. to compare a retrieval technology)
 
 1. Pick the port it implements (`ports/<name>.py`) and read its docstring —

--- a/src/monkeygrab/adapters/embedding/__init__.py
+++ b/src/monkeygrab/adapters/embedding/__init__.py
@@ -4,7 +4,9 @@
 # MODULE MAP -- Section index
 # ─────────────────────────────────────────────
 #
-#  +-- ollama_embedder.py   OllamaEmbedder   -- ollama.embeddings
+#  +-- ollama_embedder.py    OllamaEmbedder    -- ollama.embeddings
+#  +-- jina_clip_embedder.py JinaClipEmbedder  -- text+image, via out-of-process worker
+#  +-- jina_clip_worker.py   (not an adapter)  -- runs only under .venv-mineru; see its docstring
 #
 # ─────────────────────────────────────────────
 """

--- a/src/monkeygrab/adapters/embedding/jina_clip_embedder.py
+++ b/src/monkeygrab/adapters/embedding/jina_clip_embedder.py
@@ -1,0 +1,391 @@
+"""JinaClipEmbedder -- Embedder/ImageEmbedder adapter over an out-of-process jina-clip-v2 worker.
+
+# ─────────────────────────────────────────────
+# MODULE MAP -- Section index
+# ─────────────────────────────────────────────
+#
+#  +-- 1. CONSTANTS         truncation dim, default timeouts, worker script path
+#  +-- 2. WORKER LIFECYCLE  lazy start, one persistent subprocess, hard-fail on death
+#  +-- 3. ADAPTER           JinaClipEmbedder: Embedder.embed + ImageEmbedder.embed_image
+#  +-- 4. VECTOR MATH       pure, unit-testable L2-normalize / normalized-sum combination
+#
+# ─────────────────────────────────────────────
+
+License note (jina-clip-v2, CC BY-NC): this adapter loads a non-commercial-
+licensed model. That is an accepted, documented decision for this project's
+personal/portfolio use
+(docs/design/2026-07-26-monkeygrab-v2.md, section 3) -- not something to
+re-litigate in code; a deployment under a different license needs a
+different embedding model, not a change to this file.
+
+Why out-of-process at all: jina-clip-v2's remote code targets transformers
+4.x and fails to import under the product's transformers 5.1 (`Tensor.item()
+cannot be called on meta tensors`, reproduced with lazy loading disabled and
+CPU forced). It DOES load in the isolated `.venv-mineru` environment (torch
+2.6.0+cu124, transformers 4.57.6, sentence-transformers 5.6.1). Rather than
+downgrade the product's pinned stack to accommodate one model, this adapter
+runs the model in that isolated interpreter as a persistent subprocess
+(`jina_clip_worker.py`, same directory) and speaks line-JSON over its
+stdin/stdout -- the same design MinerU uses as an external CLI, for the same
+reason: colliding dependency pins, isolated by process boundary instead of
+by degrading either environment. This file itself imports nothing but the
+standard library, so it (and its unit tests) run in the product environment
+without torch, CUDA, or the model ever being touched.
+"""
+
+import itertools
+import json
+import math
+import os
+import queue
+import subprocess
+import threading
+from pathlib import Path
+from typing import Dict, List, Optional
+
+# Not subclassed from monkeygrab.ports.embedder.Embedder /
+# monkeygrab.ports.image_embedder.ImageEmbedder: Protocol conformance here is
+# structural (duck typing), the same contract every other adapter in this
+# package satisfies without inheriting its port.
+
+# ─────────────────────────────────────────────
+# SECTION 1: CONSTANTS
+# ─────────────────────────────────────────────
+
+_TRUNCATE_DIM = 512  # must match jina_clip_worker.py's _TRUNCATE_DIM
+# Cold model load was measured at ~29s in the spike; generous margin for a
+# slower disk/first-run cache warm-up without masking a genuinely hung worker.
+_DEFAULT_STARTUP_TIMEOUT_S = 180.0
+_DEFAULT_REQUEST_TIMEOUT_S = 60.0
+_WORKER_SCRIPT = str(Path(__file__).with_name("jina_clip_worker.py"))
+
+# Sentinel distinct from any real message, used by the stdout-reading thread
+# to signal "the pipe closed" (worker died) without waiting for a timeout.
+_EOF = object()
+
+
+# ─────────────────────────────────────────────
+# SECTION 2: WORKER LIFECYCLE
+# ─────────────────────────────────────────────
+
+
+class JinaClipEmbedder:
+    """Embeds text and images via a persistent jina-clip-v2 worker subprocess.
+
+    The worker is started lazily on the first ``embed``/``embed_image`` call
+    (never at construction time -- building this adapter, e.g. in a test
+    with ``subprocess.Popen`` doubled, never launches a real process) and
+    reused across every subsequent call: loading the model costs ~29s, so a
+    process per call would make indexing a real corpus infeasible. Call
+    ``close()`` when done to terminate the worker; it is also attempted
+    best-effort on garbage collection, but an explicit ``close()`` is the
+    caller's responsibility, matching every other resource in this project.
+
+    Truncation is fixed at 512 dimensions (Matryoshka), the value verified
+    in the spike; not a constructor parameter.
+
+    Tables are never routed through ``embed_image``: they are indexed as
+    their HTML text via ``embed`` instead (docs/design/2026-07-26-
+    monkeygrab-v2.md, section "F3") -- that routing decision belongs to the
+    caller (the multimodal indexing use case), not this adapter.
+
+    Failure policy: hard-fail, with one deliberate exception to "restart
+    transparently" -- once the worker process is observed dead (either
+    mid-request, via a closed stdout pipe, or lazily on the next call), this
+    adapter never respawns it silently. A crash loop (e.g. repeated CUDA
+    OOM) must surface as a repeated, visible failure, not disappear behind
+    what looks like uninterrupted operation. A caller that wants a fresh
+    worker constructs a new ``JinaClipEmbedder``.
+    """
+
+    def __init__(
+        self,
+        python_executable: str,
+        *,
+        worker_script: str = _WORKER_SCRIPT,
+        startup_timeout_s: float = _DEFAULT_STARTUP_TIMEOUT_S,
+        request_timeout_s: float = _DEFAULT_REQUEST_TIMEOUT_S,
+    ):
+        """Args:
+            python_executable: Path to the isolated environment's python
+                (e.g. ``.venv-mineru/Scripts/python.exe``) that has jina-
+                clip-v2's dependencies installed. Required, not defaulted --
+                that path is machine-specific and this project never
+                captures machine-specific config in a default argument.
+            worker_script: Path to ``jina_clip_worker.py``. Defaults to the
+                copy shipped next to this file; overridable for tests.
+            startup_timeout_s: Seconds to wait for the worker's "ready"
+                message before giving up on the cold model load.
+            request_timeout_s: Seconds to wait for a response to any single
+                embed request before treating the worker as hung.
+        """
+        self._python_executable = python_executable
+        self._worker_script = worker_script
+        self._startup_timeout_s = startup_timeout_s
+        self._request_timeout_s = request_timeout_s
+
+        self._process: Optional[subprocess.Popen] = None
+        self._responses: "queue.Queue" = queue.Queue()
+        self._stderr_tail: List[str] = []
+        self._next_id = itertools.count(1)
+        self._dead_reason: Optional[str] = None
+
+    # --- lifecycle ------------------------------------------------------
+
+    def _ensure_worker(self) -> subprocess.Popen:
+        if self._process is not None:
+            if self._process.poll() is None:
+                return self._process
+            # The process object exists but has already exited -- record it
+            # as dead instead of silently spawning a replacement (see class
+            # docstring: a crash loop must stay visible).
+            exit_code = self._process.poll()
+            self._process = None
+            self._dead_reason = (
+                f"jina-clip worker exited (code {exit_code}) between calls; "
+                f"stderr: {self._format_stderr()}"
+            )
+
+        if self._dead_reason is not None:
+            raise RuntimeError(f"jina-clip worker is no longer usable: {self._dead_reason}")
+
+        self._start_worker()
+        return self._process
+
+    def _start_worker(self) -> None:
+        try:
+            process = subprocess.Popen(
+                [self._python_executable, self._worker_script],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                encoding="utf-8",
+                bufsize=1,
+            )
+        except OSError as exc:
+            raise RuntimeError(
+                f"could not start the jina-clip worker with interpreter "
+                f"{self._python_executable!r}: {exc}"
+            ) from exc
+
+        self._process = process
+        self._responses = queue.Queue()
+        self._stderr_tail = []
+        threading.Thread(target=self._pump_stdout, args=(process,), daemon=True).start()
+        threading.Thread(target=self._pump_stderr, args=(process,), daemon=True).start()
+
+        ready = self._await_message(self._startup_timeout_s, phase="starting up")
+
+        if ready.get("event") == "fatal":
+            self._fail_dead(f"jina-clip worker failed to start: {ready.get('error')}")
+        if ready.get("event") != "ready":
+            self._fail_dead(f"jina-clip worker sent an unexpected startup message: {ready!r}")
+        if ready.get("dim") != _TRUNCATE_DIM:
+            self._fail_dead(
+                f"jina-clip worker reported dim={ready.get('dim')!r}, expected "
+                f"{_TRUNCATE_DIM} (truncate_dim mismatch between adapter and worker)"
+            )
+
+    def _pump_stdout(self, process: subprocess.Popen) -> None:
+        try:
+            for line in process.stdout:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    message = json.loads(line)
+                except json.JSONDecodeError:
+                    message = {"event": "fatal", "error": f"worker sent a non-JSON line: {line!r}"}
+                self._responses.put(message)
+        finally:
+            # The pipe closed (worker exited). Unblock whoever is waiting
+            # immediately instead of making them sit through the full
+            # timeout to discover the same thing.
+            self._responses.put(_EOF)
+
+    def _pump_stderr(self, process: subprocess.Popen) -> None:
+        try:
+            for line in process.stderr:
+                self._stderr_tail.append(line.rstrip())
+                del self._stderr_tail[:-20]  # keep only the tail for the eventual error message
+        except Exception:
+            pass
+
+    def _format_stderr(self) -> str:
+        return " | ".join(self._stderr_tail) if self._stderr_tail else "(no stderr captured)"
+
+    def _await_message(self, timeout_s: float, *, phase: str) -> dict:
+        try:
+            item = self._responses.get(timeout=timeout_s)
+        except queue.Empty:
+            self._fail_dead(
+                f"jina-clip worker did not respond within {timeout_s}s while {phase}"
+            )
+        if item is _EOF:
+            exit_code = self._process.poll() if self._process is not None else None
+            self._fail_dead(
+                f"jina-clip worker exited unexpectedly while {phase} "
+                f"(exit code {exit_code}); stderr: {self._format_stderr()}"
+            )
+        return item
+
+    def _fail_dead(self, reason: str) -> None:
+        """Mark the worker permanently unusable and raise. Never returns."""
+        self._dead_reason = reason
+        process, self._process = self._process, None
+        if process is not None and process.poll() is None:
+            process.kill()
+        raise RuntimeError(reason)
+
+    def close(self) -> None:
+        """Terminate the worker process, if one is running. Safe to call more than once."""
+        process, self._process = self._process, None
+        if process is None or process.poll() is not None:
+            return
+        try:
+            process.stdin.close()
+        except Exception:
+            pass
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            process.kill()
+
+    def __del__(self):
+        # Best-effort only: an orphaned GPU process is worse than a slightly
+        # late cleanup, but callers should still call close() explicitly.
+        try:
+            self.close()
+        except Exception:
+            pass
+
+    # --- request/response -------------------------------------------------
+
+    def _request(self, op: str, payload: Dict[str, str]) -> List[float]:
+        self._ensure_worker()
+        request_id = next(self._next_id)
+        message = {"id": request_id, "op": op, **payload}
+
+        try:
+            self._process.stdin.write(json.dumps(message) + "\n")
+            self._process.stdin.flush()
+        except (BrokenPipeError, OSError) as exc:
+            self._fail_dead(f"jina-clip worker's stdin pipe is broken: {exc}")
+
+        response = self._await_message(self._request_timeout_s, phase=f"handling op={op!r}")
+
+        if "event" in response:
+            # A startup-shaped message ("fatal", or a non-JSON line the reader
+            # thread couldn't parse) arriving mid-request is a protocol
+            # violation, not a normal id-keyed response -- report it as such
+            # instead of falling through to a confusing id-mismatch error.
+            self._fail_dead(
+                f"jina-clip worker protocol violation while handling op={op!r}: "
+                f"{response.get('error', response)}"
+            )
+        if response.get("id") != request_id:
+            self._fail_dead(
+                f"jina-clip worker response id {response.get('id')!r} does not match "
+                f"request id {request_id!r} -- protocol desynchronized"
+            )
+        if not response.get("ok"):
+            raise RuntimeError(
+                f"jina-clip worker reported an error for op={op!r}: {response.get('error')}"
+            )
+
+        vector = response.get("vector")
+        if not isinstance(vector, list) or len(vector) != _TRUNCATE_DIM:
+            got = len(vector) if isinstance(vector, list) else type(vector).__name__
+            raise RuntimeError(
+                f"jina-clip worker returned a vector of unexpected shape for op={op!r}: "
+                f"expected {_TRUNCATE_DIM} floats, got {got}"
+            )
+        return vector
+
+    # ─────────────────────────────────────────────
+    # SECTION 3: ADAPTER
+    # ─────────────────────────────────────────────
+
+    def embed(self, text: str, *, keep_alive: Optional[int] = None) -> List[float]:
+        """Embed ``text`` via the out-of-process jina-clip-v2 worker.
+
+        Satisfies the ``Embedder`` port. ``keep_alive`` is accepted for
+        signature compatibility with that port but has no effect here: VRAM
+        residency is governed by the worker process's own lifetime (see
+        ``close``), not a per-call parameter like Ollama's -- the worker
+        keeps the model loaded across calls by design.
+
+        Args:
+            text: Text to embed.
+            keep_alive: Unused; present only to satisfy the ``Embedder``
+                port signature.
+
+        Returns:
+            The 512-dimensional embedding vector.
+
+        Raises:
+            RuntimeError: On any worker startup, protocol, or embedding failure.
+        """
+        return self._request("text", {"text": text})
+
+    def embed_image(self, image_path: str, *, caption: str = "") -> List[float]:
+        """Embed the image at ``image_path``, combined with ``caption`` if real.
+
+        Satisfies the ``ImageEmbedder`` port. When ``caption`` is non-empty
+        (after stripping whitespace -- a caption that is empty or only
+        whitespace is treated exactly like "no caption", never sent to the
+        model), the image and caption vectors are each L2-normalized, summed
+        element-wise, and the SUM is re-normalized to unit length -- not
+        averaged. Mathematically, normalizing a sum and normalizing an
+        average point in the same direction (normalization removes the
+        scalar factor), so the real risk an arithmetic mean introduces is
+        someone returning `(v1 + v2) / 2` WITHOUT the final re-normalization
+        step: that vector has sub-unit norm, and every image+caption chunk
+        would then silently under-rank against the unit-normalized
+        text-only vectors sharing the same FAISS inner-product index. The
+        combination here always ends in a fresh L2 normalization specifically
+        to rule that out.
+
+        Args:
+            image_path: Path to the image file on disk.
+            caption: Caption text found near the image, if any.
+
+        Returns:
+            The 512-dimensional combined embedding vector.
+
+        Raises:
+            RuntimeError: If ``image_path`` does not exist, or on any
+                worker startup, protocol, or embedding failure.
+        """
+        if not os.path.isfile(image_path):
+            raise RuntimeError(f"jina-clip: image file not found: {image_path!r}")
+
+        image_vector = _l2_normalize(self._request("image", {"path": image_path}))
+
+        caption = caption.strip()
+        if not caption:
+            return image_vector
+
+        # _request already enforces both vectors are exactly _TRUNCATE_DIM long,
+        # so no separate dimension-mismatch check is needed here.
+        caption_vector = _l2_normalize(self._request("text", {"text": caption}))
+        combined = [a + b for a, b in zip(image_vector, caption_vector)]
+        return _l2_normalize(combined)
+
+
+# ─────────────────────────────────────────────
+# SECTION 4: VECTOR MATH
+# ─────────────────────────────────────────────
+
+
+def _l2_normalize(vector: List[float]) -> List[float]:
+    """Return ``vector`` scaled to unit L2 norm. Pure function, no I/O.
+
+    Kept free of any worker/subprocess dependency so the image+caption
+    combination rule is directly unit-testable without doubling anything.
+    """
+    norm = math.sqrt(sum(component * component for component in vector))
+    if norm == 0.0:
+        raise RuntimeError("jina-clip: cannot L2-normalize a zero vector")
+    return [component / norm for component in vector]

--- a/src/monkeygrab/adapters/embedding/jina_clip_worker.py
+++ b/src/monkeygrab/adapters/embedding/jina_clip_worker.py
@@ -108,7 +108,28 @@ def _load_model():
     except Exception as exc:
         _fatal(f"failed to load {_MODEL_NAME!r}: {exc}")
 
+    _patch_declared_modalities(model)
     return model
+
+
+def _patch_declared_modalities(model) -> None:
+    """Work around a version-skew gap between jina-clip-v2's remote code and
+    sentence-transformers 5.x's modality validation.
+
+    sentence-transformers 5.x added a strict pre-flight check in `.encode()`
+    that rejects any input whose type isn't in the module's declared
+    `modalities` list. `InputModule.modalities` defaults to `["text"]` and
+    jina-clip-v2's remote `custom_st.Transformer` (written before this
+    feature existed) never overrides it -- so `.encode()` refuses images with
+    "Modality 'image' is not supported", even though that same class's own
+    `tokenize()`/`forward()` implementation (verified by reading its source)
+    fully handles `PIL.Image.Image` inputs via `get_image_features`. This
+    patches only the DECLARATION read by the pre-flight check, on the class
+    object loaded into this process -- it does not modify the cached remote
+    code file, and it does not change what the model computes.
+    """
+    inner_module = model[0]
+    inner_module.__class__.modalities = property(lambda self: ["text", "image"])
 
 
 # ─────────────────────────────────────────────

--- a/src/monkeygrab/adapters/embedding/jina_clip_worker.py
+++ b/src/monkeygrab/adapters/embedding/jina_clip_worker.py
@@ -1,0 +1,168 @@
+"""jina_clip_worker.py -- persistent out-of-process host for jina-clip-v2.
+
+# ─────────────────────────────────────────────
+# MODULE MAP -- Section index
+# ─────────────────────────────────────────────
+#
+#  +-- 1. CONSTANTS       model name, Matryoshka truncation dimension
+#  +-- 2. STARTUP         CUDA hard-check, model load, "ready"/"fatal" handshake
+#  +-- 3. REQUEST HANDLING  one line-JSON request in, one line-JSON response out
+#  +-- 4. MAIN LOOP       read stdin until EOF, dispatch, never crash on a bad request
+#
+# ─────────────────────────────────────────────
+
+Runs ONLY under the isolated `.venv-mineru` interpreter (torch 2.6.0+cu124,
+transformers 4.57.6, sentence-transformers 5.6.1) -- jina-clip-v2's remote
+code is written against transformers 4.x and fails to load under the
+product's own transformers 5.1 environment (`Tensor.item() cannot be called
+on meta tensors`, reproduced with lazy loading disabled and CPU forced).
+Never imported by product code: `JinaClipEmbedder`
+(`monkeygrab.adapters.embedding.jina_clip_embedder`) launches this file as a
+subprocess with `.venv-mineru`'s python and talks to it over stdin/stdout,
+exactly like MinerU is invoked as an external CLI -- same reasoning, the
+dependency graphs collide and the product environment is not degraded to
+accommodate one adapter.
+
+Wire protocol, one JSON object per line, UTF-8, always flushed immediately
+(the parent blocks on readline otherwise):
+
+  stdin  -> {"id": <int>, "op": "text",  "text": <str>}
+          | {"id": <int>, "op": "image", "path": <str>}
+  stdout <- {"event": "ready", "dim": <int>}                    -- once, after model load
+          | {"event": "fatal", "error": <str>}                  -- once, then exit(1)
+          | {"id": <int>, "ok": true,  "vector": [<float>, ...]}
+          | {"id": <int>, "ok": false, "error": <str>}
+
+A per-request failure (bad op, missing file, backend error) replies with
+`ok: false` and keeps the process alive -- one bad request must not take
+down a worker that took ~29s to load. Only a startup failure (no CUDA, the
+model itself refuses to load) is fatal to the whole process; the caller
+must restart it explicitly rather than have it silently come back in a
+degraded state.
+"""
+
+import json
+import sys
+
+# ─────────────────────────────────────────────
+# SECTION 1: CONSTANTS
+# ─────────────────────────────────────────────
+
+_MODEL_NAME = "jinaai/jina-clip-v2"
+# Matryoshka truncation: jina-clip-v2's native dimension is 1024; 512 is the
+# value verified in the spike (loads, produces correctly-discriminating
+# text<->image similarity) and is fixed here, not exposed as a knob --
+# changing it means re-verifying discrimination quality, not a config edit.
+_TRUNCATE_DIM = 512
+
+
+def _emit(message: dict) -> None:
+    """Write one line-JSON message to stdout and flush immediately.
+
+    Without an explicit flush, stdout stays block-buffered when it's a pipe
+    (not a TTY), and the parent process's readline blocks forever waiting
+    for a message that is sitting in an unflushed buffer.
+    """
+    print(json.dumps(message), flush=True)
+
+
+def _fatal(error: str) -> None:
+    """Report a startup failure and terminate. Never returns."""
+    _emit({"event": "fatal", "error": error})
+    sys.exit(1)
+
+
+# ─────────────────────────────────────────────
+# SECTION 2: STARTUP
+# ─────────────────────────────────────────────
+
+
+def _load_model():
+    """Hard-check CUDA, then load jina-clip-v2. Exits the process on any failure.
+
+    CUDA is required, not preferred: the spike measured ~100s/document on
+    CPU, which makes indexing a real corpus infeasible. Degrading to CPU
+    silently would trade a clear startup error for a pipeline that "works"
+    but is unusable in practice -- the hard-fail policy this project uses
+    everywhere applies here too.
+    """
+    try:
+        import torch
+    except ImportError as exc:
+        _fatal(f"torch is not installed in this interpreter: {exc}")
+
+    if not torch.cuda.is_available():
+        _fatal(
+            "CUDA is required to run jina-clip-v2 (the CPU path was measured at "
+            "~100s/document, infeasible for indexing) but torch.cuda.is_available() "
+            "is False in this worker's interpreter."
+        )
+
+    try:
+        from sentence_transformers import SentenceTransformer
+    except ImportError as exc:
+        _fatal(f"sentence-transformers is not installed in this interpreter: {exc}")
+
+    try:
+        model = SentenceTransformer(_MODEL_NAME, trust_remote_code=True, device="cuda")
+    except Exception as exc:
+        _fatal(f"failed to load {_MODEL_NAME!r}: {exc}")
+
+    return model
+
+
+# ─────────────────────────────────────────────
+# SECTION 3: REQUEST HANDLING
+# ─────────────────────────────────────────────
+
+
+def _handle_request(line: str, model) -> None:
+    """Parse and answer one request line. Always replies; never raises."""
+    try:
+        request = json.loads(line)
+    except json.JSONDecodeError as exc:
+        # No id could be recovered from unparsable input; the adapter treats
+        # a response with id=None as a protocol desync and fails loudly.
+        _emit({"id": None, "ok": False, "error": f"invalid JSON request: {exc}"})
+        return
+
+    request_id = request.get("id")
+    op = request.get("op")
+
+    try:
+        if op == "text":
+            text = request["text"]
+            vector = model.encode(text, truncate_dim=_TRUNCATE_DIM, normalize_embeddings=True)
+        elif op == "image":
+            from PIL import Image
+
+            with Image.open(request["path"]) as image:
+                image = image.convert("RGB")
+                vector = model.encode(
+                    image, truncate_dim=_TRUNCATE_DIM, normalize_embeddings=True
+                )
+        else:
+            raise ValueError(f"unknown op {op!r}")
+        _emit({"id": request_id, "ok": True, "vector": vector.tolist()})
+    except Exception as exc:
+        _emit({"id": request_id, "ok": False, "error": str(exc)})
+
+
+# ─────────────────────────────────────────────
+# SECTION 4: MAIN LOOP
+# ─────────────────────────────────────────────
+
+
+def main() -> None:
+    model = _load_model()
+    _emit({"event": "ready", "dim": _TRUNCATE_DIM})
+
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        _handle_request(line, model)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/monkeygrab/adapters/extraction/mineru_extractor.py
+++ b/src/monkeygrab/adapters/extraction/mineru_extractor.py
@@ -1,0 +1,499 @@
+"""MineruExtractor / MineruImageExtractor -- PdfExtractor and ImageExtractor
+adapters over the MinerU CLI (`-b pipeline` backend).
+
+# ─────────────────────────────────────────────
+# MODULE MAP -- Section index
+# ─────────────────────────────────────────────
+#
+#  +-- SECTION 1: CLI INVOCATION + CACHE  -- _run_mineru and its helpers
+#  +-- SECTION 2: CONTENT-LIST PARSING    -- pure, testable block -> text/image mapping
+#  +-- SECTION 3: MineruExtractor         -- PdfExtractor adapter
+#  +-- SECTION 4: MineruImageExtractor    -- ImageExtractor adapter
+#
+# ─────────────────────────────────────────────
+
+MinerU is never a Python dependency of this product (see rag/requirements.txt):
+it is an external CLI, invoked through ``subprocess`` against its own isolated
+venv, so its pins never collide with the product's. Both adapters in this
+module share one CLI invocation per PDF (``_run_mineru``) -- MinerU emits
+Markdown, a structured ``*_content_list.json`` and cropped figures in a single
+run, so calling it twice (once per port) would double the cost for nothing.
+
+Two adapters, not one, because ``PdfExtractor`` and ``ImageExtractor`` are two
+separate ``Protocol``s, each requiring its own ``extract(pdf_path)`` method
+with a different return type -- a single class cannot satisfy both under the
+same method name.
+
+**Tables are this adapter's reason for existing** (issue #3): MinerU reports
+each table as a block with a `table_body` HTML string, which SECTION 2 copies
+into the page text verbatim, wrapped in its `<table>`/`</table>` tags. Nothing
+downstream needs to know it came from MinerU to notice it -- an HTML table
+tag inside a chunk's text is grep-able as "this chunk is a table" on its own,
+without depending on any adapter-specific signal. Images are never rendered
+as HTML/base64 inline text: they go through ``MineruImageExtractor`` instead,
+matching this project's multimodal image pipeline (docs/design/2026-07-26-
+monkeygrab-v2.md, section 3: "Las tablas se indexan como texto HTML, no como
+imagenes").
+
+**Hard-fail policy** (issue #6, this adapter's other reason for existing): the
+old pymupdf4llm -> pypdf fallback chain hid the fact that MinerU integration
+had never actually worked, for months, by silently degrading to a lower-
+fidelity extractor and producing plausible-looking output. ``_run_mineru``
+raises with an actionable message on every failure mode (CLI missing, exit
+code != 0, no output directory, empty Markdown) instead. ``MineruExtractor``
+(the ``PdfExtractor`` adapter) always lets that exception propagate, per the
+port's hard-fail contract. ``MineruImageExtractor`` (the ``ImageExtractor``
+adapter) is the one documented exception in this codebase's hard-fail policy:
+its port's own docstring specifies that extraction failures are swallowed and
+logged, matching ``PymupdfImageExtractor``'s fitz-open failure carve-out --
+see SECTION 4 for why that is not a contradiction of the above.
+"""
+
+import hashlib
+import json
+import logging
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import fitz
+
+from monkeygrab.domain.extracted_image import ExtractedImage
+from monkeygrab.domain.extracted_page import ExtractedPage
+
+# Not subclassed from the ports: Protocol conformance here is structural
+# (duck typing), the same contract every other adapter in this package
+# satisfies without inheriting its port.
+
+logger = logging.getLogger(__name__)
+
+# Repo root, computed the same way monkeygrab.config.paths derives
+# RAG_BASE_DIR: this file lives at <root>/src/monkeygrab/adapters/extraction/
+# mineru_extractor.py, so four `dirname` calls from its own directory land on
+# <root>.
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+_PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(_THIS_DIR))))
+
+# Bumped whenever SECTION 2's block-to-text/image mapping changes shape.
+# Folded into the cache key so every cached extraction from a previous
+# version of this adapter is treated as a miss instead of being replayed
+# under parsing logic it was never produced for.
+_CACHE_VERSION = "v1"
+
+# MinerU block types that carry no document content -- running headers,
+# footers, page numbers and marginal footnotes. Structural (by MinerU's own
+# `type` field), not tied to any one document's layout.
+_DISCARDED_BLOCK_TYPES = frozenset({"page_number", "footer", "page_footnote", "aside_text"})
+
+
+# ─────────────────────────────────────────────
+# SECTION 1: CLI INVOCATION + CACHE
+# ─────────────────────────────────────────────
+
+
+def _default_mineru_bin() -> str:
+    """Resolve the configured MinerU binary: ``MINERU_BIN`` env var, else the
+    project's isolated venv."""
+    configured = os.getenv("MINERU_BIN", "").strip()
+    if configured:
+        return configured
+    return os.path.join(_PROJECT_ROOT, ".venv-mineru", "Scripts", "mineru.exe")
+
+
+def _default_cache_dir() -> Path:
+    """Resolve the extraction cache directory: ``MINERU_CACHE_DIR`` env var,
+    else ``<repo_root>/.mineru_cache`` (gitignored -- see .gitignore)."""
+    configured = os.getenv("MINERU_CACHE_DIR", "").strip()
+    if configured:
+        return Path(configured)
+    return Path(_PROJECT_ROOT) / ".mineru_cache"
+
+
+def _resolve_runnable_bin(configured: str) -> Optional[str]:
+    """Turn a configured MinerU binary (path or bare command) into something
+    ``subprocess.run`` can actually execute, or ``None`` if it cannot be found.
+    """
+    if os.path.isfile(configured):
+        return configured
+    return shutil.which(configured)
+
+
+def _cache_key(pdf_path: Path, mineru_bin: str) -> str:
+    """Cache key for one (PDF, MinerU binary, parsing-logic version) triple.
+
+    Includes the PDF's size and mtime rather than hashing its bytes -- MinerU
+    extraction is expensive enough (seconds to minutes) that the cost of a
+    false cache hit on a byte-identical-but-touched file would be trivial
+    compared to hashing every PDF's full content on every indexing run.
+    """
+    stat = pdf_path.stat()
+    raw = f"{pdf_path.resolve()}|{stat.st_size}|{stat.st_mtime_ns}|{mineru_bin}|{_CACHE_VERSION}"
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+
+
+def _validate_output(dest: Path, pdf_stem: str) -> Tuple[Path, Path]:
+    """Locate and sanity-check MinerU's output inside ``dest``.
+
+    MinerU nests its own output one level deeper than the ``-o`` directory it
+    is given: ``<dest>/<pdf_stem>/auto/<pdf_stem>.md`` plus a sibling
+    ``*_content_list.json`` with the structured block list this adapter
+    parses (SECTION 2).
+
+    Returns:
+        ``(md_path, content_list_path)``.
+
+    Raises:
+        RuntimeError: If the ``auto/`` directory, the Markdown file or the
+            content-list JSON is missing, or the Markdown is empty --
+            the three "MinerU silently produced nothing usable" failure
+            modes this adapter must never paper over (see module docstring).
+    """
+    auto_dir = dest / pdf_stem / "auto"
+    if not auto_dir.is_dir():
+        raise RuntimeError(
+            f"MinerU produced no output directory (expected {auto_dir}). "
+            "Check the CLI's own stderr/stdout for the real cause."
+        )
+
+    md_path = auto_dir / f"{pdf_stem}.md"
+    if not md_path.is_file() or not md_path.read_text(encoding="utf-8").strip():
+        raise RuntimeError(
+            f"MinerU produced an empty Markdown file: {md_path}. "
+            "This is the exact failure mode the pymupdf4llm/pypdf fallback "
+            "used to hide -- this adapter does not degrade, fix the MinerU "
+            "installation or its model cache (MINERU_MODEL_SOURCE)."
+        )
+
+    content_list_path = auto_dir / f"{pdf_stem}_content_list.json"
+    if not content_list_path.is_file():
+        raise RuntimeError(f"MinerU produced no content-list JSON: {content_list_path}")
+
+    return md_path, content_list_path
+
+
+def _run_mineru(
+    pdf_path: Path,
+    mineru_bin: str,
+    cache_dir: Path,
+    model_source: str,
+    timeout_seconds: int,
+) -> Tuple[Path, Path]:
+    """Extract ``pdf_path`` with MinerU, reusing a cached prior run if valid.
+
+    Args:
+        pdf_path: PDF to extract.
+        mineru_bin: Configured MinerU binary -- a path or a bare command to
+            resolve on PATH.
+        cache_dir: Root directory extraction output is cached under, one
+            subdirectory per (PDF, binary, parsing-version) triple.
+        model_source: Value for the ``MINERU_MODEL_SOURCE`` env var the CLI
+            reads (``"local"`` uses the already-downloaded HuggingFace cache
+            and never attempts a download).
+        timeout_seconds: Passed straight to ``subprocess.run``.
+
+    Returns:
+        ``(md_path, content_list_path)`` -- see ``_validate_output``.
+
+    Raises:
+        RuntimeError: MinerU binary not found, CLI exited non-zero, or its
+            output failed validation (see ``_validate_output``).
+        FileNotFoundError: ``pdf_path`` does not exist.
+    """
+    resolved_bin = _resolve_runnable_bin(mineru_bin)
+    if resolved_bin is None:
+        raise RuntimeError(
+            f"MinerU CLI not found (looked for {mineru_bin!r} on disk and on "
+            "PATH). Install MinerU in an isolated venv and either add it to "
+            "PATH or set MINERU_BIN to the executable, e.g. "
+            r".venv-mineru\Scripts\mineru.exe (Windows) or "
+            ".venv-mineru/bin/mineru (Linux/Mac)."
+        )
+
+    if not pdf_path.is_file():
+        raise FileNotFoundError(f"PDF not found: {pdf_path}")
+
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    dest = cache_dir / f"{pdf_path.stem}-{_cache_key(pdf_path, resolved_bin)}"
+
+    if dest.exists():
+        try:
+            return _validate_output(dest, pdf_path.stem)
+        except RuntimeError:
+            # A previous run was interrupted or produced a partial result --
+            # do not replay it, and do not leave a permanently-stuck bad
+            # cache entry either. Re-extract from scratch.
+            logger.warning("Discarding incomplete MinerU cache at %s, re-extracting", dest)
+            shutil.rmtree(dest, ignore_errors=True)
+
+    dest.mkdir(parents=True, exist_ok=True)
+
+    env = os.environ.copy()
+    env.setdefault("MINERU_MODEL_SOURCE", model_source)
+
+    cmd = [resolved_bin, "-p", str(pdf_path), "-o", str(dest), "-b", "pipeline"]
+    logger.info("Running MinerU: %s", " ".join(cmd))
+    try:
+        proc = subprocess.run(
+            cmd, capture_output=True, text=True, env=env, timeout=timeout_seconds, check=False,
+        )
+    except OSError as exc:
+        raise RuntimeError(f"Failed to launch MinerU CLI ({resolved_bin!r}): {exc}") from exc
+
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"MinerU CLI failed (exit code {proc.returncode}) for {pdf_path.name}:\n"
+            f"{(proc.stderr or proc.stdout)[-4000:]}"
+        )
+
+    return _validate_output(dest, pdf_path.stem)
+
+
+# ─────────────────────────────────────────────
+# SECTION 2: CONTENT-LIST PARSING
+# ─────────────────────────────────────────────
+
+
+def _render_block_text(block: Dict[str, Any]) -> str:
+    """Render one MinerU content-list block as page text.
+
+    Tables and equations keep their MinerU-native markup verbatim (HTML,
+    LaTeX) -- see the module docstring for why that matters for tables.
+    Figures/charts contribute only their caption here; their pixels are
+    ``MineruImageExtractor``'s job, not this text path's.
+    """
+    block_type = block.get("type", "")
+
+    if block_type in _DISCARDED_BLOCK_TYPES:
+        return ""
+
+    if block_type == "text":
+        text = block.get("text", "")
+        level = block.get("text_level")
+        # MinerU marks headings with a numeric `text_level` instead of
+        # Markdown `#` syntax; reproduce the Markdown convention so a
+        # section_header lookup downstream still recognizes it as one.
+        if level and text:
+            return f"{'#' * int(level)} {text}"
+        return text
+
+    if block_type == "equation":
+        return block.get("text", "")
+
+    if block_type == "table":
+        caption = " ".join(block.get("table_caption") or []).strip()
+        body = block.get("table_body", "")
+        if caption and body:
+            return f"{caption}\n{body}"
+        return body or caption
+
+    if block_type == "list":
+        return "\n".join(block.get("list_items") or [])
+
+    if block_type in ("image", "chart"):
+        caption_key = "image_caption" if block_type == "image" else "chart_caption"
+        return " ".join(block.get(caption_key) or []).strip()
+
+    # Forward-compatible fallback: an unrecognized block type still
+    # contributes its "text" field if present, so a future MinerU release
+    # adding new block kinds degrades to plain inclusion instead of silently
+    # dropping content.
+    return block.get("text", "")
+
+
+def _content_list_to_pages(blocks: List[Dict[str, Any]]) -> List[ExtractedPage]:
+    """Group MinerU content-list blocks into per-page text.
+
+    Args:
+        blocks: Parsed ``*_content_list.json`` -- a flat list of blocks, each
+            carrying a zero-based ``page_idx`` (MinerU's own convention,
+            already matching ``ExtractedPage.page``'s -- no offset needed,
+            unlike pymupdf4llm's 1-based page numbers).
+
+    Returns:
+        One ``ExtractedPage`` per ``page_idx`` that produced at least one
+        non-empty rendered block, in ascending page order. A page whose only
+        blocks are page furniture (all discarded, see
+        ``_DISCARDED_BLOCK_TYPES``) is omitted rather than emitted empty.
+    """
+    by_page: Dict[int, List[str]] = {}
+    for block in blocks:
+        if "page_idx" not in block:
+            continue
+        rendered = _render_block_text(block)
+        if rendered:
+            by_page.setdefault(int(block["page_idx"]), []).append(rendered)
+
+    return [
+        ExtractedPage(page=page_idx, text="\n\n".join(parts))
+        for page_idx, parts in sorted(by_page.items())
+    ]
+
+
+def _content_list_to_images(
+    blocks: List[Dict[str, Any]], auto_dir: Path
+) -> Dict[int, List[ExtractedImage]]:
+    """Group MinerU content-list ``image``/``chart`` blocks into per-page images.
+
+    Tables are deliberately excluded here even though MinerU also gives them
+    an ``img_path`` (a rendering of the table as a picture) -- this adapter
+    indexes tables as HTML text (SECTION 2's ``_render_block_text``), not as
+    images, per the module docstring.
+
+    Args:
+        blocks: Parsed ``*_content_list.json``.
+        auto_dir: The ``auto/`` directory the content-list JSON lives in --
+            every block's ``img_path`` is relative to it (MinerU already
+            includes the ``images/`` prefix in the value).
+
+    Returns:
+        Mapping of zero-based page number to the images found on that page.
+        A referenced image file that is missing or unreadable is skipped
+        (logged), not fatal -- matching the ``ImageExtractor`` port's
+        documented per-image failure carve-out.
+    """
+    images_by_page: Dict[int, List[ExtractedImage]] = {}
+
+    for block in blocks:
+        block_type = block.get("type")
+        if block_type not in ("image", "chart"):
+            continue
+
+        rel_path = block.get("img_path")
+        page_idx = block.get("page_idx")
+        if not rel_path or page_idx is None:
+            continue
+
+        image_path = auto_dir / rel_path
+        try:
+            image_bytes = image_path.read_bytes()
+            pixmap = fitz.Pixmap(str(image_path))
+            width, height = pixmap.width, pixmap.height
+        except Exception as exc:
+            logger.warning("Skipping unreadable MinerU figure %s: %s", image_path, exc)
+            continue
+
+        caption_key = "image_caption" if block_type == "image" else "chart_caption"
+        caption = " ".join(block.get(caption_key) or []).strip()
+        ext = image_path.suffix.lstrip(".").lower() or "jpg"
+
+        images_by_page.setdefault(int(page_idx), []).append(
+            ExtractedImage(image_bytes=image_bytes, width=width, height=height, ext=ext, caption=caption)
+        )
+
+    return images_by_page
+
+
+# ─────────────────────────────────────────────
+# SECTION 3: MINERUEXTRACTOR (PdfExtractor)
+# ─────────────────────────────────────────────
+
+
+class MineruExtractor:
+    """Extracts PDF pages as text via the MinerU CLI, tables kept as HTML.
+
+    Hard-fail, per the ``PdfExtractor`` port and this adapter's whole reason
+    for existing (module docstring, issue #6): never falls back to pymupdf.
+    """
+
+    def __init__(
+        self,
+        mineru_bin: Optional[str] = None,
+        cache_dir: Optional[str] = None,
+        model_source: str = "local",
+        timeout_seconds: int = 1800,
+    ):
+        """Args:
+            mineru_bin: Path to the MinerU executable, or a bare command to
+                resolve on PATH. Defaults to the ``MINERU_BIN`` env var, then
+                the project's isolated venv (``.venv-mineru``).
+            cache_dir: Directory cached extractions are stored under.
+                Defaults to the ``MINERU_CACHE_DIR`` env var, then
+                ``<repo_root>/.mineru_cache``.
+            model_source: ``MINERU_MODEL_SOURCE`` value passed to the CLI
+                (``"local"`` never attempts a model download).
+            timeout_seconds: Maximum time to wait for one PDF's extraction.
+        """
+        self._mineru_bin = mineru_bin if mineru_bin is not None else _default_mineru_bin()
+        self._cache_dir = Path(cache_dir) if cache_dir is not None else _default_cache_dir()
+        self._model_source = model_source
+        self._timeout_seconds = timeout_seconds
+
+    def extract(self, pdf_path: str) -> List[ExtractedPage]:
+        """Extract every page of ``pdf_path`` via MinerU.
+
+        Args:
+            pdf_path: Absolute or relative path to the PDF file.
+
+        Returns:
+            One ``ExtractedPage`` per page that produced extractable text,
+            in page order, 0-based.
+
+        Raises:
+            RuntimeError: MinerU CLI missing, failed, or produced no/empty
+                output. Never falls back to a different extractor.
+            FileNotFoundError: ``pdf_path`` does not exist.
+        """
+        _, content_list_path = _run_mineru(
+            Path(pdf_path), self._mineru_bin, self._cache_dir, self._model_source, self._timeout_seconds,
+        )
+        blocks = json.loads(content_list_path.read_text(encoding="utf-8"))
+        return _content_list_to_pages(blocks)
+
+
+# ─────────────────────────────────────────────
+# SECTION 4: MINERUIMAGEEXTRACTOR (ImageExtractor)
+# ─────────────────────────────────────────────
+
+
+class MineruImageExtractor:
+    """Extracts figures/charts (not tables) from a PDF via the MinerU CLI.
+
+    Shares ``_run_mineru``'s cache with ``MineruExtractor``: indexing a PDF
+    through both adapters (text then images, as ``IndexCorpus`` does) runs
+    the CLI only once.
+
+    Per the ``ImageExtractor`` port's documented carve-out from this
+    project's hard-fail default, CLI-level failures (binary missing, exit
+    code != 0, empty output) are logged and swallowed here, returning ``{}``
+    -- exactly like ``PymupdfImageExtractor``'s "fitz cannot open the file"
+    case. This does not reopen the hard-fail question SECTION 3 exists to
+    close: ``IndexCorpus`` always calls the ``PdfExtractor`` first, so a
+    broken MinerU installation already aborts the whole PDF via
+    ``MineruExtractor`` before this adapter would ever run in production.
+    """
+
+    def __init__(
+        self,
+        mineru_bin: Optional[str] = None,
+        cache_dir: Optional[str] = None,
+        model_source: str = "local",
+        timeout_seconds: int = 1800,
+    ):
+        """Args: same as ``MineruExtractor.__init__``."""
+        self._mineru_bin = mineru_bin if mineru_bin is not None else _default_mineru_bin()
+        self._cache_dir = Path(cache_dir) if cache_dir is not None else _default_cache_dir()
+        self._model_source = model_source
+        self._timeout_seconds = timeout_seconds
+
+    def extract(self, pdf_path: str) -> Dict[int, List[ExtractedImage]]:
+        """Extract every figure/chart of ``pdf_path``, grouped by page.
+
+        Args:
+            pdf_path: Absolute or relative path to the PDF file.
+
+        Returns:
+            Mapping of zero-based page number to the figures found on that
+            page. ``{}`` if MinerU could not extract the file at all.
+        """
+        try:
+            _, content_list_path = _run_mineru(
+                Path(pdf_path), self._mineru_bin, self._cache_dir, self._model_source, self._timeout_seconds,
+            )
+        except Exception as exc:
+            logger.warning("MinerU image extraction failed for %s: %s", pdf_path, exc)
+            return {}
+
+        blocks = json.loads(content_list_path.read_text(encoding="utf-8"))
+        return _content_list_to_images(blocks, content_list_path.parent)

--- a/src/monkeygrab/adapters/vectorstore/__init__.py
+++ b/src/monkeygrab/adapters/vectorstore/__init__.py
@@ -5,6 +5,7 @@
 # ─────────────────────────────────────────────
 #
 #  +-- chroma_store.py   ChromaVectorStore   -- chromadb.PersistentClient
+#  +-- faiss_store.py    FaissVectorStore    -- faiss.IndexFlatIP + JSONL sidecar
 #
 # ─────────────────────────────────────────────
 """

--- a/src/monkeygrab/adapters/vectorstore/faiss_store.py
+++ b/src/monkeygrab/adapters/vectorstore/faiss_store.py
@@ -1,0 +1,329 @@
+"""FaissVectorStore -- VectorStore adapter over a persisted FAISS index.
+
+# ─────────────────────────────────────────────
+# MODULE MAP -- Section index
+# ─────────────────────────────────────────────
+#
+#  +-- SECTION 1: PERSISTENCE FORMAT   -- filenames + format version
+#  +-- SECTION 2: METADATA CONVERSION  -- Chunk/Fragment metadata <-> JSONL row
+#  +-- SECTION 3: DISK I/O             -- load-or-init, save (index + sidecar)
+#  +-- SECTION 4: ADAPTER              -- the five VectorStore operations
+#
+# ─────────────────────────────────────────────
+"""
+
+import json
+import os
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+import faiss
+import numpy as np
+
+from monkeygrab.config.paths import PathsConfig
+from monkeygrab.domain.chunk import Chunk
+from monkeygrab.domain.chunk_metadata import ChunkMetadata
+from monkeygrab.domain.fragment import Fragment
+
+# Not subclassed from monkeygrab.ports.vector_store.VectorStore: Protocol
+# conformance here is structural (duck typing), the same contract every other
+# adapter in this package satisfies without inheriting its port.
+
+# A row kept in memory per stored chunk: (id, doc text, metadata). Position in
+# this list is always the FAISS vector's position in the index -- both grow by
+# one, together, on every add() -- so no separate id<->position table needs
+# its own persistence; it is rebuilt from this list on load (see SECTION 3).
+_Row = Tuple[str, str, ChunkMetadata]
+
+
+# ─────────────────────────────────────────────
+# SECTION 1: PERSISTENCE FORMAT
+# ─────────────────────────────────────────────
+
+# Bump on any change to the on-disk layout (vector dtype/metric, JSONL schema,
+# file names): a store built under an older version must not be silently read
+# as the new one -- see _load_or_init's version check.
+_FORMAT_VERSION = "1"
+
+_INDEX_FILENAME = "index.faiss"
+_META_FILENAME = "meta.jsonl"
+_VERSION_FILENAME = "version.txt"
+
+
+# ─────────────────────────────────────────────
+# SECTION 2: METADATA CONVERSION
+# ─────────────────────────────────────────────
+
+
+def _metadata_to_dict(metadata: ChunkMetadata) -> Dict[str, Any]:
+    """Serialize a ``ChunkMetadata`` into the dict shape written to ``meta.jsonl``.
+
+    Unlike Chroma (whose metadata values must be str/int/float/bool, forcing
+    unset optional fields to be omitted entirely), JSONL has no such
+    restriction -- every field is always present, ``null`` when unset.
+    """
+    return {
+        "source": metadata.source,
+        "page": metadata.page,
+        "chunk": metadata.chunk,
+        "section_header": metadata.section_header,
+        "total_chunks_in_page": metadata.total_chunks_in_page,
+        "format": metadata.format,
+        "image_width": metadata.image_width,
+        "image_height": metadata.image_height,
+    }
+
+
+def _metadata_from_dict(meta: Dict[str, Any]) -> ChunkMetadata:
+    """Rebuild a ``ChunkMetadata`` from a ``meta.jsonl`` row's ``metadata`` dict."""
+    return ChunkMetadata(
+        source=meta["source"],
+        page=meta["page"],
+        chunk=meta.get("chunk", 0),
+        total_chunks_in_page=meta.get("total_chunks_in_page"),
+        format=meta.get("format"),
+        section_header=meta.get("section_header", ""),
+        image_width=meta.get("image_width"),
+        image_height=meta.get("image_height"),
+    )
+
+
+# ─────────────────────────────────────────────
+# SECTION 3: DISK I/O
+# ─────────────────────────────────────────────
+
+
+def _corrupt(store_dir: str, reason: str) -> RuntimeError:
+    """Build the one hard-fail message shape used for every corruption case."""
+    return RuntimeError(
+        f"FAISS store at {store_dir!r} is corrupted ({reason}). "
+        "Delete the directory and reindex; a partially written or hand-edited "
+        "store cannot be repaired in place."
+    )
+
+
+def _load_or_init(store_dir: str) -> Tuple[Optional["faiss.Index"], List[_Row]]:
+    """Load an existing store directory, or recognize a brand-new (empty) one.
+
+    A freshly created directory with none of the three files present is a
+    valid empty store (``add`` has simply never been called yet) -- returns
+    ``(None, [])``. Any other partial combination of the three files is
+    corruption: a complete store is always all-three-or-none, because
+    ``_save`` only ever leaves the directory in one of those two states.
+    """
+    index_path = os.path.join(store_dir, _INDEX_FILENAME)
+    meta_path = os.path.join(store_dir, _META_FILENAME)
+    version_path = os.path.join(store_dir, _VERSION_FILENAME)
+    present = [p for p in (index_path, meta_path, version_path) if os.path.exists(p)]
+
+    if not present:
+        return None, []
+    if len(present) != 3:
+        missing = [
+            os.path.basename(p)
+            for p in (index_path, meta_path, version_path)
+            if p not in present
+        ]
+        raise _corrupt(store_dir, f"missing {missing} while other store files exist")
+
+    with open(version_path, "r", encoding="utf-8") as f:
+        version = f.read().strip()
+    if version != _FORMAT_VERSION:
+        raise _corrupt(
+            store_dir,
+            f"built with format version {version!r}, this adapter reads {_FORMAT_VERSION!r}",
+        )
+
+    rows: List[_Row] = []
+    try:
+        with open(meta_path, "r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                row = json.loads(line)
+                rows.append((row["id"], row["doc"], _metadata_from_dict(row["metadata"])))
+    except (json.JSONDecodeError, KeyError) as e:
+        raise _corrupt(store_dir, f"{_META_FILENAME} could not be parsed: {e}") from e
+
+    try:
+        index = faiss.read_index(index_path)
+    except RuntimeError as e:
+        raise _corrupt(store_dir, f"{_INDEX_FILENAME} could not be loaded: {e}") from e
+
+    if index.ntotal != len(rows):
+        raise _corrupt(
+            store_dir,
+            f"index has {index.ntotal} vectors but {_META_FILENAME} has {len(rows)} rows",
+        )
+
+    return index, rows
+
+
+# ─────────────────────────────────────────────
+# SECTION 4: ADAPTER
+# ─────────────────────────────────────────────
+
+
+class FaissVectorStore:
+    """Stores and retrieves embedded chunks in a FAISS ``IndexFlatIP`` index.
+
+    Exact (not approximate) search: an ``IndexFlatIP`` scores every stored
+    vector against the query rather than using a graph/quantized index. This
+    project's corpora are small enough that an ANN index would only add
+    approximation error for no measurable speed win (see
+    ``docs/design/2026-07-26-monkeygrab-v2.md``, section 3). Vectors are
+    L2-normalized before insertion and before querying, which turns the
+    index's raw inner product into cosine similarity.
+
+    Persistence layout: three files under ``<path_db>/<collection_name>/``
+    (the same two-level split ChromaDB uses -- one client path holding
+    several named collections):
+
+    - ``index.faiss`` -- the FAISS index itself (``faiss.write_index``).
+    - ``meta.jsonl`` -- one JSON object per stored chunk, in insertion
+      order: ``{"id", "doc", "metadata"}``.
+    - ``version.txt`` -- the on-disk format version, checked on load so a
+      future layout change fails loudly on old stores instead of
+      misreading them.
+
+    Id-to-position mapping: FAISS indexes by integer position, but chunk ids
+    are strings (``Chunk.id``, e.g. ``"paper.pdf_pag2_chunk3"``). Row *i* of
+    ``meta.jsonl`` is always FAISS vector *i* -- both are appended to
+    together, in the same call, and never reordered -- so an id-position map
+    is never itself persisted; it is rebuilt in ``__init__`` by reading
+    ``meta.jsonl`` once and enumerating it. Reopening an existing index is
+    therefore just replaying that enumeration, not a separate migration step.
+
+    Determinism: ``IndexFlatIP.search`` is exact, but does not document a
+    tie-break rule for equal scores, and this adapter must not depend on
+    whatever FAISS happens to do internally. Every query re-scores the
+    *entire* index (cheap at this project's scale, and already the chosen
+    tradeoff above) and re-sorts the candidates by ``(-score, id)`` before
+    truncating to ``n_results`` -- so a tie is always broken by ascending
+    chunk id, regardless of FAISS's internal ordering or thread count.
+
+    Failure policy: hard-fail. A corrupted directory, a query/insert vector
+    whose dimension does not match the index, or a failed write all raise
+    with an actionable message -- never an empty result or a silent
+    fallback. An id with no match in ``get_by_ids`` is *not* a failure (see
+    the ``VectorStore`` port docstring): callers use it for neighbor-context
+    expansion, where asking for a chunk past a document's first/last page is
+    an expected, not exceptional, outcome.
+    """
+
+    def __init__(self, paths: PathsConfig):
+        """Args:
+            paths: Path config; the store directory is
+                ``<paths.path_db>/<paths.collection_name>``, created if absent.
+        """
+        self._dir = os.path.join(paths.path_db, paths.collection_name)
+        os.makedirs(self._dir, exist_ok=True)
+        self._index_path = os.path.join(self._dir, _INDEX_FILENAME)
+        self._meta_path = os.path.join(self._dir, _META_FILENAME)
+        self._version_path = os.path.join(self._dir, _VERSION_FILENAME)
+
+        self._index, self._rows = _load_or_init(self._dir)
+        self._id_to_pos: Dict[str, int] = {row[0]: i for i, row in enumerate(self._rows)}
+
+    def add(self, chunk: Chunk, embedding: Sequence[float]) -> None:
+        if chunk.id in self._id_to_pos:
+            raise ValueError(
+                f"chunk id {chunk.id!r} already exists in the FAISS store at "
+                f"{self._dir!r}; positions are append-only, re-adding would "
+                "desync the id-to-position map"
+            )
+
+        vector = np.asarray([list(embedding)], dtype=np.float32)
+        if self._index is None:
+            self._index = faiss.IndexFlatIP(vector.shape[1])
+        elif vector.shape[1] != self._index.d:
+            raise ValueError(
+                f"embedding has dimension {vector.shape[1]}, FAISS index at "
+                f"{self._dir!r} expects {self._index.d}"
+            )
+
+        faiss.normalize_L2(vector)
+        self._index.add(vector)
+        position = len(self._rows)
+        row: _Row = (chunk.id, chunk.text, chunk.metadata)
+        self._rows.append(row)
+        self._id_to_pos[chunk.id] = position
+        self._save(row)
+
+    def query(self, embedding: Sequence[float], n_results: int) -> List[Fragment]:
+        if self._index is None or self._index.ntotal == 0:
+            return []
+
+        vector = np.asarray([list(embedding)], dtype=np.float32)
+        if vector.shape[1] != self._index.d:
+            raise ValueError(
+                f"query embedding has dimension {vector.shape[1]}, FAISS index "
+                f"at {self._dir!r} expects {self._index.d}"
+            )
+        faiss.normalize_L2(vector)
+
+        # Score every stored vector (k = ntotal) so the tie-break re-sort below
+        # sees the full candidate set -- see the class docstring's determinism
+        # note for why a partial top-k from FAISS would not be safe here.
+        k = self._index.ntotal
+        scores, positions = self._index.search(vector, k)
+        candidates = [
+            (float(scores[0][j]), self._rows[positions[0][j]][0], int(positions[0][j]))
+            for j in range(k)
+        ]
+        candidates.sort(key=lambda c: (-c[0], c[1]))
+
+        fragments = []
+        for score, _chunk_id, position in candidates[:n_results]:
+            _, doc, metadata = self._rows[position]
+            # Cosine distance (1 - cosine similarity) on the normalized
+            # vectors this store indexes -- not a literal L2 magnitude like
+            # Chroma's default metric, but the same "smaller is nearer"
+            # contract the Fragment.distancia field documents; ordering is
+            # what downstream ranking (RRF, min/max/mean debug stats) uses.
+            fragments.append(Fragment(doc=doc, metadata=metadata, distancia=1.0 - score))
+        return fragments
+
+    def get_by_ids(self, ids: Sequence[str]) -> List[Fragment]:
+        fragments = []
+        for chunk_id in ids:
+            position = self._id_to_pos.get(chunk_id)
+            if position is None:
+                continue
+            _, doc, metadata = self._rows[position]
+            fragments.append(Fragment(doc=doc, metadata=metadata))
+        return fragments
+
+    def get_page(self, limit: Optional[int], offset: int) -> List[Fragment]:
+        rows = self._rows[offset:] if limit is None else self._rows[offset : offset + limit]
+        return [Fragment(doc=doc, metadata=metadata) for _, doc, metadata in rows]
+
+    def count(self) -> int:
+        return len(self._rows)
+
+    def _save(self, new_row: _Row) -> None:
+        """Persist the just-added row: rewrite the index, append to the sidecar.
+
+        The index has no incremental on-disk append, so each ``add`` rewrites
+        it whole (written to a temp path, then ``os.replace``d in, so a failed
+        write never leaves a half-written ``index.faiss``); the JSONL sidecar
+        only ever grows, so it is opened in append mode. If the index write
+        fails, this raises before the sidecar is touched, leaving the
+        directory exactly as it was before this ``add`` -- still consistent
+        and reloadable, just missing the chunk that failed to persist.
+        """
+        try:
+            tmp_path = self._index_path + ".tmp"
+            faiss.write_index(self._index, tmp_path)
+            os.replace(tmp_path, self._index_path)
+
+            with open(self._meta_path, "a", encoding="utf-8") as f:
+                chunk_id, doc, metadata = new_row
+                f.write(json.dumps({"id": chunk_id, "doc": doc, "metadata": _metadata_to_dict(metadata)}))
+                f.write("\n")
+
+            if not os.path.exists(self._version_path):
+                with open(self._version_path, "w", encoding="utf-8") as f:
+                    f.write(_FORMAT_VERSION)
+        except OSError as e:
+            raise RuntimeError(f"failed to persist FAISS store at {self._dir!r}: {e}") from e

--- a/src/monkeygrab/application/index_corpus.py
+++ b/src/monkeygrab/application/index_corpus.py
@@ -129,6 +129,31 @@ def _build_document_sample(pages: Sequence[ExtractedPage], contextual_doc_chars:
     return "\n\n".join(partes)[:contextual_doc_chars]
 
 
+def _text_chunk_format(chunk_text: str) -> str:
+    """Classify a text chunk as a table or as prose.
+
+    An extractor that preserves table structure emits HTML, and a chunk carrying
+    a table is a different kind of content from a paragraph: it answers "what
+    value is in this cell" rather than "what does this section say". Marking it
+    lets retrieval surface tables for questions that need one.
+
+    Without this, a preserved table is indexed as ordinary prose and becomes
+    invisible as a table — which is why table retrieval measured 0/5 on the
+    text-flattening path even though the numbers were present in the text.
+
+    The test is the HTML tag rather than the extractor's identity, so any backend
+    that keeps tables intact benefits and none has to announce itself.
+
+    Args:
+        chunk_text: Raw chunk text, before contextual enrichment.
+
+    Returns:
+        ``"table"`` when the chunk contains an HTML table, ``"markdown"``
+        otherwise.
+    """
+    return "table" if "<table" in chunk_text.lower() else "markdown"
+
+
 # ─────────────────────────────────────────────
 # IMAGE DESCRIPTION FILTERING (pure helpers)
 # ─────────────────────────────────────────────
@@ -303,7 +328,7 @@ class IndexCorpus:
                     page=page.page,
                     chunk=chunk_idx,
                     total_chunks_in_page=len(text_chunks),
-                    format="markdown",
+                    format=_text_chunk_format(chunk_text),
                     section_header=text_chunk.header,
                 )
                 chunk = Chunk(text=final_text, metadata=metadata)

--- a/src/monkeygrab/composition.py
+++ b/src/monkeygrab/composition.py
@@ -1,0 +1,164 @@
+"""Composition root -- builds the adapter graph a StackConfig asks for.
+
+# ─────────────────────────────────────────────
+# MODULE MAP -- Section index
+# ─────────────────────────────────────────────
+#
+#  +-- 1. build_extractor      text extraction backend
+#  +-- 2. build_vector_store   vector index backend
+#  +-- 3. build_embedder       embedding backend
+#  +-- 4. build_stack          all three at once, as a named tuple
+#
+# ─────────────────────────────────────────────
+
+This is the only module that knows which concrete adapter exists. Use cases
+receive ports, so nothing above this layer changes when a technology is swapped:
+comparing two stacks is an environment variable plus a second run of the gate.
+
+Every import here is deferred inside its factory, and that is not a style
+preference. Importing an adapter imports its library, so a module-level import
+would drag chromadb, faiss and torch into every process regardless of what was
+selected -- paying the startup cost of three backends to use one, and making a
+missing optional dependency fatal for users who never asked for it.
+
+Dependencies: none at import time, by construction.
+"""
+
+from typing import Any, NamedTuple
+
+from monkeygrab.config.app_config import AppConfig
+from monkeygrab.config.stack import (
+    EMBEDDER_JINA_CLIP,
+    EMBEDDER_OLLAMA,
+    EXTRACTOR_MINERU,
+    EXTRACTOR_PYMUPDF,
+    VECTOR_STORE_CHROMA,
+    VECTOR_STORE_FAISS,
+)
+
+
+class Stack(NamedTuple):
+    """The three swappable adapters, built and ready to inject.
+
+    Attributes:
+        extractor: Implements ``ports.PdfExtractor``.
+        vector_store: Implements ``ports.VectorStore``.
+        embedder: Implements ``ports.Embedder``.
+    """
+
+    extractor: Any
+    vector_store: Any
+    embedder: Any
+
+
+# ─────────────────────────────────────────────
+# SECTION 1: EXTRACTOR
+# ─────────────────────────────────────────────
+
+
+def build_extractor(config: AppConfig) -> Any:
+    """Build the text extraction adapter named by ``config.stack.extractor``.
+
+    Args:
+        config: Application configuration, injected into the adapter.
+
+    Returns:
+        An object satisfying ``ports.PdfExtractor``.
+
+    Raises:
+        ValueError: If the selector holds an unimplemented value. StackConfig
+            validates on construction, so reaching this means the two lists
+            disagree -- a bug here, not bad input.
+    """
+    choice = config.stack.extractor
+    if choice == EXTRACTOR_PYMUPDF:
+        from monkeygrab.adapters.extraction.pymupdf_extractor import PymupdfExtractor
+
+        return PymupdfExtractor(config.chunking)
+    if choice == EXTRACTOR_MINERU:
+        from monkeygrab.adapters.extraction.mineru_extractor import MineruExtractor
+
+        return MineruExtractor(config.chunking)
+    raise ValueError(f"No extractor adapter for {choice!r}")
+
+
+# ─────────────────────────────────────────────
+# SECTION 2: VECTOR STORE
+# ─────────────────────────────────────────────
+
+
+def build_vector_store(config: AppConfig) -> Any:
+    """Build the vector store adapter named by ``config.stack.vector_store``.
+
+    The index path carries the stack slug, because two stacks produce vectors of
+    different dimension and meaning: sharing a directory would silently mix them.
+
+    Args:
+        config: Application configuration, injected into the adapter.
+
+    Returns:
+        An object satisfying ``ports.VectorStore``.
+
+    Raises:
+        ValueError: If the selector holds an unimplemented value.
+    """
+    choice = config.stack.vector_store
+    if choice == VECTOR_STORE_CHROMA:
+        from monkeygrab.adapters.vectorstore.chroma_store import ChromaVectorStore
+
+        return ChromaVectorStore(config.paths.path_db, config.paths.collection_name)
+    if choice == VECTOR_STORE_FAISS:
+        from monkeygrab.adapters.vectorstore.faiss_store import FaissVectorStore
+
+        return FaissVectorStore(f"{config.paths.path_db}_faiss")
+    raise ValueError(f"No vector store adapter for {choice!r}")
+
+
+# ─────────────────────────────────────────────
+# SECTION 3: EMBEDDER
+# ─────────────────────────────────────────────
+
+
+def build_embedder(config: AppConfig) -> Any:
+    """Build the embedding adapter named by ``config.stack.embedder``.
+
+    Args:
+        config: Application configuration, injected into the adapter.
+
+    Returns:
+        An object satisfying ``ports.Embedder``.
+
+    Raises:
+        ValueError: If the selector holds an unimplemented value.
+    """
+    choice = config.stack.embedder
+    if choice == EMBEDDER_OLLAMA:
+        from monkeygrab.adapters.embedding.ollama_embedder import OllamaEmbedder
+
+        return OllamaEmbedder(config.models)
+    if choice == EMBEDDER_JINA_CLIP:
+        from monkeygrab.adapters.embedding.jina_clip_embedder import JinaClipEmbedder
+
+        return JinaClipEmbedder()
+    raise ValueError(f"No embedder adapter for {choice!r}")
+
+
+# ─────────────────────────────────────────────
+# SECTION 4: WHOLE STACK
+# ─────────────────────────────────────────────
+
+
+def build_stack(config: AppConfig) -> Stack:
+    """Build every swappable adapter for ``config``.
+
+    Args:
+        config: Application configuration.
+
+    Returns:
+        A ``Stack`` with the three adapters.
+    """
+    return Stack(
+        extractor=build_extractor(config),
+        vector_store=build_vector_store(config),
+        embedder=build_embedder(config),
+    )

--- a/src/monkeygrab/config/app_config.py
+++ b/src/monkeygrab/config/app_config.py
@@ -38,6 +38,7 @@ from monkeygrab.config.models import (
 from monkeygrab.config.paths import RAG_BASE_DIR, PathsConfig, derive_db_paths
 from monkeygrab.config.reranking import RerankingConfig
 from monkeygrab.config.retrieval import RetrievalConfig
+from monkeygrab.config.stack import StackConfig, stack_from_env
 
 # The 7 sections with runtime-override support via with_overrides(); anything
 # nested deeper (e.g. models.ollama.*) is set at construction time only, same
@@ -79,6 +80,9 @@ class AppConfig:
     context: ContextConfig = field(default_factory=ContextConfig)
     flags: PipelineFlagsConfig = field(default_factory=PipelineFlagsConfig)
     paths: PathsConfig = field(default_factory=PathsConfig)
+    # Which implementation stands behind each swappable port. Its default is the
+    # current production stack, so an unset environment behaves exactly as before.
+    stack: StackConfig = field(default_factory=StackConfig)
 
     # ─────────────────────────────────────────────
     # SECTION 2: FROM_ENV
@@ -196,6 +200,7 @@ class AppConfig:
         return cls(
             models=models, chunking=chunking, retrieval=retrieval,
             reranking=reranking, context=context, flags=flags, paths=paths,
+            stack=stack_from_env(),
         )
 
     # ─────────────────────────────────────────────

--- a/src/monkeygrab/config/stack.py
+++ b/src/monkeygrab/config/stack.py
@@ -1,0 +1,113 @@
+"""StackConfig -- which implementation stands behind each port.
+
+# ─────────────────────────────────────────────
+# MODULE MAP -- Section index
+# ─────────────────────────────────────────────
+#
+#  +-- 1. Choice constants     the valid value of each selector
+#  +-- 2. StackConfig          frozen dataclass, one field per swappable port
+#  +-- 3. from_env()           reads the selectors, rejecting unknown values
+#
+# ─────────────────────────────────────────────
+
+Ports make an implementation replaceable in principle; this module is what makes
+it replaceable in practice. Without a selector, comparing two technologies means
+editing the code that wires them, which is expensive enough that the comparison
+never happens and the choice stays a matter of opinion.
+
+With it, running the same gold-case gate against pymupdf+Chroma and against
+MinerU+FAISS is a change of environment variable and a second run, so "is this
+actually better" becomes a measurement.
+
+An unknown value raises at construction. Coercing it to a default is how the
+previous configuration hid the fact that its MinerU path did not exist at all.
+"""
+
+from dataclasses import dataclass
+
+from monkeygrab.config import env
+
+# ─────────────────────────────────────────────
+# SECTION 1: CHOICES
+# ─────────────────────────────────────────────
+
+# Text extraction. pymupdf is fast and loses table structure; mineru is slow and
+# preserves tables as HTML and formulas as LaTeX.
+EXTRACTOR_PYMUPDF = "pymupdf"
+EXTRACTOR_MINERU = "mineru"
+EXTRACTORS = (EXTRACTOR_PYMUPDF, EXTRACTOR_MINERU)
+
+# Vector store. Both are exact search at this corpus size; faiss owns only the
+# index while chroma also owns storage and metadata.
+VECTOR_STORE_CHROMA = "chroma"
+VECTOR_STORE_FAISS = "faiss"
+VECTOR_STORES = (VECTOR_STORE_CHROMA, VECTOR_STORE_FAISS)
+
+# Embeddings. ollama is text-only, so a figure must first be captioned by a
+# vision model; jina_clip puts text and images in one space, which is the whole
+# point of the multimodal path.
+EMBEDDER_OLLAMA = "ollama"
+EMBEDDER_JINA_CLIP = "jina_clip"
+EMBEDDERS = (EMBEDDER_OLLAMA, EMBEDDER_JINA_CLIP)
+
+
+# ─────────────────────────────────────────────
+# SECTION 2: STACKCONFIG
+# ─────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class StackConfig:
+    """Which adapter implements each swappable port.
+
+    Attributes:
+        extractor: Text extraction backend, one of ``EXTRACTORS``.
+        vector_store: Vector index backend, one of ``VECTOR_STORES``.
+        embedder: Embedding backend, one of ``EMBEDDERS``.
+    """
+
+    extractor: str = EXTRACTOR_PYMUPDF
+    vector_store: str = VECTOR_STORE_CHROMA
+    embedder: str = EMBEDDER_OLLAMA
+
+    @property
+    def is_multimodal(self) -> bool:
+        """True when the embedder places text and images in a shared space.
+
+        Callers use this to decide whether figures need a vision model to
+        describe them first, or can be embedded directly.
+        """
+        return self.embedder == EMBEDDER_JINA_CLIP
+
+    @property
+    def slug(self) -> str:
+        """Short identifier of this combination, for index paths and reports.
+
+        Two stacks produce incompatible vectors, so their indexes must never
+        share a directory; embedding this in the path makes that structural
+        rather than a thing to remember.
+        """
+        return f"{self.extractor}-{self.embedder}-{self.vector_store}"
+
+
+# ─────────────────────────────────────────────
+# SECTION 3: CONSTRUCTION
+# ─────────────────────────────────────────────
+
+
+def stack_from_env() -> StackConfig:
+    """Build a StackConfig from the process environment.
+
+    Returns:
+        StackConfig with the selected backends.
+
+    Raises:
+        ValueError: If any selector holds a value that is not implemented. The
+            default stays the current production stack, so an unset environment
+            changes nothing.
+    """
+    return StackConfig(
+        extractor=env.read_env_choice("PDF_EXTRACTOR", EXTRACTOR_PYMUPDF, EXTRACTORS),
+        vector_store=env.read_env_choice("VECTOR_STORE", VECTOR_STORE_CHROMA, VECTOR_STORES),
+        embedder=env.read_env_choice("EMBEDDER", EMBEDDER_OLLAMA, EMBEDDERS),
+    )

--- a/src/monkeygrab/ports/__init__.py
+++ b/src/monkeygrab/ports/__init__.py
@@ -7,6 +7,7 @@
 #  +-- pdf_extractor.py    PdfExtractor    -- PDF -> per-page raw text
 #  +-- image_extractor.py  ImageExtractor  -- PDF -> raster images by page
 #  +-- embedder.py         Embedder        -- text -> embedding vector
+#  +-- image_embedder.py   ImageEmbedder   -- image (+caption) -> embedding vector
 #  +-- vector_store.py     VectorStore     -- add/query/get/count over chunks
 #  +-- lexical_index.py    LexicalIndex    -- BM25-style text search
 #  +-- reranker.py         Reranker        -- Cross-Encoder-style re-scoring
@@ -32,6 +33,7 @@ strategy. Each Protocol's docstring restates this for its own failure modes.
 
 from monkeygrab.ports.chat_model import ChatModel
 from monkeygrab.ports.embedder import Embedder
+from monkeygrab.ports.image_embedder import ImageEmbedder
 from monkeygrab.ports.image_extractor import ImageExtractor
 from monkeygrab.ports.lexical_index import LexicalIndex
 from monkeygrab.ports.model_unloader import ModelUnloader
@@ -42,6 +44,7 @@ from monkeygrab.ports.vector_store import VectorStore
 __all__ = [
     "ChatModel",
     "Embedder",
+    "ImageEmbedder",
     "ImageExtractor",
     "LexicalIndex",
     "ModelUnloader",

--- a/src/monkeygrab/ports/image_embedder.py
+++ b/src/monkeygrab/ports/image_embedder.py
@@ -1,0 +1,60 @@
+"""ImageEmbedder -- image (optionally captioned) to embedding vector.
+
+# ─────────────────────────────────────────────
+# SECTION 1: PORT
+# ─────────────────────────────────────────────
+"""
+
+from typing import List, Protocol
+
+
+class ImageEmbedder(Protocol):
+    """Embeds one image into the same vector space as this embedder's text.
+
+    Deliberately a SEPARATE Protocol from ``Embedder``, not an extra method
+    on it. ``Embedder`` is the contract every text embedder in this project
+    satisfies, including ``OllamaEmbedder`` -- and Ollama's embedding models
+    are text-only, so a figure has to be captioned by a vision model first
+    and only the caption text goes through ``Embedder.embed`` (see the
+    ``ChatModel`` "ocr" role). Adding ``embed_image`` to ``Embedder`` would
+    either force a text-only adapter to implement a method it cannot honor,
+    or silently narrow what the base contract promises. Only a genuinely
+    multimodal embedder (``StackConfig.is_multimodal``, see
+    ``monkeygrab.config.stack``) also satisfies ``ImageEmbedder``; callers
+    check that flag before deciding whether a figure needs a vision-model
+    caption or can be embedded directly -- the same place they would check
+    for any other capability that not every adapter behind ``Embedder`` has.
+
+    Combining an image with its caption is part of THIS port's contract,
+    not left to the caller, because how to combine two vectors from the same
+    model into one (raw magnitude vs. re-normalized, sum vs. average) is
+    model- and adapter-specific -- exactly the kind of detail a port exists
+    to hide behind one call. A caption is used only when it is real text
+    (non-empty after stripping); an image with no caption is embedded alone.
+
+    Failure policy: hard-fail, same as every port in this project -- a
+    missing image file, a backend failure, or an unexpected vector
+    dimension raises. Nothing here degrades to a zero vector or silently
+    skips the image.
+    """
+
+    def embed_image(self, image_path: str, *, caption: str = "") -> List[float]:
+        """Embed the image at ``image_path``, optionally combined with ``caption``.
+
+        Args:
+            image_path: Path to the image file on disk.
+            caption: Caption text found near the image, if any. Empty (the
+                default -- also what ``ExtractedImage.caption`` is when no
+                caption was found near an image) means "no caption": the
+                image is embedded alone. A non-empty caption is combined
+                into the returned vector by the adapter's own rule.
+
+        Returns:
+            The embedding vector, same dimensionality and space as this
+            embedder's ``embed`` (text) output.
+
+        Raises:
+            Exception: On any embedding failure -- missing file, backend
+                error, or unexpected vector dimension.
+        """
+        ...

--- a/tests/unit/adapters/test_faiss_store.py
+++ b/tests/unit/adapters/test_faiss_store.py
@@ -1,0 +1,319 @@
+"""Unit tests for monkeygrab.adapters.vectorstore.faiss_store.FaissVectorStore.
+
+Round-trips a real faiss.IndexFlatIP through tmp_path directories -- unlike
+test_chroma_store.py (which stubs chromadb.PersistentClient), there is no
+thin client seam to stub here: the whole point of this adapter is what it
+does with a real FAISS index, so these tests exercise it directly. The one
+exception is test_add_hard_fails_when_persistence_write_fails, which injects
+a write failure that cannot be reliably reproduced with a real disk.
+"""
+
+import math
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import pytest
+
+from monkeygrab.adapters.vectorstore.chroma_store import ChromaVectorStore
+from monkeygrab.adapters.vectorstore.faiss_store import FaissVectorStore
+from monkeygrab.config.paths import PathsConfig
+from monkeygrab.domain.chunk import Chunk
+from monkeygrab.domain.chunk_metadata import ChunkMetadata
+
+
+def _chunk(source, page, chunk_idx, text="body"):
+    return Chunk(text=text, metadata=ChunkMetadata(source=source, page=page, chunk=chunk_idx))
+
+
+def _paths(tmp_path, name="store"):
+    return PathsConfig(path_db=str(tmp_path / "db"), collection_name=name)
+
+
+def _unit(vector):
+    """Normalize a vector to unit L2 norm.
+
+    Fixture vectors across this file use unit length so that Chroma's L2
+    ranking and FAISS's cosine ranking provably agree -- see the
+    interchangeability test below for the full argument.
+    """
+    norm = math.sqrt(sum(v * v for v in vector))
+    return [v / norm for v in vector]
+
+
+# ─────────────────────────────────────────────
+# Round-trip: add / query / get_by_ids / get_page / count
+# ─────────────────────────────────────────────
+
+
+def test_add_query_get_by_ids_get_page_count_round_trip(tmp_path):
+    store = FaissVectorStore(_paths(tmp_path))
+
+    c0 = _chunk("a.pdf", 0, 0, "alpha body")
+    c1 = _chunk("a.pdf", 0, 1, "beta body")
+    c2 = _chunk("a.pdf", 1, 0, "gamma body")
+    store.add(c0, _unit([1.0, 0.0, 0.0]))
+    store.add(c1, _unit([0.0, 1.0, 0.0]))
+    store.add(c2, _unit([0.9, 0.1, 0.0]))
+
+    assert store.count() == 3
+
+    # c0 is an exact match (distancia ~ 0); c2 is closer to the query than
+    # c1, which is orthogonal to it.
+    results = store.query(_unit([1.0, 0.0, 0.0]), n_results=2)
+    assert [r.id for r in results] == [c0.id, c2.id]
+    assert results[0].doc == "alpha body"
+    assert results[0].distancia == pytest.approx(0.0, abs=1e-6)
+
+    by_ids = store.get_by_ids([c1.id, c2.id, "missing.pdf_pag9_chunk9"])
+    assert {f.id for f in by_ids} == {c1.id, c2.id}
+
+    page = store.get_page(limit=2, offset=1)
+    assert [f.id for f in page] == [c1.id, c2.id]
+
+    full_page = store.get_page(limit=None, offset=0)
+    assert [f.id for f in full_page] == [c0.id, c1.id, c2.id]
+
+
+def test_get_by_ids_returns_partial_list_for_missing_ids_without_raising(tmp_path):
+    """Matches the VectorStore port contract: an absent id is not a failure --
+    the engine relies on this for neighbor-context expansion at document
+    edges, where the "next" or "previous" chunk legitimately does not exist."""
+    store = FaissVectorStore(_paths(tmp_path))
+    c0 = _chunk("w.pdf", 0, 0)
+    store.add(c0, _unit([1.0, 0.0]))
+
+    fragments = store.get_by_ids([c0.id, "missing.pdf_pag9_chunk9"])
+
+    assert [f.id for f in fragments] == [c0.id]
+
+
+def test_query_on_empty_store_returns_empty_list(tmp_path):
+    store = FaissVectorStore(_paths(tmp_path))
+    assert store.query([1.0, 0.0], n_results=5) == []
+
+
+# ─────────────────────────────────────────────
+# Determinism
+# ─────────────────────────────────────────────
+
+
+def test_query_breaks_score_ties_by_ascending_chunk_id(tmp_path):
+    """Two chunks share an identical embedding -- an exact score tie. FAISS's
+    own internal tie order (here, insertion order: cb before ca) must be
+    overridden by the documented (score desc, id asc) re-sort."""
+    store = FaissVectorStore(_paths(tmp_path))
+    cb = _chunk("z.pdf", 0, 1)  # id "z.pdf_pag0_chunk1"
+    ca = _chunk("z.pdf", 0, 0)  # id "z.pdf_pag0_chunk0" -- lexicographically smaller
+    store.add(cb, _unit([1.0, 0.0]))
+    store.add(ca, _unit([1.0, 0.0]))
+
+    results = store.query(_unit([1.0, 0.0]), n_results=2)
+
+    assert [r.id for r in results] == [ca.id, cb.id]
+
+
+def test_repeated_identical_queries_return_identical_order(tmp_path):
+    store = FaissVectorStore(_paths(tmp_path))
+    for i, vec in enumerate([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.7, 0.7, 0.0]]):
+        store.add(_chunk("rep.pdf", 0, i), _unit(vec))
+
+    query_vector = _unit([0.6, 0.5, 0.1])
+    first = [f.id for f in store.query(query_vector, n_results=3)]
+    second = [f.id for f in store.query(query_vector, n_results=3)]
+
+    assert first == second
+
+
+# ─────────────────────────────────────────────
+# Persistence
+# ─────────────────────────────────────────────
+
+
+def test_persists_to_disk_and_reopening_matches(tmp_path):
+    paths = _paths(tmp_path, "persisted")
+    store = FaissVectorStore(paths)
+    store.add(_chunk("p.pdf", 0, 0, "one"), _unit([1.0, 0.0]))
+    store.add(_chunk("p.pdf", 0, 1, "two"), _unit([0.0, 1.0]))
+
+    store_dir = Path(paths.path_db) / paths.collection_name
+    assert (store_dir / "index.faiss").exists()
+    assert (store_dir / "meta.jsonl").exists()
+    assert (store_dir / "version.txt").exists()
+
+    reopened = FaissVectorStore(paths)
+
+    assert reopened.count() == store.count() == 2
+    assert reopened.get_page(limit=None, offset=0) == store.get_page(limit=None, offset=0)
+    assert reopened.query(_unit([1.0, 0.0]), n_results=1) == store.query(_unit([1.0, 0.0]), n_results=1)
+
+
+def test_version_mismatch_hard_fails_on_reopen(tmp_path):
+    paths = _paths(tmp_path, "versioned")
+    store = FaissVectorStore(paths)
+    store.add(_chunk("v.pdf", 0, 0), _unit([1.0, 0.0]))
+
+    version_path = Path(paths.path_db) / paths.collection_name / "version.txt"
+    version_path.write_text("999", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="format version"):
+        FaissVectorStore(paths)
+
+
+def test_partial_store_directory_hard_fails(tmp_path):
+    """A directory missing one of the three sidecar files (e.g. meta.jsonl
+    deleted by hand) is not a fresh store -- it is corruption."""
+    paths = _paths(tmp_path, "partial")
+    store = FaissVectorStore(paths)
+    store.add(_chunk("q.pdf", 0, 0), _unit([1.0, 0.0]))
+
+    meta_path = Path(paths.path_db) / paths.collection_name / "meta.jsonl"
+    meta_path.unlink()
+
+    with pytest.raises(RuntimeError, match="corrupted"):
+        FaissVectorStore(paths)
+
+
+def test_corrupted_index_file_hard_fails(tmp_path):
+    paths = _paths(tmp_path, "badindex")
+    store = FaissVectorStore(paths)
+    store.add(_chunk("r.pdf", 0, 0), _unit([1.0, 0.0]))
+
+    index_path = Path(paths.path_db) / paths.collection_name / "index.faiss"
+    index_path.write_bytes(b"not a real faiss index")
+
+    with pytest.raises(RuntimeError, match="corrupted"):
+        FaissVectorStore(paths)
+
+
+def test_corrupted_meta_jsonl_hard_fails(tmp_path):
+    paths = _paths(tmp_path, "badmeta")
+    store = FaissVectorStore(paths)
+    store.add(_chunk("s.pdf", 0, 0), _unit([1.0, 0.0]))
+
+    meta_path = Path(paths.path_db) / paths.collection_name / "meta.jsonl"
+    meta_path.write_text("{not valid json", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="corrupted"):
+        FaissVectorStore(paths)
+
+
+def test_meta_and_index_row_count_mismatch_hard_fails(tmp_path):
+    paths = _paths(tmp_path, "mismatch")
+    store = FaissVectorStore(paths)
+    store.add(_chunk("t.pdf", 0, 0), _unit([1.0, 0.0]))
+
+    meta_path = Path(paths.path_db) / paths.collection_name / "meta.jsonl"
+    extra_row = (
+        '{"id": "extra", "doc": "x", "metadata": {"source": "t.pdf", "page": 0, "chunk": 1, '
+        '"section_header": "", "total_chunks_in_page": null, "format": null, '
+        '"image_width": null, "image_height": null}}\n'
+    )
+    with meta_path.open("a", encoding="utf-8") as f:
+        f.write(extra_row)
+
+    with pytest.raises(RuntimeError, match="corrupted"):
+        FaissVectorStore(paths)
+
+
+# ─────────────────────────────────────────────
+# Hard fails: dimension, duplicate id, write failure
+# ─────────────────────────────────────────────
+
+
+def test_add_hard_fails_on_dimension_mismatch(tmp_path):
+    store = FaissVectorStore(_paths(tmp_path))
+    store.add(_chunk("u.pdf", 0, 0), _unit([1.0, 0.0, 0.0]))
+
+    with pytest.raises(ValueError, match="dimension"):
+        store.add(_chunk("u.pdf", 0, 1), _unit([1.0, 0.0]))
+
+
+def test_query_hard_fails_on_dimension_mismatch(tmp_path):
+    store = FaissVectorStore(_paths(tmp_path))
+    store.add(_chunk("u.pdf", 0, 0), _unit([1.0, 0.0, 0.0]))
+
+    with pytest.raises(ValueError, match="dimension"):
+        store.query(_unit([1.0, 0.0]), n_results=1)
+
+
+def test_add_hard_fails_on_duplicate_chunk_id(tmp_path):
+    store = FaissVectorStore(_paths(tmp_path))
+    chunk = _chunk("dup.pdf", 0, 0)
+    store.add(chunk, _unit([1.0, 0.0]))
+
+    with pytest.raises(ValueError, match="already exists"):
+        store.add(chunk, _unit([0.0, 1.0]))
+
+
+def test_add_hard_fails_when_persistence_write_fails(tmp_path, monkeypatch):
+    from monkeygrab.adapters.vectorstore import faiss_store as module
+
+    store = FaissVectorStore(_paths(tmp_path, "writefail"))
+
+    def _boom(*args, **kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(module.faiss, "write_index", _boom)
+
+    with pytest.raises(RuntimeError, match="failed to persist"):
+        store.add(_chunk("x.pdf", 0, 0), _unit([1.0, 0.0]))
+
+
+# ─────────────────────────────────────────────
+# Equivalence with ChromaVectorStore
+# ─────────────────────────────────────────────
+
+
+def test_faiss_and_chroma_are_interchangeable_behind_the_port(tmp_path):
+    """Same vectors and metadata through both real adapters -- the query
+    order must match exactly, proving they are swappable behind VectorStore.
+
+    Distance *values* are deliberately not compared: Chroma reports its own
+    distance metric (squared L2 by default) over the raw vectors it was
+    given, while FaissVectorStore reports cosine distance (1 - cosine
+    similarity) over its own L2-normalized copy of those vectors (see
+    FaissVectorStore.query's docstring note) -- the two numbers are not
+    meant to agree. The fixture vectors below are pre-normalized to unit
+    length specifically so the *orderings* agree regardless of which metric
+    Chroma uses: for unit vectors a and b, ||a - b||^2 == 2 - 2*cos(a, b), a
+    strictly monotonic function of cosine similarity, so "nearest by L2" and
+    "nearest by cosine" always pick the same order.
+    """
+    chunks_and_vectors = [
+        (_chunk("eq.pdf", 0, 0, "north"), _unit([1.0, 0.0, 0.0])),
+        (_chunk("eq.pdf", 0, 1, "east"), _unit([0.0, 1.0, 0.0])),
+        (_chunk("eq.pdf", 1, 0, "near-north"), _unit([0.9, 0.1, 0.0])),
+        (_chunk("eq.pdf", 1, 1, "far corner"), _unit([-0.3, -0.3, 0.9])),
+    ]
+
+    chroma_store = ChromaVectorStore(_paths(tmp_path, "chroma_eq"))
+    faiss_store = FaissVectorStore(
+        PathsConfig(path_db=str(tmp_path / "faiss_db"), collection_name="faiss_eq")
+    )
+    for chunk, vector in chunks_and_vectors:
+        chroma_store.add(chunk, vector)
+        faiss_store.add(chunk, vector)
+
+    query_vector = _unit([0.95, 0.05, 0.0])
+    chroma_results = chroma_store.query(query_vector, n_results=4)
+    faiss_results = faiss_store.query(query_vector, n_results=4)
+
+    assert [f.id for f in chroma_results] == [f.id for f in faiss_results]
+
+    # get_by_ids: mix existing and nonexistent ids. The port explicitly
+    # allows "no particular order" here, so compare as id sets, not lists --
+    # and this is exactly the case (a neighbor lookup that partially misses)
+    # the two adapters must agree on to be truly interchangeable.
+    existing_ids = {chunks_and_vectors[0][0].id, chunks_and_vectors[2][0].id}
+    ids_to_fetch = list(existing_ids) + ["missing.pdf_pag9_chunk9"]
+    chroma_by_ids = {f.id for f in chroma_store.get_by_ids(ids_to_fetch)}
+    faiss_by_ids = {f.id for f in faiss_store.get_by_ids(ids_to_fetch)}
+    assert chroma_by_ids == faiss_by_ids == existing_ids
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/unit/adapters/test_jina_clip_embedder.py
+++ b/tests/unit/adapters/test_jina_clip_embedder.py
@@ -1,0 +1,419 @@
+"""Unit tests for monkeygrab.adapters.embedding.jina_clip_embedder.JinaClipEmbedder.
+
+Doubles subprocess.Popen entirely -- no real process, no torch, no CUDA, no
+model download -- so these run in milliseconds, in the fast/architecture CI
+gate. The fake worker is a small queue-backed line-JSON echo server that
+lives entirely in this file; it exercises the SAME background-thread /
+timeout code path the real worker talks to, just without a real pipe.
+"""
+
+import json
+import queue
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import pytest
+
+from monkeygrab.adapters.embedding import jina_clip_embedder as module
+from monkeygrab.adapters.embedding.jina_clip_embedder import JinaClipEmbedder
+
+_DIM = module._TRUNCATE_DIM  # 512, kept as the module's own constant, not re-hardcoded here
+
+
+def _vector(fill=0.1, n=_DIM):
+    return [fill] * n
+
+
+# ─────────────────────────────────────────────
+# Fake subprocess plumbing
+# ─────────────────────────────────────────────
+
+
+class _FakeStream:
+    """Iterable line stream fed from a queue -- stands in for a Popen pipe.
+
+    `for line in process.stdout` on a real pipe blocks until a line arrives
+    and raises StopIteration on EOF; this reproduces exactly that so the
+    adapter's background reader threads behave identically against it.
+    """
+
+    def __init__(self):
+        self._q: "queue.Queue" = queue.Queue()
+
+    def push(self, line: str):
+        self._q.put(line)
+
+    def close(self):
+        self._q.put(None)
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        item = self._q.get()
+        if item is None:
+            raise StopIteration
+        return item
+
+
+class _FakeStdin:
+    def __init__(self, on_write):
+        self.lines = []
+        self._on_write = on_write
+
+    def write(self, data):
+        self.lines.append(data)
+        self._on_write(data)
+
+    def flush(self):
+        pass
+
+    def close(self):
+        pass
+
+
+class _FakeProcess:
+    """Stands in for subprocess.Popen's return value.
+
+    `behavior(process, request_dict)` is called for every line written to
+    stdin (after JSON-decoding it) and decides what, if anything, the fake
+    worker "replies" with by pushing onto `process.stdout`.
+
+    `startup_message` controls what's on stdout before any request is ever
+    sent (mirrors the real worker's ready/fatal handshake):
+      - "ready" (default): push {"event": "ready", "dim": _DIM}.
+      - "eof": close stdout immediately, i.e. the process died before
+        signaling readiness.
+      - None: push nothing -- the test drives stdout manually.
+      - any dict: pushed as-is (e.g. a "fatal" startup message).
+    """
+
+    def __init__(self, behavior, *, startup_message="ready"):
+        self.stdout = _FakeStream()
+        self.stderr = _FakeStream()
+        self._returncode = None
+        self.killed = False
+        self.stdin = _FakeStdin(on_write=lambda data: self._on_write(data))
+        self._behavior = behavior
+
+        if startup_message == "ready":
+            self.stdout.push(json.dumps({"event": "ready", "dim": _DIM}) + "\n")
+        elif startup_message == "eof":
+            self.stdout.close()
+        elif startup_message is not None:
+            self.stdout.push(json.dumps(startup_message) + "\n")
+        # startup_message is None: caller drives stdout manually.
+
+    def _on_write(self, data: str):
+        request = json.loads(data)
+        self._behavior(self, request)
+
+    def poll(self):
+        return self._returncode
+
+    def kill(self):
+        self.killed = True
+        self._returncode = -9
+        self.stdout.close()
+        self.stderr.close()
+
+    def wait(self, timeout=None):
+        return self._returncode
+
+
+def _echo_ok(process: _FakeProcess, request: dict):
+    """Default behavior: reply ok=True with a filler vector of the right shape."""
+    process.stdout.push(
+        json.dumps({"id": request["id"], "ok": True, "vector": _vector()}) + "\n"
+    )
+
+
+def _make_popen(behavior=_echo_ok, *, startup_message="ready"):
+    """Return (fake_popen_callable, calls) -- calls records every FakeProcess made."""
+    calls = []
+
+    def fake_popen(cmd, **kwargs):
+        process = _FakeProcess(behavior, startup_message=startup_message)
+        calls.append(process)
+        return process
+
+    return fake_popen, calls
+
+
+def _embedder(monkeypatch, behavior=_echo_ok, *, startup_message="ready", **kwargs):
+    fake_popen, calls = _make_popen(behavior, startup_message=startup_message)
+    monkeypatch.setattr(module.subprocess, "Popen", fake_popen)
+    embedder = JinaClipEmbedder("fake-python", worker_script="fake-worker.py", **kwargs)
+    return embedder, calls
+
+
+# ─────────────────────────────────────────────
+# Protocol: request serialization / response parsing
+# ─────────────────────────────────────────────
+
+
+def test_embed_sends_a_text_request_and_returns_the_worker_vector(monkeypatch):
+    embedder, calls = _embedder(monkeypatch)
+
+    result = embedder.embed("hello world")
+
+    assert result == _vector()
+    sent = json.loads(calls[0].stdin.lines[0])
+    assert sent == {"id": 1, "op": "text", "text": "hello world"}
+
+
+def test_request_ids_increment_across_calls(monkeypatch):
+    embedder, calls = _embedder(monkeypatch)
+
+    embedder.embed("first")
+    embedder.embed("second")
+
+    ids = [json.loads(line)["id"] for line in calls[0].stdin.lines]
+    assert ids == [1, 2]
+
+
+# ─────────────────────────────────────────────
+# Worker lifecycle: lazy start, reuse
+# ─────────────────────────────────────────────
+
+
+def test_worker_is_not_started_at_construction(monkeypatch):
+    fake_popen, calls = _make_popen()
+    monkeypatch.setattr(module.subprocess, "Popen", fake_popen)
+
+    JinaClipEmbedder("fake-python", worker_script="fake-worker.py")
+
+    assert calls == []
+
+
+def test_worker_starts_once_and_is_reused_across_calls(monkeypatch):
+    embedder, calls = _embedder(monkeypatch)
+
+    embedder.embed("one")
+    embedder.embed("two")
+    embedder.embed("three")
+
+    assert len(calls) == 1
+
+
+def test_close_before_ever_starting_is_a_no_op(monkeypatch):
+    embedder, _ = _embedder(monkeypatch)
+
+    embedder.close()  # must not raise
+
+
+def test_close_terminates_the_worker_and_a_later_call_starts_a_fresh_one(monkeypatch):
+    embedder, calls = _embedder(monkeypatch)
+    embedder.embed("one")
+    assert len(calls) == 1
+
+    embedder.close()
+    calls[0]._returncode = 0  # simulate the OS having reaped the closed process
+
+    embedder.embed("two")
+
+    assert len(calls) == 2
+
+
+# ─────────────────────────────────────────────
+# Failure modes: all must raise, never hang or degrade silently
+# ─────────────────────────────────────────────
+
+
+def test_worker_that_dies_before_ready_raises(monkeypatch):
+    embedder, _ = _embedder(monkeypatch, startup_message="eof")
+
+    with pytest.raises(RuntimeError, match="exited unexpectedly"):
+        embedder.embed("hello")
+
+
+def test_worker_startup_fatal_message_raises_with_the_reported_reason(monkeypatch):
+    embedder, _ = _embedder(
+        monkeypatch, startup_message={"event": "fatal", "error": "CUDA not available"}
+    )
+
+    with pytest.raises(RuntimeError, match="CUDA not available"):
+        embedder.embed("hello")
+
+
+def test_invalid_json_from_worker_raises(monkeypatch):
+    def behavior(process, request):
+        process.stdout.push("not-json-at-all\n")
+
+    embedder, _ = _embedder(monkeypatch, behavior)
+
+    with pytest.raises(RuntimeError, match="non-JSON"):
+        embedder.embed("hello")
+
+
+def test_worker_reported_error_raises_with_the_message(monkeypatch):
+    def behavior(process, request):
+        process.stdout.push(
+            json.dumps({"id": request["id"], "ok": False, "error": "boom"}) + "\n"
+        )
+
+    embedder, _ = _embedder(monkeypatch, behavior)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        embedder.embed("hello")
+
+
+def test_unexpected_vector_dimension_raises(monkeypatch):
+    def behavior(process, request):
+        process.stdout.push(
+            json.dumps({"id": request["id"], "ok": True, "vector": [0.1, 0.2]}) + "\n"
+        )
+
+    embedder, _ = _embedder(monkeypatch, behavior)
+
+    with pytest.raises(RuntimeError, match="unexpected shape"):
+        embedder.embed("hello")
+
+
+def test_mismatched_response_id_raises(monkeypatch):
+    def behavior(process, request):
+        process.stdout.push(
+            json.dumps({"id": 9999, "ok": True, "vector": _vector()}) + "\n"
+        )
+
+    embedder, _ = _embedder(monkeypatch, behavior)
+
+    with pytest.raises(RuntimeError, match="desynchronized"):
+        embedder.embed("hello")
+
+
+def test_worker_dying_mid_request_raises_instead_of_hanging(monkeypatch):
+    def behavior(process, request):
+        process.stdout.close()  # EOF: simulate a crash instead of a reply
+
+    embedder, _ = _embedder(monkeypatch, behavior)
+
+    with pytest.raises(RuntimeError, match="exited unexpectedly"):
+        embedder.embed("hello")
+
+
+def test_worker_that_never_responds_times_out_instead_of_hanging(monkeypatch):
+    def behavior(process, request):
+        pass  # never reply
+
+    embedder, _ = _embedder(monkeypatch, behavior, request_timeout_s=0.05)
+
+    with pytest.raises(RuntimeError, match="did not respond within"):
+        embedder.embed("hello")
+
+
+def test_worker_marked_dead_refuses_further_calls_without_a_new_process(monkeypatch):
+    embedder, calls = _embedder(monkeypatch, startup_message="eof")
+
+    with pytest.raises(RuntimeError):
+        embedder.embed("first")
+
+    with pytest.raises(RuntimeError, match="no longer usable"):
+        embedder.embed("second")
+
+    # Only one process was ever attempted -- death does not trigger a silent respawn.
+    assert len(calls) == 1
+
+
+# ─────────────────────────────────────────────
+# Image + caption combination: normalized sum, not a mean
+# ─────────────────────────────────────────────
+
+
+def test_embed_image_without_caption_sends_only_an_image_request(monkeypatch):
+    def behavior(process, request):
+        assert request["op"] == "image"
+        process.stdout.push(
+            json.dumps({"id": request["id"], "ok": True, "vector": _vector(0.2)}) + "\n"
+        )
+
+    embedder, calls = _embedder(monkeypatch, behavior)
+    monkeypatch.setattr(module.os.path, "isfile", lambda path: True)
+
+    result = embedder.embed_image("figure.png")
+
+    ops = [json.loads(line)["op"] for line in calls[0].stdin.lines]
+    assert ops == ["image"]
+    # A lone image vector is just re-normalized (already unit-norm here), so
+    # it should equal the L2-normalized filler vector.
+    assert result == pytest.approx(module._l2_normalize(_vector(0.2)))
+
+
+@pytest.mark.parametrize("caption", ["", "   ", "\t\n"])
+def test_embed_image_treats_blank_caption_as_no_caption(monkeypatch, caption):
+    def behavior(process, request):
+        process.stdout.push(
+            json.dumps({"id": request["id"], "ok": True, "vector": _vector(0.3)}) + "\n"
+        )
+
+    embedder, calls = _embedder(monkeypatch, behavior)
+    monkeypatch.setattr(module.os.path, "isfile", lambda path: True)
+
+    embedder.embed_image("figure.png", caption=caption)
+
+    ops = [json.loads(line)["op"] for line in calls[0].stdin.lines]
+    assert ops == ["image"]  # never a "text" request for a blank caption
+
+
+def test_embed_image_raises_when_the_file_does_not_exist(monkeypatch):
+    embedder, calls = _embedder(monkeypatch)
+    monkeypatch.setattr(module.os.path, "isfile", lambda path: False)
+
+    with pytest.raises(RuntimeError, match="not found"):
+        embedder.embed_image("missing.png")
+
+    assert calls == []  # never even tried to talk to a worker
+
+
+def test_embed_image_with_caption_is_a_normalized_sum_not_an_unnormalized_mean(monkeypatch):
+    # Two orthogonal-ish unit vectors so sum-then-normalize is easy to hand-compute
+    # and clearly distinguishable from a raw (unnormalized) arithmetic mean.
+    image_raw = [1.0, 0.0] + [0.0] * (_DIM - 2)
+    caption_raw = [0.0, 1.0] + [0.0] * (_DIM - 2)
+
+    def behavior(process, request):
+        vector = image_raw if request["op"] == "image" else caption_raw
+        process.stdout.push(
+            json.dumps({"id": request["id"], "ok": True, "vector": vector}) + "\n"
+        )
+
+    embedder, calls = _embedder(monkeypatch, behavior)
+    monkeypatch.setattr(module.os.path, "isfile", lambda path: True)
+
+    result = embedder.embed_image("figure.png", caption="a real caption")
+
+    ops = [json.loads(line)["op"] for line in calls[0].stdin.lines]
+    assert ops == ["image", "text"]  # both vectors were actually requested
+
+    expected_sum_normalized = module._l2_normalize(
+        [a + b for a, b in zip(image_raw, caption_raw)]
+    )
+    unnormalized_mean = [(a + b) / 2 for a, b in zip(image_raw, caption_raw)]
+
+    assert result == pytest.approx(expected_sum_normalized)
+    assert result != pytest.approx(unnormalized_mean)  # the mean has sub-unit norm
+    assert sum(component * component for component in result) == pytest.approx(1.0)
+
+
+# ─────────────────────────────────────────────
+# Vector math: pure function, tested directly
+# ─────────────────────────────────────────────
+
+
+def test_l2_normalize_returns_a_unit_vector():
+    result = module._l2_normalize([3.0, 4.0])
+
+    assert result == pytest.approx([0.6, 0.8])
+
+
+def test_l2_normalize_rejects_a_zero_vector():
+    with pytest.raises(RuntimeError, match="zero vector"):
+        module._l2_normalize([0.0, 0.0, 0.0])
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/unit/adapters/test_mineru_extractor.py
+++ b/tests/unit/adapters/test_mineru_extractor.py
@@ -1,0 +1,462 @@
+"""Unit tests for monkeygrab.adapters.extraction.mineru_extractor.
+
+Stubs ``subprocess.run`` entirely -- no real MinerU CLI, no GPU, no network --
+so these run in milliseconds. The fake ``subprocess.run`` inspects the ``-o``
+argument it is given and writes the directory structure MinerU would have
+produced, so tests never need to predict the adapter's internal cache-key
+hash.
+
+The failure-mode tests are the important ones here: this adapter's whole
+reason for existing (issue #6) is refusing to silently degrade the way the
+old pymupdf4llm/pypdf fallback chain did, so every way MinerU can fail must
+surface as a raised exception with an actionable message, never as empty or
+partial output.
+"""
+
+import base64
+import json
+import os
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import pytest  # noqa: E402
+
+from monkeygrab.adapters.extraction import mineru_extractor as module  # noqa: E402
+from monkeygrab.adapters.extraction.mineru_extractor import (  # noqa: E402
+    MineruExtractor,
+    MineruImageExtractor,
+)
+from monkeygrab.domain.extracted_image import ExtractedImage  # noqa: E402
+from monkeygrab.domain.extracted_page import ExtractedPage  # noqa: E402
+
+# A minimal-but-valid 1x1 transparent PNG, small enough to inline. Used as a
+# stand-in for a MinerU-cropped figure -- fitz.Pixmap can read real
+# dimensions from it, unlike arbitrary bytes.
+_TINY_PNG = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk"
+    "+A8AAQUBAScY42YAAAAASUVORK5CYII="
+)
+
+
+# ─────────────────────────────────────────────
+# Fakes / helpers
+# ─────────────────────────────────────────────
+
+
+class _FakeCompleted:
+    def __init__(self, returncode=0, stdout="", stderr=""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def _dest_from_cmd(cmd):
+    """Extract the ``-o`` argument MinerU would have written into."""
+    return Path(cmd[cmd.index("-o") + 1])
+
+
+def _write_valid_output(dest: Path, pdf_stem: str, blocks=None, md_text="# Heading\n\nSome text."):
+    """Write the directory tree MinerU produces for a successful extraction."""
+    auto = dest / pdf_stem / "auto"
+    auto.mkdir(parents=True, exist_ok=True)
+    (auto / f"{pdf_stem}.md").write_text(md_text, encoding="utf-8")
+    (auto / f"{pdf_stem}_content_list.json").write_text(
+        json.dumps(blocks if blocks is not None else []), encoding="utf-8"
+    )
+    return auto
+
+
+def _make_pdf(tmp_path: Path, name="paper.pdf") -> Path:
+    pdf = tmp_path / name
+    pdf.write_bytes(b"%PDF-1.4 fake pdf bytes")
+    return pdf
+
+
+def _make_bin(tmp_path: Path, name="mineru.exe") -> Path:
+    bin_path = tmp_path / name
+    bin_path.write_text("fake binary", encoding="utf-8")
+    return bin_path
+
+
+# ─────────────────────────────────────────────
+# Command construction
+# ─────────────────────────────────────────────
+
+
+def test_extract_builds_the_correct_mineru_command(monkeypatch, tmp_path):
+    pdf = _make_pdf(tmp_path)
+    bin_path = _make_bin(tmp_path)
+    cache_dir = tmp_path / "cache"
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        _write_valid_output(_dest_from_cmd(cmd), pdf.stem)
+        return _FakeCompleted()
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+
+    MineruExtractor(mineru_bin=str(bin_path), cache_dir=str(cache_dir)).extract(str(pdf))
+
+    assert len(calls) == 1
+    cmd = calls[0]
+    assert cmd[0] == str(bin_path)
+    assert cmd[cmd.index("-p") + 1] == str(pdf)
+    assert cmd[cmd.index("-b") + 1] == "pipeline"
+    assert Path(cmd[cmd.index("-o") + 1]).parent == cache_dir
+
+
+# ─────────────────────────────────────────────
+# Environment variables
+# ─────────────────────────────────────────────
+
+
+def test_model_source_defaults_to_local(monkeypatch, tmp_path):
+    pdf = _make_pdf(tmp_path)
+    bin_path = _make_bin(tmp_path)
+    seen_env = {}
+
+    def fake_run(cmd, **kwargs):
+        seen_env.update(kwargs["env"])
+        _write_valid_output(_dest_from_cmd(cmd), pdf.stem)
+        return _FakeCompleted()
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+    monkeypatch.delenv("MINERU_MODEL_SOURCE", raising=False)
+
+    MineruExtractor(mineru_bin=str(bin_path), cache_dir=str(tmp_path / "cache")).extract(str(pdf))
+
+    assert seen_env["MINERU_MODEL_SOURCE"] == "local"
+
+
+def test_model_source_is_configurable(monkeypatch, tmp_path):
+    pdf = _make_pdf(tmp_path)
+    bin_path = _make_bin(tmp_path)
+    seen_env = {}
+
+    def fake_run(cmd, **kwargs):
+        seen_env.update(kwargs["env"])
+        _write_valid_output(_dest_from_cmd(cmd), pdf.stem)
+        return _FakeCompleted()
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+
+    MineruExtractor(
+        mineru_bin=str(bin_path), cache_dir=str(tmp_path / "cache"), model_source="modelscope",
+    ).extract(str(pdf))
+
+    assert seen_env["MINERU_MODEL_SOURCE"] == "modelscope"
+
+
+def test_a_preexisting_ambient_model_source_env_var_is_not_overridden(monkeypatch, tmp_path):
+    """setdefault semantics: the caller's shell environment wins over this
+    adapter's own default, matching the reference MinerU spike's behavior."""
+    pdf = _make_pdf(tmp_path)
+    bin_path = _make_bin(tmp_path)
+    seen_env = {}
+
+    def fake_run(cmd, **kwargs):
+        seen_env.update(kwargs["env"])
+        _write_valid_output(_dest_from_cmd(cmd), pdf.stem)
+        return _FakeCompleted()
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+    monkeypatch.setenv("MINERU_MODEL_SOURCE", "modelscope")  # ambient, set before construction
+
+    MineruExtractor(mineru_bin=str(bin_path), cache_dir=str(tmp_path / "cache")).extract(str(pdf))
+
+    assert seen_env["MINERU_MODEL_SOURCE"] == "modelscope"
+
+
+def test_default_mineru_bin_reads_the_mineru_bin_env_var(monkeypatch, tmp_path):
+    bin_path = _make_bin(tmp_path, "custom-mineru")
+    monkeypatch.setenv("MINERU_BIN", str(bin_path))
+
+    assert module._default_mineru_bin() == str(bin_path)
+
+
+def test_default_mineru_bin_falls_back_to_the_project_venv(monkeypatch):
+    monkeypatch.delenv("MINERU_BIN", raising=False)
+
+    resolved = module._default_mineru_bin()
+
+    assert resolved.endswith(os.path.join(".venv-mineru", "Scripts", "mineru.exe"))
+
+
+# ─────────────────────────────────────────────
+# Failure modes -- the important tests
+# ─────────────────────────────────────────────
+
+
+def test_missing_binary_raises_an_actionable_error(tmp_path):
+    pdf = _make_pdf(tmp_path)
+    extractor = MineruExtractor(
+        mineru_bin=str(tmp_path / "does-not-exist-anywhere"), cache_dir=str(tmp_path / "cache"),
+    )
+
+    with pytest.raises(RuntimeError, match="MinerU CLI not found"):
+        extractor.extract(str(pdf))
+
+
+def test_missing_pdf_raises_file_not_found(tmp_path):
+    bin_path = _make_bin(tmp_path)
+    extractor = MineruExtractor(mineru_bin=str(bin_path), cache_dir=str(tmp_path / "cache"))
+
+    with pytest.raises(FileNotFoundError):
+        extractor.extract(str(tmp_path / "missing.pdf"))
+
+
+def test_nonzero_exit_code_raises_with_the_cli_stderr(monkeypatch, tmp_path):
+    pdf = _make_pdf(tmp_path)
+    bin_path = _make_bin(tmp_path)
+
+    def fake_run(cmd, **kwargs):
+        return _FakeCompleted(returncode=1, stderr="model cache not found: PDF-Extract-Kit-1.0")
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+    extractor = MineruExtractor(mineru_bin=str(bin_path), cache_dir=str(tmp_path / "cache"))
+
+    with pytest.raises(RuntimeError, match="exit code 1") as excinfo:
+        extractor.extract(str(pdf))
+    assert "model cache not found" in str(excinfo.value)
+
+
+def test_no_output_directory_raises(monkeypatch, tmp_path):
+    pdf = _make_pdf(tmp_path)
+    bin_path = _make_bin(tmp_path)
+
+    def fake_run(cmd, **kwargs):
+        return _FakeCompleted(returncode=0)  # exits clean but writes nothing
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+    extractor = MineruExtractor(mineru_bin=str(bin_path), cache_dir=str(tmp_path / "cache"))
+
+    with pytest.raises(RuntimeError, match="no output directory"):
+        extractor.extract(str(pdf))
+
+
+def test_empty_markdown_raises_instead_of_falling_back(monkeypatch, tmp_path):
+    """The exact failure mode the old pymupdf4llm/pypdf fallback hid for months."""
+    pdf = _make_pdf(tmp_path)
+    bin_path = _make_bin(tmp_path)
+
+    def fake_run(cmd, **kwargs):
+        _write_valid_output(_dest_from_cmd(cmd), pdf.stem, blocks=[], md_text="   \n  ")
+        return _FakeCompleted(returncode=0)
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+    extractor = MineruExtractor(mineru_bin=str(bin_path), cache_dir=str(tmp_path / "cache"))
+
+    with pytest.raises(RuntimeError, match="empty Markdown"):
+        extractor.extract(str(pdf))
+
+
+def test_missing_content_list_json_raises(monkeypatch, tmp_path):
+    pdf = _make_pdf(tmp_path)
+    bin_path = _make_bin(tmp_path)
+
+    def fake_run(cmd, **kwargs):
+        auto = _dest_from_cmd(cmd) / pdf.stem / "auto"
+        auto.mkdir(parents=True)
+        (auto / f"{pdf.stem}.md").write_text("real content", encoding="utf-8")
+        # deliberately no *_content_list.json
+        return _FakeCompleted(returncode=0)
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+    extractor = MineruExtractor(mineru_bin=str(bin_path), cache_dir=str(tmp_path / "cache"))
+
+    with pytest.raises(RuntimeError, match="content-list JSON"):
+        extractor.extract(str(pdf))
+
+
+def test_launch_failure_raises_runtime_error(monkeypatch, tmp_path):
+    """subprocess.run itself raising (e.g. the resolved path stops being executable)."""
+    pdf = _make_pdf(tmp_path)
+    bin_path = _make_bin(tmp_path)
+
+    def fake_run(cmd, **kwargs):
+        raise OSError("Exec format error")
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+    extractor = MineruExtractor(mineru_bin=str(bin_path), cache_dir=str(tmp_path / "cache"))
+
+    with pytest.raises(RuntimeError, match="Failed to launch MinerU CLI"):
+        extractor.extract(str(pdf))
+
+
+def test_image_extractor_swallows_cli_failure_and_returns_empty_mapping(tmp_path):
+    """Unlike MineruExtractor, MineruImageExtractor follows the ImageExtractor
+    port's documented soft-fail carve-out."""
+    pdf = _make_pdf(tmp_path)
+    extractor = MineruImageExtractor(
+        mineru_bin=str(tmp_path / "does-not-exist-anywhere"), cache_dir=str(tmp_path / "cache"),
+    )
+
+    assert extractor.extract(str(pdf)) == {}
+
+
+# ─────────────────────────────────────────────
+# Caching
+# ─────────────────────────────────────────────
+
+
+def test_second_extraction_of_the_same_pdf_reuses_the_cache(monkeypatch, tmp_path):
+    pdf = _make_pdf(tmp_path)
+    bin_path = _make_bin(tmp_path)
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        _write_valid_output(_dest_from_cmd(cmd), pdf.stem)
+        return _FakeCompleted()
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+    extractor = MineruExtractor(mineru_bin=str(bin_path), cache_dir=str(tmp_path / "cache"))
+
+    extractor.extract(str(pdf))
+    extractor.extract(str(pdf))
+
+    assert len(calls) == 1  # second call was a cache hit, no subprocess spawned
+
+
+def test_the_pdf_extractor_and_image_extractor_share_one_cached_run(monkeypatch, tmp_path):
+    """IndexCorpus calls PdfExtractor then ImageExtractor on the same PDF --
+    the second must not re-run the (expensive) CLI."""
+    pdf = _make_pdf(tmp_path)
+    bin_path = _make_bin(tmp_path)
+    cache_dir = tmp_path / "cache"
+    calls = []
+
+    blocks = [
+        {"type": "text", "text": "Title", "text_level": 1, "page_idx": 0},
+        {
+            "type": "image",
+            "img_path": "images/fig.png",
+            "image_caption": ["Figure 1: a diagram"],
+            "page_idx": 0,
+        },
+    ]
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        auto = _write_valid_output(_dest_from_cmd(cmd), pdf.stem, blocks=blocks)
+        (auto / "images").mkdir()
+        (auto / "images" / "fig.png").write_bytes(_TINY_PNG)
+        return _FakeCompleted()
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+
+    pages = MineruExtractor(mineru_bin=str(bin_path), cache_dir=str(cache_dir)).extract(str(pdf))
+    images = MineruImageExtractor(mineru_bin=str(bin_path), cache_dir=str(cache_dir)).extract(str(pdf))
+
+    assert len(calls) == 1
+    assert pages == [ExtractedPage(page=0, text="# Title\n\nFigure 1: a diagram")]
+    assert images == {0: [ExtractedImage(
+        image_bytes=_TINY_PNG, width=1, height=1, ext="png", caption="Figure 1: a diagram",
+    )]}
+
+
+def test_a_corrupted_cache_entry_is_discarded_and_reextracted(monkeypatch, tmp_path):
+    pdf = _make_pdf(tmp_path)
+    bin_path = _make_bin(tmp_path)
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        _write_valid_output(_dest_from_cmd(cmd), pdf.stem)
+        return _FakeCompleted()
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+    extractor = MineruExtractor(mineru_bin=str(bin_path), cache_dir=str(tmp_path / "cache"))
+
+    extractor.extract(str(pdf))
+    assert len(calls) == 1
+
+    # Simulate a previous run that was interrupted mid-write: the cache
+    # directory exists but its Markdown is now empty/corrupt.
+    dest = _dest_from_cmd(calls[0])
+    (dest / pdf.stem / "auto" / f"{pdf.stem}.md").write_text("", encoding="utf-8")
+
+    extractor.extract(str(pdf))
+
+    assert len(calls) == 2  # bad cache was discarded, MinerU ran again
+
+
+# ─────────────────────────────────────────────
+# Parsing a representative MinerU output
+# ─────────────────────────────────────────────
+
+
+def test_parses_a_representative_mineru_output_including_a_table_and_a_figure(monkeypatch, tmp_path):
+    pdf = _make_pdf(tmp_path)
+    bin_path = _make_bin(tmp_path)
+
+    table_html = "<table><tr><td>Model</td><td>BLEU</td></tr><tr><td>Base</td><td>27.3</td></tr></table>"
+    blocks = [
+        # Page 0: a heading, a paragraph, and page furniture that must be dropped.
+        {"type": "text", "text": "Attention Is All You Need", "text_level": 1, "page_idx": 0},
+        {"type": "text", "text": "We propose a new architecture.", "page_idx": 0},
+        {"type": "footer", "text": "NeurIPS 2017", "page_idx": 0},
+        {"type": "page_number", "text": "1", "page_idx": 0},
+        # Page 1: a table -- the whole point of this adapter.
+        {
+            "type": "table",
+            "img_path": "images/table1.png",
+            "table_caption": ["Table 1: Results"],
+            "table_body": table_html,
+            "page_idx": 1,
+        },
+        # Page 2: a figure with a caption, plus a page-footnote to drop.
+        {
+            "type": "image",
+            "img_path": "images/fig1.png",
+            "image_caption": ["Figure 1: model architecture"],
+            "page_idx": 2,
+        },
+        {"type": "page_footnote", "text": "Work performed at Google Brain.", "page_idx": 2},
+    ]
+
+    def fake_run(cmd, **kwargs):
+        auto = _write_valid_output(_dest_from_cmd(cmd), pdf.stem, blocks=blocks)
+        images_dir = auto / "images"
+        images_dir.mkdir()
+        (images_dir / "table1.png").write_bytes(_TINY_PNG)
+        (images_dir / "fig1.png").write_bytes(_TINY_PNG)
+        return _FakeCompleted()
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+    cache_dir = str(tmp_path / "cache")
+
+    pages = MineruExtractor(mineru_bin=str(bin_path), cache_dir=cache_dir).extract(str(pdf))
+    images = MineruImageExtractor(mineru_bin=str(bin_path), cache_dir=cache_dir).extract(str(pdf))
+
+    pages_by_number = {p.page: p.text for p in pages}
+
+    # Page 0: heading rendered as Markdown, paragraph kept, furniture dropped.
+    assert pages_by_number[0] == "# Attention Is All You Need\n\nWe propose a new architecture."
+
+    # Page 1: the table survives as literal HTML -- identifiable as a table
+    # by any downstream code that looks for a "<table" tag in the chunk text.
+    assert "<table>" in pages_by_number[1]
+    assert table_html in pages_by_number[1]
+    assert "Table 1: Results" in pages_by_number[1]
+
+    # Page 2: only the figure's caption contributes to page text (its pixels
+    # go through the image port instead); the footnote is dropped.
+    assert pages_by_number[2] == "Figure 1: model architecture"
+    assert "Google Brain" not in pages_by_number[2]
+
+    # The figure itself comes back through the image port, not the text one.
+    assert images[2] == [ExtractedImage(
+        image_bytes=_TINY_PNG, width=1, height=1, ext="png", caption="Figure 1: model architecture",
+    )]
+    # Tables are never surfaced as images (indexed as HTML text instead).
+    assert 1 not in images
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/unit/application/test_table_chunk_format.py
+++ b/tests/unit/application/test_table_chunk_format.py
@@ -1,0 +1,56 @@
+"""Tests for classifying a text chunk as a table.
+
+A preserved table indexed as ordinary prose is invisible to a query that needs a
+table, which is why table retrieval measured 0/5 on the flattening path even
+though the numbers were present in the text. These tests pin the classification
+that makes the difference.
+"""
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from monkeygrab.application.index_corpus import _text_chunk_format  # noqa: E402
+
+
+def test_html_table_is_marked_as_a_table():
+    chunk = (
+        "Table 1: Maximum path lengths per layer type.\n"
+        "<table><tr><td>Layer Type</td><td>Complexity</td></tr>"
+        "<tr><td>Self-Attention</td><td>O(n^2 · d)</td></tr></table>"
+    )
+    assert _text_chunk_format(chunk) == "table"
+
+
+def test_prose_is_not_marked_as_a_table():
+    chunk = (
+        "The encoder is composed of a stack of N = 6 identical layers, each with "
+        "two sub-layers."
+    )
+    assert _text_chunk_format(chunk) == "markdown"
+
+
+def test_detection_survives_tag_attributes_and_casing():
+    """Extractors differ in how they emit the tag; the content is the same."""
+    for variant in (
+        '<table border="1">',
+        "<TABLE>",
+        "<Table class='data'>",
+    ):
+        assert _text_chunk_format(f"caption\n{variant}<tr><td>x</td></tr></table>") == "table"
+
+
+def test_prose_merely_mentioning_the_word_table_is_not_a_table():
+    """The word appears constantly in papers; only real markup counts.
+
+    Otherwise every sentence referring to "Table 3" would be indexed as a table
+    and the distinction would carry no information.
+    """
+    chunk = (
+        "As shown in Table 3, the big model outperforms all previously published "
+        "models. The table also reports training cost."
+    )
+    assert _text_chunk_format(chunk) == "markdown"

--- a/tests/unit/test_app_config_defaults.py
+++ b/tests/unit/test_app_config_defaults.py
@@ -98,6 +98,22 @@ _FIELD_MAP = [
 ]
 
 
+# Fields that exist only in the new configuration and therefore have nothing in
+# rag.chat_pdfs to be compared against. Listed explicitly rather than skipped by
+# a prefix rule, so that adding a field still forces a decision here instead of
+# quietly escaping the drift guard.
+#
+# The backend selectors are new capability: the old engine had no way to choose an
+# implementation, which is why swapping one meant editing wiring code. Their
+# defaults are covered by tests/unit/test_stack_selection.py, which asserts that
+# an unset environment reproduces the current production stack.
+_FIELDS_WITHOUT_ENGINE_COUNTERPART = {
+    "stack.extractor",
+    "stack.vector_store",
+    "stack.embedder",
+}
+
+
 def _resolve(obj, dotted_path):
     for part in dotted_path.split("."):
         obj = getattr(obj, part)
@@ -184,7 +200,7 @@ def test_field_map_is_exhaustive_over_appconfig_leaf_fields():
     import dataclasses
 
     cfg = AppConfig()
-    mapped = {path for path, _ in _FIELD_MAP}
+    mapped = {path for path, _ in _FIELD_MAP} | _FIELDS_WITHOUT_ENGINE_COUNTERPART
 
     def _leaf_paths(obj, prefix=""):
         paths = set()

--- a/tests/unit/test_stack_selection.py
+++ b/tests/unit/test_stack_selection.py
@@ -1,0 +1,121 @@
+"""Tests for selecting a backend by configuration.
+
+This is what turns the ports from an interface exercise into something usable:
+if a technology cannot be swapped by configuration, comparing two of them means
+editing wiring code, which is expensive enough that the comparison never happens.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from monkeygrab.config.stack import (  # noqa: E402
+    EMBEDDER_JINA_CLIP,
+    EMBEDDER_OLLAMA,
+    EXTRACTOR_MINERU,
+    EXTRACTOR_PYMUPDF,
+    VECTOR_STORE_CHROMA,
+    VECTOR_STORE_FAISS,
+    StackConfig,
+    stack_from_env,
+)
+
+
+# ─────────────────────────────────────────────
+# defaults preserve today's behaviour
+# ─────────────────────────────────────────────
+
+
+def test_unset_environment_selects_the_current_production_stack(monkeypatch):
+    """An unset environment must not change what the app does today."""
+    for var in ("PDF_EXTRACTOR", "VECTOR_STORE", "EMBEDDER"):
+        monkeypatch.delenv(var, raising=False)
+
+    stack = stack_from_env()
+
+    assert stack.extractor == EXTRACTOR_PYMUPDF
+    assert stack.vector_store == VECTOR_STORE_CHROMA
+    assert stack.embedder == EMBEDDER_OLLAMA
+    assert not stack.is_multimodal
+
+
+def test_each_selector_is_read_from_its_own_variable(monkeypatch):
+    monkeypatch.setenv("PDF_EXTRACTOR", EXTRACTOR_MINERU)
+    monkeypatch.setenv("VECTOR_STORE", VECTOR_STORE_FAISS)
+    monkeypatch.setenv("EMBEDDER", EMBEDDER_JINA_CLIP)
+
+    stack = stack_from_env()
+
+    assert stack.extractor == EXTRACTOR_MINERU
+    assert stack.vector_store == VECTOR_STORE_FAISS
+    assert stack.embedder == EMBEDDER_JINA_CLIP
+    assert stack.is_multimodal
+
+
+def test_stacks_can_be_mixed(monkeypatch):
+    """Backends are independent: MinerU with Chroma is a legitimate combination.
+
+    The comparison this exists for needs one variable changed at a time, so the
+    selectors must not be secretly coupled to each other.
+    """
+    monkeypatch.setenv("PDF_EXTRACTOR", EXTRACTOR_MINERU)
+    monkeypatch.delenv("VECTOR_STORE", raising=False)
+    monkeypatch.delenv("EMBEDDER", raising=False)
+
+    stack = stack_from_env()
+
+    assert stack.extractor == EXTRACTOR_MINERU
+    assert stack.vector_store == VECTOR_STORE_CHROMA
+    assert not stack.is_multimodal
+
+
+# ─────────────────────────────────────────────
+# unknown values fail loudly
+# ─────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "variable",
+    ["PDF_EXTRACTOR", "VECTOR_STORE", "EMBEDDER"],
+)
+def test_an_unimplemented_backend_raises_instead_of_falling_back(monkeypatch, variable):
+    """Coercing an unknown value to the default is how the previous
+    configuration hid the fact that its MinerU path did not exist at all: it
+    documented PDF_EXTRACTOR=mineru while no such code existed, and asking for
+    it silently produced pymupdf output.
+    """
+    monkeypatch.setenv(variable, "something-that-does-not-exist")
+
+    with pytest.raises(ValueError, match=variable):
+        stack_from_env()
+
+
+# ─────────────────────────────────────────────
+# identity of an index depends on the stack
+# ─────────────────────────────────────────────
+
+
+def test_different_stacks_have_different_slugs():
+    """Two stacks produce vectors of different dimension and meaning, so their
+    indexes must never resolve to the same directory.
+    """
+    old = StackConfig()
+    new = StackConfig(
+        extractor=EXTRACTOR_MINERU,
+        vector_store=VECTOR_STORE_FAISS,
+        embedder=EMBEDDER_JINA_CLIP,
+    )
+
+    assert old.slug != new.slug
+    assert EXTRACTOR_MINERU in new.slug and EMBEDDER_JINA_CLIP in new.slug
+
+
+def test_stack_config_is_immutable():
+    stack = StackConfig()
+    with pytest.raises(Exception):
+        stack.extractor = EXTRACTOR_MINERU  # type: ignore[misc]


### PR DESCRIPTION
The multimodal stack from #3, #4 and #5. **Not wired into the pipeline yet** — the adapters exist and are verified individually; pointing the indexing use case at them and running the A/B is #13.

## Verified against the real thing, not mocks

| Piece | Evidence |
|---|---|
| **MinerU** | 15 pages of the Attention paper in 83 s: **4 tables recovered with HTML intact**, 5 figures with correct captions. Second pass 0.1 s from cache. |
| **Multimodal embedder** | Figure scores **0.357** against text describing it, **0.055** against unrelated text — cross-modal retrieval discriminates. Cold start 28 s, then 0.4 s per image. |
| **FAISS** | Same vectors into Chroma and FAISS return the **same ids in the same order**. They are interchangeable behind the port, tested rather than claimed. |

Suite: 324 passed, 1 skipped. `ruff` clean.

## What makes this swappable rather than just present

Ports made the implementations replaceable in principle; nothing made them replaceable in practice, since choosing a different store still meant editing wiring code. Three selectors now name the backend for extraction, vector store and embeddings, so running the same gate against both stacks is one environment variable and a second run.

Unknown values raise. The previous configuration documented a `PDF_EXTRACTOR=mineru` option while no such code existed, and asking for it silently produced pymupdf output.

Every import in the composition root is deferred inside its factory: importing an adapter imports its library, so module-level imports would drag chromadb, faiss and torch into every process regardless of what was selected.

## The half of MinerU that nearly got lost

Extraction was only half the value. Indexing marked **every** text chunk as markdown, so a perfectly recovered table was indexed as prose and stayed invisible to a query that needed a table — precisely why table retrieval measured 0/5 while the numbers were sitting in the text. A chunk carrying an HTML table is now marked as one, keyed on the markup rather than on the extractor's identity.

## Constraints discovered, and why they shaped the design

> [!IMPORTANT]
> **jina-clip-v2 cannot run in the product environment.** Under transformers 5.1 it fails initializing weights; disabling lazy init and forcing CPU do not help. It loads in the isolated venv with transformers 4.57, so the adapter drives a persistent worker there. Downgrading the main environment for one model would have been the wrong trade — and it is the same reason MinerU stays a CLI.

Two further findings worth keeping:

- sentence-transformers 5.6.1 added a declared-modalities check that jina-clip's remote code predates: it declares text only while its own forward pass handles images. The worker patches the declaration after loading rather than editing cached model code.
- MinerU 3.4.4 differs from what the spike documented — tables and formulas are on by default and page indices are already zero-based.

## Judgement calls

- **Image embedding is a separate port**, not a widening of the text one: the Ollama embedder is text-only, and widening would force every embedder to pretend otherwise.
- **A dead worker is never silently restarted.** Once observed dead, later calls fail explicitly, because a CUDA OOM restarting in a loop reads as slowness instead of failure.
- **`faiss-cpu`, not GPU.** The GPU is worth spending on the embedder and the generator; exact inner-product search at this corpus size is not the bottleneck.
- **One instruction of mine was wrong and got corrected in review**: I asked for absent ids to raise, which contradicts the port — context expansion relies on absent neighbours at document boundaries being normal.

## Licence

jina-clip-v2 is **CC BY-NC**, non-commercial, accepted by decision and recorded in the adapter's docstring. Commercial use would need a permissive alternative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)