### PR TITLE
Make the evaluation gate trustworthy enough to optimise against

### DIFF
--- a/src/monkeygrab/adapters/vectorstore/faiss_store.py
+++ b/src/monkeygrab/adapters/vectorstore/faiss_store.py
@@ -158,7 +158,7 @@ class FaissVectorStore:
     L2-normalized before insertion and before querying, which turns the
     index's raw inner product into cosine similarity.
 
-    Persistence layout: three files under ``<path_db>/<collection_name>/``
+    Persistence layout: four files under ``<path_db>/<collection_name>/``
     (one client path holding several named collections):
 
     - ``index.faiss`` -- the FAISS index itself (``faiss.write_index``).
@@ -167,6 +167,15 @@ class FaissVectorStore:
     - ``version.txt`` -- the on-disk format version, checked on load so a
       future layout change fails loudly on old stores instead of
       misreading them.
+    - ``fingerprint.txt`` -- an opaque recipe fingerprint the caller hands
+      this adapter to persist; this store never interprets it (meaning
+      lives in ``monkeygrab.application.index_fingerprint``). Deliberately
+      optional, and deliberately excluded from ``_load_or_init``'s
+      all-or-none presence check: every store written before fingerprinting
+      existed lacks this file and must keep loading. Do not fold it into
+      that check -- doing so would turn every pre-existing index into a
+      hard failure. Its absence means "recipe unknown", which callers
+      treat as stale.
 
     Id-to-position mapping: FAISS indexes by integer position, but chunk ids
     are strings (``Chunk.id``, e.g. ``"paper.pdf_pag2_chunk3"``). Row *i* of

--- a/src/monkeygrab/adapters/vectorstore/faiss_store.py
+++ b/src/monkeygrab/adapters/vectorstore/faiss_store.py
@@ -34,6 +34,11 @@ _INDEX_FILENAME = "index.faiss"
 _META_FILENAME = "meta.jsonl"
 _VERSION_FILENAME = "version.txt"
 
+# Deliberately outside the all-or-none rule in _load_or_init: every store
+# written before fingerprinting existed lacks this file, and those stores must
+# keep loading. Absent means "recipe unknown", which callers treat as stale.
+_FINGERPRINT_FILENAME = "fingerprint.txt"
+
 
 # METADATA CONVERSION
 
@@ -198,6 +203,7 @@ class FaissVectorStore:
         self._index_path = os.path.join(self._dir, _INDEX_FILENAME)
         self._meta_path = os.path.join(self._dir, _META_FILENAME)
         self._version_path = os.path.join(self._dir, _VERSION_FILENAME)
+        self._fingerprint_path = os.path.join(self._dir, _FINGERPRINT_FILENAME)
 
         self._index, self._rows = _load_or_init(self._dir)
         self._id_to_pos: Dict[str, int] = {row[0]: i for i, row in enumerate(self._rows)}
@@ -277,6 +283,33 @@ class FaissVectorStore:
     def count(self) -> int:
         return len(self._rows)
 
+    def read_fingerprint(self) -> Optional[str]:
+        """Return the index recipe fingerprint this store recorded, if any.
+
+        Returns:
+            The stored value, or ``None`` when the store predates
+            fingerprinting or recorded a blank one. ``None`` means *unknown*,
+            never *matches*: an index whose recipe cannot be established is
+            precisely the one that must not be trusted.
+        """
+        if not os.path.exists(self._fingerprint_path):
+            return None
+        with open(self._fingerprint_path, "r", encoding="utf-8") as f:
+            return f.read().strip() or None
+
+    def write_fingerprint(self, fingerprint: str) -> None:
+        """Record the fingerprint of the recipe that produced this content.
+
+        The value is opaque to this adapter: it persists the string and never
+        interprets it. What it means lives in
+        ``monkeygrab.application.index_fingerprint``.
+
+        Args:
+            fingerprint: The digest to record.
+        """
+        with open(self._fingerprint_path, "w", encoding="utf-8") as f:
+            f.write(fingerprint + "\n")
+
     def delete_source(self, source: str) -> int:
         positions = [
             position
@@ -304,7 +337,12 @@ class FaissVectorStore:
         self._index = None
         self._rows = []
         self._id_to_pos = {}
-        for path in (self._index_path, self._meta_path, self._version_path):
+        for path in (
+            self._index_path,
+            self._meta_path,
+            self._version_path,
+            self._fingerprint_path,
+        ):
             if os.path.exists(path):
                 os.remove(path)
 

--- a/src/monkeygrab/application/index_fingerprint.py
+++ b/src/monkeygrab/application/index_fingerprint.py
@@ -1,0 +1,74 @@
+"""Index fingerprint -- what must match for a stored index to still be valid.
+
+An index is only comparable with the pipeline that built it. Reusing one that
+was built under different chunking, a different embedding model or a different
+index-time flag makes a run measure a mixture of two pipelines while reporting
+a single number, and an optimisation loop would attribute that difference to
+whatever it happened to change last. This module names exactly which
+configuration decides an index's content, so a mismatch can force a rebuild
+instead of being discovered as an unexplained score.
+
+Pure: no I/O and no infrastructure imports. Persisting the value is the vector
+store's job; deciding what it means is this module's.
+"""
+
+import hashlib
+import json
+from typing import Any, Dict
+
+from monkeygrab.config.app_config import AppConfig
+
+# The fixed multimodal stack. Not read from config because it is not
+# configurable (docs/design/2026-07-26-monkeygrab-v2.md). Bump by hand when the
+# extractor or the embedding model is replaced -- exactly the kind of change
+# that has to invalidate every index built before it.
+_EXTRACTOR_ID = "mineru"
+_EMBEDDING_ID = "jinaai/jina-clip-v2@512"
+
+_FINGERPRINT_CHARS = 16
+
+
+def index_recipe(config: AppConfig) -> Dict[str, Any]:
+    """Return the configuration that decides an index's stored content.
+
+    Only what changes stored chunks belongs here. Retrieval fan-out, fusion
+    weights, the reranker threshold and the answer models are all read at query
+    time and leave the index untouched; including them would make the loop
+    reindex the whole corpus on every candidate it evaluates.
+
+    Args:
+        config: The configuration an index was, or would be, built under.
+
+    Returns:
+        A JSON-serializable dict describing that recipe.
+    """
+    recipe: Dict[str, Any] = {
+        "extractor": _EXTRACTOR_ID,
+        "embedding": _EMBEDDING_ID,
+        "chunk_size": config.chunking.chunk_size,
+        "chunk_overlap": config.chunking.chunk_overlap,
+        "min_chunk_length": config.chunking.min_chunk_length,
+        "contextual_retrieval": config.flags.usar_contextual_retrieval,
+        "image_embeddings": config.flags.usar_embeddings_imagen,
+    }
+    # The contextual model and its document sample only reach stored text when
+    # that stage actually runs. Including them unconditionally would make an
+    # index built with the stage OFF depend on a model that never got called.
+    if config.flags.usar_contextual_retrieval:
+        recipe["contextual_model"] = config.models.contextual
+        recipe["contextual_doc_chars"] = config.chunking.contextual_doc_chars
+    return recipe
+
+
+def compute_index_fingerprint(config: AppConfig) -> str:
+    """Return a short stable digest of ``index_recipe(config)``.
+
+    Args:
+        config: The configuration an index was, or would be, built under.
+
+    Returns:
+        16 hex characters -- short enough to read in a log line, wide enough
+        that a collision between two real recipes is not a practical concern.
+    """
+    canonical = json.dumps(index_recipe(config), sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:_FINGERPRINT_CHARS]

--- a/tests/eval/README.md
+++ b/tests/eval/README.md
@@ -128,3 +128,30 @@ something is missing:
 
 Infrastructure failures leave the run inconclusive. Only a complete run with
 the calibrated generator model is compared against the baseline.
+
+## Measuring the noise floor and the gate's sensitivity
+
+Both need a GPU machine with Ollama running — the fast CI gate cannot run
+them. `compare_runs.py` itself is pure and is covered by the fast gate.
+
+**Noise floor.** Run the identical configuration twice and compare:
+
+```bash
+python tests/eval/run_eval.py
+python tests/eval/run_eval.py
+python tests/eval/compare_runs.py tests/eval/runs/<first>.json tests/eval/runs/<second>.json
+```
+
+Every flip is noise. Record the observed number: no delta at or below it counts
+as a real change, and an optimisation loop must not treat one as an improvement.
+
+**Sensitivity.** Compare a healthy run against a deliberately degraded one:
+
+```bash
+RAG_TOP_K_FINAL=1 python tests/eval/run_eval.py
+python tests/eval/compare_runs.py tests/eval/runs/<healthy>.json tests/eval/runs/<degraded>.json
+```
+
+The degraded run must flip a clearly larger number of cases to FAIL than the
+noise floor. A gate that barely moves under a known degradation cannot detect
+an improvement either.

--- a/tests/eval/README.md
+++ b/tests/eval/README.md
@@ -145,10 +145,23 @@ python tests/eval/compare_runs.py tests/eval/runs/<first>.json tests/eval/runs/<
 Every flip is noise. Record the observed number: no delta at or below it counts
 as a real change, and an optimisation loop must not treat one as an improvement.
 
-**Sensitivity.** Compare a healthy run against a deliberately degraded one:
+**Sensitivity.** Compare a healthy run (either one from the noise-floor pair
+above) against a deliberately degraded one:
 
 ```bash
-RAG_TOP_K_FINAL=1 python tests/eval/run_eval.py
+RAG_TOP_K_FINAL=1 python tests/eval/run_eval.py                       # POSIX (bash/zsh)
+```
+
+```powershell
+$env:RAG_TOP_K_FINAL = "1"                                            # PowerShell
+python tests/eval/run_eval.py
+```
+
+`$env:RAG_TOP_K_FINAL` persists for the rest of the PowerShell session --
+clear it (`Remove-Item Env:RAG_TOP_K_FINAL`) or restart the shell before
+running a healthy config again.
+
+```bash
 python tests/eval/compare_runs.py tests/eval/runs/<healthy>.json tests/eval/runs/<degraded>.json
 ```
 

--- a/tests/eval/README.md
+++ b/tests/eval/README.md
@@ -105,10 +105,13 @@ something is missing:
    not Ollama roles.
 2. Downloads any missing blind-set arXiv papers (reusing `fetch_papers.py`)
    and stages them under `blind_docs/<paper-slug>.pdf`.
-3. Indexes whatever is not already indexed -- dev-set papers into the
-   existing `rag/docs/en/` collection, blind-set papers into their own
-   collection under `blind_docs/` -- via the real `indexar_documentos`
-   pipeline. Already-indexed papers are never reprocessed.
+3. Indexes whatever is not already indexed -- dev-set papers read from
+   `rag/docs/en/` but stored in the eval's own isolated collection, blind-set
+   papers into their own collection under `blind_docs/` -- via the real
+   `indexar_documentos` pipeline. A paper is reused only when the store's
+   recorded index recipe (chunking, embeddings, index-time flags) matches
+   the configuration this run will use; a changed recipe discards the store
+   and rebuilds it.
 4. Verifies every paper referenced by a gold case actually has an index
    entry before running anything.
 5. Runs every case through the real retrieval + (for factual cases)

--- a/tests/eval/compare_runs.py
+++ b/tests/eval/compare_runs.py
@@ -37,6 +37,34 @@ def _outcomes(report: Dict[str, Any]) -> Dict[str, bool]:
     }
 
 
+def _reject_unusable(report: Dict[str, Any], label: str) -> None:
+    """Refuse a report that never produced a real measurement.
+
+    ``run_eval.py`` draws this same distinction itself -- it prints
+    INCONCLUSIVE and skips the baseline check for a run with infrastructure
+    errors -- but it writes the report to disk before doing so, so an
+    inconclusive or empty report is otherwise indistinguishable from a
+    healthy one once it is sitting in ``runs/``.
+
+    Args:
+        report: The parsed report to check.
+        label: Which of the two reports this is, for the error message.
+
+    Raises:
+        ValueError: The report has no cases, or has cases that never
+            completed (an Ollama timeout, a dead server, a retrieval crash).
+    """
+    results = report["results"]
+    if not results:
+        raise ValueError(f"{label} has no cases and cannot be compared")
+    broken = [r for r in results if r.get("infrastructure_error")]
+    if broken:
+        raise ValueError(
+            f"{label} is inconclusive: {len(broken)} case(s) hit an "
+            "infrastructure error and cannot be compared"
+        )
+
+
 def compare(report_a: Dict[str, Any], report_b: Dict[str, Any]) -> Dict[str, Any]:
     """Compare two run reports case by case.
 
@@ -49,9 +77,13 @@ def compare(report_a: Dict[str, Any], report_b: Dict[str, Any]) -> Dict[str, Any
         ``stable`` (count unchanged) and ``pass_rate_delta`` (b minus a).
 
     Raises:
-        ValueError: The two runs do not cover the same cases. A partial run
-            would otherwise compare as a large improvement or regression.
+        ValueError: The two runs do not cover the same cases (a partial run
+            would otherwise compare as a large improvement or regression),
+            or either run is inconclusive or empty -- a run that measured
+            nothing must not be treated as a noise-free result.
     """
+    _reject_unusable(report_a, "report_a")
+    _reject_unusable(report_b, "report_b")
     a, b = _outcomes(report_a), _outcomes(report_b)
     if a.keys() != b.keys():
         difference = sorted(set(a) ^ set(b))

--- a/tests/eval/compare_runs.py
+++ b/tests/eval/compare_runs.py
@@ -1,0 +1,103 @@
+"""compare_runs -- diff two eval run reports case by case.
+
+The gate's headline pass rate cannot tell a real improvement from sampling
+noise on its own: a two-point move is one case. What distinguishes them is
+which cases changed state between two runs, so this compares reports rather
+than rates.
+
+Two uses, same tool. Run the same configuration twice and every flip is noise,
+which measures the floor below which no delta means anything. Run a
+deliberately sabotaged configuration against a healthy one and the flips are
+the gate's sensitivity -- a measure that does not move under a known
+degradation cannot detect an improvement either.
+
+Pure over parsed JSON: no network, no GPU, no model.
+
+Usage:
+    python tests/eval/compare_runs.py runs/<a>.json runs/<b>.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+
+def _outcomes(report: Dict[str, Any]) -> Dict[str, bool]:
+    """Map ``"<case id> / <model>"`` to its pass/fail for one report.
+
+    The model is part of the key because a multi-model run grades the same case
+    once per generator, and those are different measurements.
+    """
+    return {
+        f"{r['id']} / {r['model'] or 'n-a'}": bool(r["passed"])
+        for r in report["results"]
+    }
+
+
+def compare(report_a: Dict[str, Any], report_b: Dict[str, Any]) -> Dict[str, Any]:
+    """Compare two run reports case by case.
+
+    Args:
+        report_a: The earlier/reference run, parsed.
+        report_b: The later/candidate run, parsed.
+
+    Returns:
+        ``flipped_to_pass`` and ``flipped_to_fail`` (sorted case keys),
+        ``stable`` (count unchanged) and ``pass_rate_delta`` (b minus a).
+
+    Raises:
+        ValueError: The two runs do not cover the same cases. A partial run
+            would otherwise compare as a large improvement or regression.
+    """
+    a, b = _outcomes(report_a), _outcomes(report_b)
+    if a.keys() != b.keys():
+        difference = sorted(set(a) ^ set(b))
+        raise ValueError(
+            f"runs cover different cases and cannot be compared: {difference}"
+        )
+
+    flipped_to_pass = sorted(k for k in a if not a[k] and b[k])
+    flipped_to_fail = sorted(k for k in a if a[k] and not b[k])
+    total = len(a)
+    delta = (sum(b.values()) - sum(a.values())) / total if total else 0.0
+    return {
+        "flipped_to_pass": flipped_to_pass,
+        "flipped_to_fail": flipped_to_fail,
+        "stable": total - len(flipped_to_pass) - len(flipped_to_fail),
+        "pass_rate_delta": round(delta, 4),
+    }
+
+
+def _print(result: Dict[str, Any]) -> None:
+    """Print the comparison, leading with the verdict a reader actually needs."""
+    to_pass: List[str] = result["flipped_to_pass"]
+    to_fail: List[str] = result["flipped_to_fail"]
+    if not to_pass and not to_fail:
+        print(f"identical: {result['stable']} case(s) unchanged")
+    else:
+        print(f"{len(to_pass)} flipped to PASS, {len(to_fail)} flipped to FAIL, "
+              f"{result['stable']} unchanged")
+    for key in to_pass:
+        print(f"  + {key}")
+    for key in to_fail:
+        print(f"  - {key}")
+    print(f"pass rate delta: {result['pass_rate_delta']:+.4f}")
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("report_a", type=Path)
+    parser.add_argument("report_b", type=Path)
+    args = parser.parse_args(argv)
+
+    report_a = json.loads(args.report_a.read_text(encoding="utf-8"))
+    report_b = json.loads(args.report_b.read_text(encoding="utf-8"))
+    _print(compare(report_a, report_b))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/eval/run_eval.py
+++ b/tests/eval/run_eval.py
@@ -606,15 +606,31 @@ def _bucket_stats(records: Sequence[Dict[str, Any]], key_fn) -> Dict[str, Dict[s
     }
 
 
-def build_summary(records: Sequence[Dict[str, Any]]) -> Dict[str, Any]:
-    """Build the overall / by-case-type / by-model / cross summary blocks."""
+# Case types decided entirely by retrieval: they never call a generator, so a
+# pass says a fragment of the right kind was surfaced -- not that any answer
+# used it. Blending them into one figure reads as answer quality and is not.
+_RETRIEVAL_ONLY_CASE_TYPES = ("figure_retrieval", "table_retrieval")
+
+
+def _rate(records: Sequence[Dict[str, Any]]) -> Dict[str, Any]:
+    """Pass/total/rate over ``records``; an empty bucket rates 0.0, not an error."""
     total = len(records)
     passed = sum(1 for r in records if r["passed"])
     return {
-        "overall": {
-            "total": total, "passed": passed,
-            "pass_rate": round(passed / total, 4) if total else 0.0,
-        },
+        "total": total,
+        "passed": passed,
+        "pass_rate": round(passed / total, 4) if total else 0.0,
+    }
+
+
+def build_summary(records: Sequence[Dict[str, Any]]) -> Dict[str, Any]:
+    """Build the overall / by-case-type / by-model / cross summary blocks."""
+    retrieval_only = [r for r in records if r["case_type"] in _RETRIEVAL_ONLY_CASE_TYPES]
+    answered = [r for r in records if r["case_type"] not in _RETRIEVAL_ONLY_CASE_TYPES]
+    return {
+        "overall": _rate(records),
+        "retrieval_only": _rate(retrieval_only),
+        "answer": _rate(answered),
         "by_case_type": _bucket_stats(records, lambda r: r["case_type"]),
         "by_model": _bucket_stats(records, lambda r: r["model"] or "n/a (retrieval)"),
         "by_case_type_and_model": _bucket_stats(
@@ -627,6 +643,9 @@ def print_summary(summary: Dict[str, Any]) -> None:
     """Print a compact human-readable table -- the CI log's actual payoff."""
     o = summary["overall"]
     print(f"\n=== RESULT: {o['passed']}/{o['total']} passed ({o['pass_rate']:.1%}) ===\n")
+    r, a = summary["retrieval_only"], summary["answer"]
+    print(f"  retrieval only  {r['passed']:>3}/{r['total']:<3} ({r['pass_rate']:.1%})")
+    print(f"  answered        {a['passed']:>3}/{a['total']:<3} ({a['pass_rate']:.1%})\n")
     print("-- by case type --")
     for key, b in sorted(summary["by_case_type"].items()):
         print(f"  {key:<20} {b['passed']:>3}/{b['total']:<3} ({b['pass_rate']:.1%})")

--- a/tests/eval/run_eval.py
+++ b/tests/eval/run_eval.py
@@ -86,9 +86,9 @@ BASELINE_MARGIN = 0.05
 
 # Case types decided entirely by retrieval: they skip generation in
 # run_all_cases (a pass says a fragment of the right kind was surfaced, not
-# that any answer used it) and are reported in their own build_summary bucket
-# so blending them into "answer" would not read as answer quality that it
-# isn't. One definition drives both, so a third retrieval-only type can't be
+# that any answer used it) and are reported in their own build_summary bucket,
+# because blending them into "answer" would read as answer quality that isn't
+# there. One definition drives both, so a third retrieval-only type can't be
 # added to the dispatch without also changing how it's reported.
 _RETRIEVAL_ONLY_CASE_TYPES = ("figure_retrieval", "table_retrieval")
 

--- a/tests/eval/run_eval.py
+++ b/tests/eval/run_eval.py
@@ -87,6 +87,14 @@ AUX_MODEL = "gemma4:e2b"
 # variance (model sampling, Ollama warmup) from flipping the gate red.
 BASELINE_MARGIN = 0.05
 
+# Case types decided entirely by retrieval: they skip generation in
+# run_all_cases (a pass says a fragment of the right kind was surfaced, not
+# that any answer used it) and are reported in their own build_summary bucket
+# so blending them into "answer" would not read as answer quality that it
+# isn't. One definition drives both, so a third retrieval-only type can't be
+# added to the dispatch without also changing how it's reported.
+_RETRIEVAL_ONLY_CASE_TYPES = ("figure_retrieval", "table_retrieval")
+
 
 class EvalSetupError(RuntimeError):
     """Raised when a prerequisite (Ollama, a model, an index) is missing.
@@ -563,7 +571,7 @@ def run_all_cases(
         # figure sitting next to a retrieved paragraph would otherwise count as
         # "retrieved" and quietly inflate the figure and table scores -- the
         # two the multimodal stack exists to move.
-        if case["case_type"] in ("figure_retrieval", "table_retrieval"):
+        if case["case_type"] in _RETRIEVAL_ONLY_CASE_TYPES:
             record = run_retrieval_case(case, retrieved, elapsed)
             records.append(record)
             status = "PASS" if record["passed"] else "FAIL"
@@ -604,12 +612,6 @@ def _bucket_stats(records: Sequence[Dict[str, Any]], key_fn) -> Dict[str, Dict[s
         key: {**b, "pass_rate": round(b["passed"] / b["total"], 4) if b["total"] else 0.0}
         for key, b in buckets.items()
     }
-
-
-# Case types decided entirely by retrieval: they never call a generator, so a
-# pass says a fragment of the right kind was surfaced -- not that any answer
-# used it. Blending them into one figure reads as answer quality and is not.
-_RETRIEVAL_ONLY_CASE_TYPES = ("figure_retrieval", "table_retrieval")
 
 
 def _rate(records: Sequence[Dict[str, Any]]) -> Dict[str, Any]:

--- a/tests/eval/run_eval.py
+++ b/tests/eval/run_eval.py
@@ -196,6 +196,22 @@ def stage_blind_papers(cases: Sequence[Dict[str, Any]]) -> Dict[str, str]:
     return required
 
 
+def should_rebuild(stored: Optional[str], expected: str) -> bool:
+    """Whether a store must be discarded and rebuilt before it can be measured.
+
+    Args:
+        stored: The fingerprint the store recorded, or ``None`` if it recorded
+            none.
+        expected: The fingerprint of the configuration this run will use.
+
+    Returns:
+        True unless the store provably matches. An unknown recipe rebuilds:
+        reusing chunks whose provenance cannot be established would report one
+        number for a mixture of two pipelines.
+    """
+    return stored != expected
+
+
 def ensure_indexed(rag, carpeta: Path, required_pdfs: Iterable[str], label: str):
     """Index missing PDFs into the multimodal stack; return its use cases.
 
@@ -218,6 +234,7 @@ def ensure_indexed(rag, carpeta: Path, required_pdfs: Iterable[str], label: str)
     from monkeygrab.adapters.reranking.cross_encoder_reranker import CrossEncoderReranker
     from monkeygrab.application.answer import Answer
     from monkeygrab.application.index_corpus import IndexCorpus
+    from monkeygrab.application.index_fingerprint import compute_index_fingerprint
     from monkeygrab.application.retrieve import Retrieve
     from monkeygrab.composition import build_stack
 
@@ -227,7 +244,20 @@ def ensure_indexed(rag, carpeta: Path, required_pdfs: Iterable[str], label: str)
         config = _eval_app_config(rag, carpeta)
         stack = build_stack(config)
         store = stack.vector_store
-        existing = _sources_in_store(store)
+        expected_fingerprint = compute_index_fingerprint(config)
+        stored_fingerprint = store.read_fingerprint()
+        existing = set()
+        if should_rebuild(stored_fingerprint, expected_fingerprint):
+            if store.count():
+                print(
+                    f"[index] {label}: recipe changed "
+                    f"({stored_fingerprint or 'unrecorded'} -> {expected_fingerprint}), "
+                    "discarding and rebuilding",
+                    flush=True,
+                )
+                store.clear()
+        else:
+            existing = _sources_in_store(store)
         missing = sorted(required - existing)
         if not missing:
             print(f"[index] {label}: cache hit, {len(required)} paper(s) already indexed")
@@ -264,6 +294,12 @@ def ensure_indexed(rag, carpeta: Path, required_pdfs: Iterable[str], label: str)
                 f"{label}: {still_missing} still not indexed after an indexing attempt "
                 "-- check the [index] log above for the underlying error"
             )
+
+        # Written only after every required paper is confirmed present, so an
+        # aborted indexing run never leaves a fingerprint claiming a complete
+        # index. A half-built store keeps its old (or absent) value and gets
+        # rebuilt on the next run.
+        store.write_fingerprint(expected_fingerprint)
 
         lexical = Bm25LexicalIndex(store, config.retrieval)
         # Reranking runs on whatever device the adapter detects, which is CUDA

--- a/tests/eval/run_eval.py
+++ b/tests/eval/run_eval.py
@@ -67,6 +67,18 @@ RESULTS_DIR = EVAL_DIR / "runs"
 BLIND_DOCS_DIR = EVAL_DIR / "blind_docs"
 DEV_DOCS_DIR = REPO_ROOT / "rag" / "docs" / "en"
 
+# Fed into derive_db_paths in place of DEV_DOCS_DIR when building the dev-set
+# config (see _eval_app_config's path_label) -- never read from disk, only its
+# basename matters. Deriving the FAISS collection from DEV_DOCS_DIR directly
+# would give this run the same "docs_en" collection the product's own store
+# uses, and that store has a second writer: the web UI's indexing path writes
+# chunks into it under its own flags and never records this gate's fingerprint.
+# Reusing it here would silently measure a mixture of two pipelines, and the
+# first eval run after a user adds a document there would call store.clear()
+# on a store that still has product data in it. The blind set never needed
+# this because BLIND_DOCS_DIR's basename already differs from "en".
+EVAL_DEV_LABEL = EVAL_DIR / "dev_docs"
+
 OLLAMA_BASE_URL = "http://localhost:11434"
 
 # The baseline was calibrated with this model. Other models can be measured
@@ -230,7 +242,13 @@ def should_rebuild(stored: Optional[str], expected: str) -> bool:
     return stored != expected
 
 
-def ensure_indexed(rag, carpeta: Path, required_pdfs: Iterable[str], label: str):
+def ensure_indexed(
+    rag,
+    carpeta: Path,
+    required_pdfs: Iterable[str],
+    label: str,
+    path_label: Optional[Path] = None,
+):
     """Index missing PDFs into the multimodal stack; return its use cases.
 
     Args:
@@ -238,6 +256,8 @@ def ensure_indexed(rag, carpeta: Path, required_pdfs: Iterable[str], label: str)
         carpeta: PDF directory to index.
         required_pdfs: Filenames that must end up indexed.
         label: Short name for log lines ("dev set", "blind set").
+        path_label: Forwarded to _eval_app_config to isolate the FAISS
+            collection from carpeta's own basename (see EVAL_DEV_LABEL).
 
     Returns:
         ``(Retrieve, Stack)`` for this corpus. Caller should ``close()`` the
@@ -259,7 +279,7 @@ def ensure_indexed(rag, carpeta: Path, required_pdfs: Iterable[str], label: str)
     required = set(required_pdfs)
     rag.set_docs_folder_runtime(str(carpeta))
     try:
-        config = _eval_app_config(rag, carpeta)
+        config = _eval_app_config(rag, carpeta, path_label=path_label)
         stack = build_stack(config)
         store = stack.vector_store
         expected_fingerprint = compute_index_fingerprint(config)
@@ -395,9 +415,19 @@ def _fragment_to_dict(fragment) -> Dict[str, Any]:
     return fragment_to_dict(fragment)
 
 
-def _eval_app_config(rag, carpeta: Path):
-    """Build the fixed multimodal evaluation configuration."""
+def _eval_app_config(rag, carpeta: Path, path_label: Optional[Path] = None):
+    """Build the fixed multimodal evaluation configuration.
+
+    Args:
+        rag: The imported rag.chat_pdfs module (runtime model/flag source).
+        carpeta: PDF directory this run indexes from.
+        path_label: When given, derive the FAISS store location/collection
+            name from this path's basename instead of carpeta's, without
+            changing which folder is actually indexed. See EVAL_DEV_LABEL for
+            why the dev set needs this and the blind set does not.
+    """
     from monkeygrab.config.app_config import AppConfig
+    from monkeygrab.config.paths import derive_db_paths
 
     config = AppConfig.from_env().with_overrides(
         **{
@@ -416,7 +446,13 @@ def _eval_app_config(rag, carpeta: Path):
             "flags.usar_recomp_synthesis": rag.USAR_RECOMP_SYNTHESIS,
         }
     )
-    return config.with_overrides(**{"flags.usar_contextual_retrieval": False})
+    config = config.with_overrides(**{"flags.usar_contextual_retrieval": False})
+    if path_label is not None:
+        path_db, collection_name = derive_db_paths(str(path_label), config.paths.data_dir)
+        config = config.with_overrides(
+            **{"paths.path_db": path_db, "paths.collection_name": collection_name}
+        )
+    return config
 
 
 def _sources_in_store(store) -> set[str]:
@@ -730,7 +766,7 @@ def main(argv: Optional[List[str]] = None) -> int:
         dev_required = set(_required_pdfs(cases, "corpus"))
 
         retrieve_dev, evidence_dev, stack_dev = ensure_indexed(
-            rag, DEV_DOCS_DIR, dev_required, "dev set"
+            rag, DEV_DOCS_DIR, dev_required, "dev set", path_label=EVAL_DEV_LABEL
         )
         stacks_to_close.append(stack_dev)
         retrieve_blind = None

--- a/tests/eval/run_eval.py
+++ b/tests/eval/run_eval.py
@@ -39,8 +39,6 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Sequence
 
-import requests
-
 # CONSTANTS
 
 EVAL_DIR = Path(__file__).resolve().parent
@@ -57,7 +55,6 @@ if str(REPO_ROOT / "src") not in sys.path:
 if str(EVAL_DIR) not in sys.path:
     sys.path.insert(0, str(EVAL_DIR))
 
-import fetch_papers  # noqa: E402  (tests/eval sibling module)
 import grade  # noqa: E402  (tests/eval sibling module)
 
 GOLD_FILE = EVAL_DIR / "gold_cases.jsonl"
@@ -113,6 +110,12 @@ def _installed_ollama_models() -> List[str]:
     Raises:
         EvalSetupError: Ollama is not reachable at OLLAMA_BASE_URL.
     """
+    # Deferred so importing this module -- which test_index_reuse.py and
+    # test_summary_split.py do, to reach pure helpers like should_rebuild and
+    # build_summary -- never requires requests. The fast CI gate installs
+    # only pytest, precisely to prove those helpers need nothing else.
+    import requests
+
     try:
         response = requests.get(f"{OLLAMA_BASE_URL}/api/tags", timeout=5)
         response.raise_for_status()
@@ -181,6 +184,13 @@ def stage_blind_papers(cases: Sequence[Dict[str, Any]]) -> Dict[str, str]:
     Returns:
         ``{"<paper>.pdf": arxiv_id}`` for every blind-set paper, staged.
     """
+    # Deferred for the same reason as the `requests` import in
+    # _installed_ollama_models: fetch_papers.py itself imports requests at
+    # module level, so importing it eagerly here would defeat the
+    # dependency-free fast CI gate just as much as importing requests
+    # directly would.
+    import fetch_papers
+
     required = _required_pdfs(cases, "arxiv")
     if not required:
         return {}

--- a/tests/eval/test_compare_runs.py
+++ b/tests/eval/test_compare_runs.py
@@ -50,3 +50,23 @@ def test_cases_missing_from_one_run_are_rejected():
     b = _report({"x": True})
     with pytest.raises(ValueError, match="y / m"):
         compare(a, b)
+
+
+def test_inconclusive_run_is_rejected():
+    # A record with infrastructure_error is a case that never ran -- an
+    # Ollama timeout or dead server, not a real pass/fail. Comparing it as an
+    # ordinary failure would inflate the measured noise floor with a fluke.
+    a = _report({"x": True, "y": True})
+    b = _report({"x": True, "y": True})
+    b["results"][1]["infrastructure_error"] = True
+    with pytest.raises(ValueError, match="report_b.*inconclusive"):
+        compare(a, b)
+
+
+def test_empty_run_is_rejected():
+    # Zero cases is the most complete crash of all -- it must not compare as
+    # "0 case(s) unchanged", which reads as a clean, noise-free result.
+    a = _report({})
+    b = _report({"x": True})
+    with pytest.raises(ValueError, match="report_a.*no cases"):
+        compare(a, b)

--- a/tests/eval/test_compare_runs.py
+++ b/tests/eval/test_compare_runs.py
@@ -1,0 +1,52 @@
+"""Tests for the run-to-run comparison used to measure the gate's noise floor."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from compare_runs import compare  # noqa: E402
+
+
+def _report(outcomes):
+    results = [
+        {"id": case_id, "model": "m", "passed": passed}
+        for case_id, passed in outcomes.items()
+    ]
+    return {"results": results}
+
+
+def test_identical_runs_have_no_flips():
+    report = _report({"a": True, "b": False})
+    result = compare(report, report)
+    assert result["flipped_to_pass"] == []
+    assert result["flipped_to_fail"] == []
+    assert result["stable"] == 2
+    assert result["pass_rate_delta"] == 0.0
+
+
+def test_flips_are_reported_in_both_directions():
+    a = _report({"x": False, "y": True, "z": True})
+    b = _report({"x": True, "y": False, "z": True})
+    result = compare(a, b)
+    assert result["flipped_to_pass"] == ["x / m"]
+    assert result["flipped_to_fail"] == ["y / m"]
+    assert result["stable"] == 1
+    assert result["pass_rate_delta"] == 0.0
+
+
+def test_pass_rate_delta_is_b_minus_a():
+    a = _report({"x": False, "y": False})
+    b = _report({"x": True, "y": False})
+    assert compare(a, b)["pass_rate_delta"] == 0.5
+
+
+def test_cases_missing_from_one_run_are_rejected():
+    # A run that crashed mid-way must not be silently compared as if it were
+    # complete -- that would read as a huge improvement or regression.
+    a = _report({"x": True, "y": True})
+    b = _report({"x": True})
+    with pytest.raises(ValueError, match="y / m"):
+        compare(a, b)

--- a/tests/eval/test_ensure_indexed_fingerprint.py
+++ b/tests/eval/test_ensure_indexed_fingerprint.py
@@ -1,0 +1,94 @@
+"""Pins the write-after-verify invariant in run_eval.ensure_indexed.
+
+ensure_indexed writes the index fingerprint only after confirming every
+required paper actually ended up in the store -- an indexing attempt that
+silently drops a paper must raise EvalSetupError instead. Nothing enforced
+that order: hoisting the write above the raise passed every other test.
+
+Needs the full engine importable, like ensure_indexed itself does (it
+unconditionally imports OllamaChatModel/Bm25LexicalIndex/CrossEncoderReranker
+before any of its own branching runs, regardless of which flags this test
+forces off). The monkeygrab.adapters import below is what lets
+tests/conftest.py's heuristic skip this file in the dependency-free fast
+gate, the same way it already skips tests/unit/adapters/*.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import pytest  # noqa: E402
+
+import run_eval  # noqa: E402  (tests/eval sibling module; sets up sys.path for monkeygrab)
+from monkeygrab.adapters.lexical.bm25_index import Bm25LexicalIndex  # noqa: E402,F401
+from monkeygrab.config.app_config import AppConfig  # noqa: E402
+
+
+class _FakeStore:
+    """Vector store double that never actually gains the required paper."""
+
+    def __init__(self):
+        self.fingerprint_written = False
+
+    def count(self):
+        return 0
+
+    def read_fingerprint(self):
+        return None
+
+    def clear(self):
+        pass
+
+    def get_page(self, *_a, **_kw):
+        # Empty on every call, however many indexing passes run -- simulates
+        # an indexing attempt that completes without actually adding the
+        # required paper.
+        return []
+
+    def write_fingerprint(self, value):
+        self.fingerprint_written = True
+
+
+class _FakeIndexCorpus:
+    """Stands in for the real IndexCorpus: a no-op run() is enough to reach
+    the post-index check without needing a real extractor/embedder."""
+
+    def __init__(self, *_a, **_kw):
+        pass
+
+    def run(self, *_a, **_kw):
+        pass
+
+
+class _FakeStack:
+    def __init__(self, store):
+        self.extractor = None
+        self.embedder = None
+        self.vector_store = store
+
+
+class _FakeRag:
+    @staticmethod
+    def set_docs_folder_runtime(*_a, **_kw):
+        pass
+
+
+def test_aborted_indexing_never_writes_a_fingerprint(monkeypatch, tmp_path):
+    store = _FakeStore()
+    fake_stack = _FakeStack(store)
+    fake_config = AppConfig().with_overrides(
+        **{
+            "flags.usar_embeddings_imagen": False,
+            "flags.usar_contextual_retrieval": False,
+        }
+    )
+
+    monkeypatch.setattr(run_eval, "_eval_app_config", lambda rag, carpeta, **_kw: fake_config)
+    monkeypatch.setattr("monkeygrab.composition.build_stack", lambda config: fake_stack)
+    monkeypatch.setattr("monkeygrab.application.index_corpus.IndexCorpus", _FakeIndexCorpus)
+
+    with pytest.raises(run_eval.EvalSetupError):
+        run_eval.ensure_indexed(_FakeRag(), tmp_path, ["missing.pdf"], "dev set")
+
+    assert store.fingerprint_written is False

--- a/tests/eval/test_index_reuse.py
+++ b/tests/eval/test_index_reuse.py
@@ -1,0 +1,22 @@
+"""Tests for the eval runner's index-reuse rule."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from run_eval import should_rebuild  # noqa: E402
+
+
+def test_matching_fingerprint_reuses():
+    assert should_rebuild("abc123", "abc123") is False
+
+
+def test_different_fingerprint_rebuilds():
+    assert should_rebuild("abc123", "def456") is True
+
+
+def test_unknown_fingerprint_rebuilds():
+    # A store from before fingerprinting existed. Its recipe cannot be
+    # established, so reusing it would silently mix two pipelines in one score.
+    assert should_rebuild(None, "abc123") is True

--- a/tests/eval/test_summary_split.py
+++ b/tests/eval/test_summary_split.py
@@ -1,0 +1,43 @@
+"""The summary must not blend retrieval-only cases with answered ones."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from run_eval import build_summary  # noqa: E402
+
+
+def _record(case_type, passed, model=None):
+    return {
+        "id": f"{case_type}-{passed}", "paper": "p", "case_type": case_type,
+        "lang": "en", "model": model, "passed": passed, "reason": "",
+    }
+
+
+def test_retrieval_and_answer_are_reported_apart():
+    records = [
+        _record("figure_retrieval", True),
+        _record("table_retrieval", True),
+        _record("factual_number", False, "m"),
+        _record("factual_concept", True, "m"),
+    ]
+    summary = build_summary(records)
+
+    assert summary["retrieval_only"] == {"total": 2, "passed": 2, "pass_rate": 1.0}
+    assert summary["answer"] == {"total": 2, "passed": 1, "pass_rate": 0.5}
+
+
+def test_overall_keeps_its_existing_meaning():
+    # The baseline ratchet is calibrated against this number. Changing what it
+    # counts would silently change what the gate accepts.
+    records = [
+        _record("figure_retrieval", True),
+        _record("factual_number", False, "m"),
+    ]
+    assert build_summary(records)["overall"] == {"total": 2, "passed": 1, "pass_rate": 0.5}
+
+
+def test_empty_buckets_do_not_divide_by_zero():
+    summary = build_summary([_record("figure_retrieval", True)])
+    assert summary["answer"] == {"total": 0, "passed": 0, "pass_rate": 0.0}

--- a/tests/unit/adapters/test_faiss_store_fingerprint.py
+++ b/tests/unit/adapters/test_faiss_store_fingerprint.py
@@ -1,0 +1,53 @@
+"""Tests for the FAISS store's opaque fingerprint sidecar."""
+
+from monkeygrab.adapters.vectorstore.faiss_store import FaissVectorStore
+from monkeygrab.config.paths import PathsConfig
+from monkeygrab.domain.chunk import Chunk
+from monkeygrab.domain.chunk_metadata import ChunkMetadata
+
+
+def _store(tmp_path):
+    return FaissVectorStore(PathsConfig(path_db=str(tmp_path), collection_name="c"))
+
+
+def _chunk():
+    # Chunk.id is derived from source/page/chunk, so metadata is all it needs.
+    return Chunk(
+        text="hello",
+        metadata=ChunkMetadata(source="a.pdf", page=1, chunk=0, section_header=""),
+    )
+
+
+def test_absent_fingerprint_reads_as_none(tmp_path):
+    assert _store(tmp_path).read_fingerprint() is None
+
+
+def test_written_fingerprint_survives_reopen(tmp_path):
+    store = _store(tmp_path)
+    store.write_fingerprint("abc123")
+    assert _store(tmp_path).read_fingerprint() == "abc123"
+
+
+def test_blank_fingerprint_file_reads_as_none(tmp_path):
+    store = _store(tmp_path)
+    store.write_fingerprint("   ")
+    assert _store(tmp_path).read_fingerprint() is None
+
+
+def test_clear_removes_the_fingerprint(tmp_path):
+    store = _store(tmp_path)
+    store.add(_chunk(), [0.1, 0.2, 0.3])
+    store.write_fingerprint("abc123")
+    store.clear()
+    assert store.read_fingerprint() is None
+    assert _store(tmp_path).read_fingerprint() is None
+
+
+def test_a_store_without_a_fingerprint_still_loads(tmp_path):
+    # Every index written before fingerprinting existed lacks the file. It must
+    # load as a valid store with an unknown recipe, not as corruption.
+    store = _store(tmp_path)
+    store.add(_chunk(), [0.1, 0.2, 0.3])
+    reopened = _store(tmp_path)
+    assert reopened.count() == 1
+    assert reopened.read_fingerprint() is None

--- a/tests/unit/application/test_index_fingerprint.py
+++ b/tests/unit/application/test_index_fingerprint.py
@@ -1,0 +1,62 @@
+"""Tests for the index fingerprint: what must and must not invalidate an index."""
+
+from monkeygrab.application.index_fingerprint import (
+    compute_index_fingerprint,
+    index_recipe,
+)
+from monkeygrab.config.app_config import AppConfig
+
+
+def test_same_config_gives_same_fingerprint():
+    config = AppConfig()
+    assert compute_index_fingerprint(config) == compute_index_fingerprint(AppConfig())
+
+
+def test_chunk_size_change_invalidates():
+    base = AppConfig()
+    changed = base.with_overrides(**{"chunking.chunk_size": 1000})
+    assert compute_index_fingerprint(base) != compute_index_fingerprint(changed)
+
+
+def test_index_time_flag_change_invalidates():
+    base = AppConfig()
+    changed = base.with_overrides(**{"flags.usar_embeddings_imagen": False})
+    assert compute_index_fingerprint(base) != compute_index_fingerprint(changed)
+
+
+def test_retrieval_parameters_do_not_invalidate():
+    # Retrieval fan-out is read at query time and never reaches stored chunks.
+    # If this ever flips, the loop would reindex on every candidate it tries.
+    base = AppConfig()
+    changed = base.with_overrides(
+        **{"retrieval.top_k_final": 3, "retrieval.weight_bm25_rrf": 0.9}
+    )
+    assert compute_index_fingerprint(base) == compute_index_fingerprint(changed)
+
+
+def test_answer_model_does_not_invalidate():
+    base = AppConfig()
+    changed = base.with_overrides(**{"models.rag": "some-other-model"})
+    assert compute_index_fingerprint(base) == compute_index_fingerprint(changed)
+
+
+def test_contextual_model_only_counts_when_the_stage_runs():
+    off = AppConfig().with_overrides(**{"flags.usar_contextual_retrieval": False})
+    off_other_model = off.with_overrides(**{"models.contextual": "some-other-model"})
+    assert compute_index_fingerprint(off) == compute_index_fingerprint(off_other_model)
+
+    on = AppConfig().with_overrides(**{"flags.usar_contextual_retrieval": True})
+    on_other_model = on.with_overrides(**{"models.contextual": "some-other-model"})
+    assert compute_index_fingerprint(on) != compute_index_fingerprint(on_other_model)
+
+
+def test_fingerprint_is_short_hex():
+    value = compute_index_fingerprint(AppConfig())
+    assert len(value) == 16
+    assert all(c in "0123456789abcdef" for c in value)
+
+
+def test_recipe_is_json_serializable_and_names_the_fixed_stack():
+    recipe = index_recipe(AppConfig())
+    assert recipe["extractor"] == "mineru"
+    assert recipe["embedding"].startswith("jinaai/jina-clip-v2")


### PR DESCRIPTION
Block A of `docs/design/2026-07-28-loop-automejorable.md`. Closes acceptance criteria 3 and 4, and delivers the tooling for 1 and 2.

## Why

The gate reused a vector index keyed on **PDF filename alone**. Change chunking, the embedding model or an index-time flag and every existing paper stayed put, so the run measured the old index under the new settings and reported one number for a mixture of two pipelines. An optimisation loop on top of that would attribute the difference to whatever it changed last.

Separately, figure and table cases never reach a generator: they pass when retrieval surfaces a fragment of the expected kind. Folded into a single headline number they read as answer quality, which matters because a figure chunk reaches generation as its caption or a `[figure] page=N` placeholder.

## What changed

| Piece | Where |
|---|---|
| Fingerprint derived from the config that decides index content | `src/monkeygrab/application/index_fingerprint.py` (new, stdlib only) |
| The store persists it as an opaque string | `src/monkeygrab/adapters/vectorstore/faiss_store.py` |
| The runner rebuilds on a mismatch; unrecorded rebuilds | `tests/eval/run_eval.py` |
| Retrieval and answer reported apart; `overall` untouched | `tests/eval/run_eval.py` |
| Case-by-case run comparison | `tests/eval/compare_runs.py` (new) |

Deliberately excluded from the fingerprint: retrieval fan-out, fusion weights, reranking and the answer models. They are read at query time, so including them would reindex the whole corpus on every candidate the loop evaluates.

`overall` keeps its exact meaning: `baseline_min_pass_rate.txt` is calibrated against it, and redefining it would silently change what the gate accepts. `grade.py` and `gold_cases.jsonl` are untouched, so no grading rule moved.

## Two findings the whole-branch review caught

**The fast CI gate would have failed.** The `architecture` job installs only pytest; the new eval tests import `run_eval`, which imported `requests` at module level. The local suite passed because a dev environment is complete. Those imports are now deferred into the functions that need them, verified by blocking `requests` through an import hook.

**The eval dev set shared its FAISS collection with the product's English store**, since the collection name derives from the folder basename. That gave the fingerprint a second writer which never maintained it, and made running the gate silently drop user-added PDFs from the product's index. The dev set now indexes into its own isolated collection: same PDFs measured, separate index.

## Pending measurement, not done

Criteria 1 (repeatability) and 2 (sensitivity) need two pairs of runs on a GPU machine with Ollama. This branch delivers the tool and the documented procedure in `tests/eval/README.md`; **the noise floor is currently unknown**, and until it is measured no delta from an optimisation loop means anything.

Wiring the fingerprint into the product's own indexing path is deliberately out of scope and needs sign-off (design section 6.2). Today the product still reuses its index by presence.

Suite: 289 to 315 passing, 1 skipped. `tests/characterization/` untouched throughout.