### PR TITLE
perf(eval): stop reloading the generator every case in the gate's phase 2

### DIFF
--- a/docs/design/2026-07-28-loop-automejorable.md
+++ b/docs/design/2026-07-28-loop-automejorable.md
@@ -96,9 +96,23 @@ Un loop es un optimizador: todo aquello contra lo que optimiza deja de ser una
 muestra independiente. Si el loop usara el gate completo como función objetivo,
 el conjunto ciego se consumiría en la primera iteración.
 
+> [!WARNING]
+> **Los tiempos de esta sección estaban mal por un factor de ~4.** Medido la
+> noche del 2026-07-29 (issue #27): con `OLLAMA_KEEP_ALIVE=0` (el default del
+> producto), Ollama descarta los pesos del generador tras cada llamada, así que
+> cada caso factual paga una carga en frío completa en la fase de generación:
+> 195 a 210 s por caso, de forma uniforme. La estimación original asumía
+> ~32 s/caso, extrapolados de un informe (2026-07-27) cuya cifra por caso no
+> aislaba generación de recuperación. Los números de la tabla y del diagrama
+> siguientes quedan corregidos con ese factor ~4, aplicado a las cifras
+> originales del diseño. Son una corrección, no una medición directa de este
+> conjunto de búsqueda (que aún no existe): la cifra real, una vez aplicado el
+> Cambio 1 (keep-alive del generador acotado a la fase de evaluación,
+> `tests/eval/run_eval.py`), queda pendiente de medir.
+
 | Conjunto | Papel | Cuándo se toca | Tamaño |
 |---|---|---|---|
-| **Búsqueda** | Función objetivo del loop | Cada iteración | ~11 docs · ~60 casos · ~34 min |
+| **Búsqueda** | Función objetivo del loop | Cada iteración | ~11 docs · ~60 casos · ~136 min (corregido ~4x; pendiente de medir tras el Cambio 1) |
 | **Validación** | Detecta sobreajuste al conjunto de búsqueda | Al cerrar una tanda | ~4 docs · ~22 casos |
 | **Ciego** | Acepta una versión | Sólo para aceptar; nunca dentro del loop | ~5 docs · ~28 casos |
 
@@ -162,9 +176,9 @@ espacio de acción se amplíe a código.
 
 ```mermaid
 flowchart LR
-    P[Proponente] -->|configuración| F[Nivel rápido<br/>~15 casos · ~8 min]
+    P[Proponente] -->|configuración| F[Nivel rápido<br/>~15 casos · ~32 min]
     F -->|regresión| X[Descartado]
-    F -->|sin regresión| G[Conjunto de búsqueda<br/>~60 casos · ~34 min]
+    F -->|sin regresión| G[Conjunto de búsqueda<br/>~60 casos · ~136 min]
     G --> L[(Libro de evidencias<br/>versionado)]
     L --> P
 
@@ -181,11 +195,14 @@ ajustables y con qué valores. Escrito a mano, no inferido por introspección:
 añadir un parámetro debe ser una decisión visible, porque cada uno multiplica el
 espacio contra un presupuesto de evaluaciones muy corto.
 
-**Proponente.** A una hora por evaluación completa, una noche da del orden de
-diez o quince candidatos. La búsqueda aleatoria es inútil con ese presupuesto, así
-que el proponente natural es un LLM que lea los fallos concretos y razone qué
-mover. Para saber si ese razonamiento aporta algo, el arnés incluye un proponente
-determinista como control y el criterio 5 se corre con ambos.
+**Proponente.** A ~4 horas por evaluación completa (nivel rápido más conjunto de
+búsqueda; corregido con el factor de la nota de la sección 3, pendiente de
+remedir tras el Cambio 1 del issue #27), una noche da del orden de tres o cuatro
+candidatos, no diez o quince como asumía la estimación original. La búsqueda
+aleatoria es inútil con ese presupuesto, así que el proponente natural es un LLM
+que lea los fallos concretos y razone qué mover. Para saber si ese razonamiento
+aporta algo, el arnés incluye un proponente determinista como control y el
+criterio 5 se corre con ambos.
 
 **Evaluador.** Aplica la configuración, corre el nivel rápido, descarta si hay
 regresión, y sólo entonces paga el conjunto de búsqueda completo. Devuelve el

--- a/docs/design/2026-07-28-loop-automejorable.md
+++ b/docs/design/2026-07-28-loop-automejorable.md
@@ -104,11 +104,14 @@ el conjunto ciego se consumiría en la primera iteración.
 > 195 a 210 s por caso, de forma uniforme. La estimación original asumía
 > ~32 s/caso, extrapolados de un informe (2026-07-27) cuya cifra por caso no
 > aislaba generación de recuperación. Los números de la tabla y del diagrama
-> siguientes quedan corregidos con ese factor ~4, aplicado a las cifras
-> originales del diseño. Son una corrección, no una medición directa de este
-> conjunto de búsqueda (que aún no existe): la cifra real, una vez aplicado el
-> Cambio 1 (keep-alive del generador acotado a la fase de evaluación,
-> `tests/eval/run_eval.py`), queda pendiente de medir.
+> siguientes quedan corregidos con ese factor ~4, aplicado de forma plana a
+> las cifras originales del diseño -- incluidos los casos `figure_retrieval`
+> y `table_retrieval`, que nunca llaman al generador, así que la cifra
+> corregida es un límite superior, no una medición por tipo de caso. Son una
+> corrección, no una medición directa de este conjunto de búsqueda (que aún
+> no existe): la cifra real, una vez aplicado el Cambio 1 (keep-alive del
+> generador acotado a la fase de evaluación, `tests/eval/run_eval.py`), queda
+> pendiente de medir.
 
 | Conjunto | Papel | Cuándo se toca | Tamaño |
 |---|---|---|---|
@@ -195,14 +198,14 @@ ajustables y con qué valores. Escrito a mano, no inferido por introspección:
 añadir un parámetro debe ser una decisión visible, porque cada uno multiplica el
 espacio contra un presupuesto de evaluaciones muy corto.
 
-**Proponente.** A ~4 horas por evaluación completa (nivel rápido más conjunto de
-búsqueda; corregido con el factor de la nota de la sección 3, pendiente de
-remedir tras el Cambio 1 del issue #27), una noche da del orden de tres o cuatro
-candidatos, no diez o quince como asumía la estimación original. La búsqueda
-aleatoria es inútil con ese presupuesto, así que el proponente natural es un LLM
-que lea los fallos concretos y razone qué mover. Para saber si ese razonamiento
-aporta algo, el arnés incluye un proponente determinista como control y el
-criterio 5 se corre con ambos.
+**Proponente.** A ~2.8 horas por evaluación completa (32 + 136 min: nivel
+rápido más conjunto de búsqueda; corregido con el factor de la nota de la
+sección 3, pendiente de remedir tras el Cambio 1 del issue #27), una noche da
+del orden de tres o cuatro candidatos, no diez o quince como asumía la
+estimación original. La búsqueda aleatoria es inútil con ese presupuesto, así
+que el proponente natural es un LLM que lea los fallos concretos y razone qué
+mover. Para saber si ese razonamiento aporta algo, el arnés incluye un
+proponente determinista como control y el criterio 5 se corre con ambos.
 
 **Evaluador.** Aplica la configuración, corre el nivel rápido, descarta si hay
 regresión, y sólo entonces paga el conjunto de búsqueda completo. Devuelve el

--- a/tests/eval/run_eval.py
+++ b/tests/eval/run_eval.py
@@ -542,17 +542,44 @@ def run_factual_case(
 # Measured in issue #27 (2026-07-29): with the product default KEEP_ALIVE=0,
 # Ollama discards the model's weights after every call, so each factual case
 # in phase 2 paid a ~200s cold load -- a fixed per-call cost, not variance.
-# That reload buys nothing here specifically: run_all_cases already calls
-# _release_gpu_models() before phase 2 starts, so Ollama owns the GPU alone
-# from that point and there is nothing else waiting on the VRAM it would
-# free. 120s comfortably survives the sub-second gap between one case's
-# generation calls and the next (grading plus a dict lookup, no GPU work),
-# without pinning the model in memory once the harness itself exits.
+# The reload is pure waste only when every Ollama role resolves to one model
+# -- true for DEFAULT_MODELS, since AUX_MODEL is the same "gemma4:e2b", which
+# makes OllamaModelUnloader.unload_all_except a no-op. A --models sweep whose
+# generator differs from AUX_MODEL still pays RECOMP's own reload each case
+# (stream() unloads every other configured role before it runs) and puts two
+# models on an 8 GB card -- see _release_gpu_models's docstring for what a
+# short-on-VRAM Ollama does instead of failing fast. 120s survives the
+# sub-second gap between one case's calls and the next (grading, a dict
+# lookup, no GPU work) without pinning a model once the harness itself exits.
 _EVAL_GENERATION_KEEP_ALIVE_SECONDS = "120"
 
 
+def _release_ollama_models(model_names: Iterable[str]) -> None:
+    """POST keep_alive=0 for each model, best-effort.
+
+    Same request shape as OllamaModelUnloader.unload_all_except (see
+    src/monkeygrab/adapters/chat/ollama_model_unloader.py) -- reused rather
+    than reinvented. Restoring OLLAMA_KEEP_ALIVE only changes what the *next*
+    request will ask for; it does not reach back and shorten the 120s the
+    last request already told Ollama to hold the model for, so the run has
+    to ask explicitly to free the card before it exits. A failure here must
+    not mask the run's results, so exceptions are logged and swallowed.
+    """
+    import requests
+
+    for name in sorted(set(model_names)):
+        try:
+            requests.post(
+                f"{OLLAMA_BASE_URL}/api/generate",
+                json={"model": name, "keep_alive": 0},
+                timeout=30,
+            )
+        except Exception as exc:  # noqa: BLE001 - best-effort, see docstring
+            print(f"[phase] failed to release {name!r}: {exc}", flush=True)
+
+
 @contextlib.contextmanager
-def _generation_keep_alive():
+def _generation_keep_alive(models_used: Iterable[str]):
     """Scope OLLAMA_KEEP_ALIVE to this process, for phase 2's generation calls only.
 
     generar_respuesta_silenciosa (rag/engine/generation.py) builds a fresh
@@ -562,13 +589,19 @@ def _generation_keep_alive():
     reaches that call, so the environment is the only lever available here.
 
     Deliberately scoped to the phase 2 block (set after _release_gpu_models,
-    restored once generation finishes) rather than the whole run: phase 1
-    never touches Ollama, so it cannot benefit, and leaving it set past
-    main() would let a non-zero keep-alive leak into anything else importing
-    rag.chat_pdfs afterwards. Does not touch the product default -- see
-    issue #27: keep_alive=0 exists because the embedder and reranker
+    environment variable restored once generation finishes -- that restore
+    only affects future requests, so ``models_used`` is explicitly released
+    below to free Ollama's own 120s hold on them) rather than the whole run:
+    phase 1 never touches Ollama, so it cannot benefit, and leaving it set
+    past main() would let a non-zero keep-alive leak into anything else
+    importing rag.chat_pdfs afterwards. Does not touch the product default --
+    see issue #27: keep_alive=0 exists because the embedder and reranker
     contend for the same 8 GB (issue #25), and raising it globally would
     make that contention worse.
+
+    Args:
+        models_used: Every Ollama model name this phase may have loaded
+            (generator(s) under test plus AUX_MODEL), released on exit.
     """
     previous = os.environ.get("OLLAMA_KEEP_ALIVE")
     os.environ["OLLAMA_KEEP_ALIVE"] = _EVAL_GENERATION_KEEP_ALIVE_SECONDS
@@ -579,6 +612,7 @@ def _generation_keep_alive():
             os.environ.pop("OLLAMA_KEEP_ALIVE", None)
         else:
             os.environ["OLLAMA_KEEP_ALIVE"] = previous
+        _release_ollama_models(models_used)
 
 
 def _release_gpu_models(*retrievers) -> None:
@@ -680,7 +714,7 @@ def run_all_cases(
     _release_gpu_models(retrieve_dev, retrieve_blind)
 
     print(f"\n[phase 2/2] generation for {len(pending)} case(s) (Ollama alone on GPU)", flush=True)
-    with _generation_keep_alive():
+    with _generation_keep_alive(set(models) | {AUX_MODEL}):
         for item in pending:
             records.extend(
                 run_factual_case(rag, item["case"], item["fragments"], models, item["elapsed"])

--- a/tests/eval/run_eval.py
+++ b/tests/eval/run_eval.py
@@ -30,8 +30,10 @@ CPU otherwise, which is not a supported configuration for this gate.
 from __future__ import annotations
 
 import argparse
+import contextlib
 import json
 import math
+import os
 import shutil
 import sys
 import time
@@ -537,6 +539,48 @@ def run_factual_case(
     return records
 
 
+# Measured in issue #27 (2026-07-29): with the product default KEEP_ALIVE=0,
+# Ollama discards the model's weights after every call, so each factual case
+# in phase 2 paid a ~200s cold load -- a fixed per-call cost, not variance.
+# That reload buys nothing here specifically: run_all_cases already calls
+# _release_gpu_models() before phase 2 starts, so Ollama owns the GPU alone
+# from that point and there is nothing else waiting on the VRAM it would
+# free. 120s comfortably survives the sub-second gap between one case's
+# generation calls and the next (grading plus a dict lookup, no GPU work),
+# without pinning the model in memory once the harness itself exits.
+_EVAL_GENERATION_KEEP_ALIVE_SECONDS = "120"
+
+
+@contextlib.contextmanager
+def _generation_keep_alive():
+    """Scope OLLAMA_KEEP_ALIVE to this process, for phase 2's generation calls only.
+
+    generar_respuesta_silenciosa (rag/engine/generation.py) builds a fresh
+    AppConfig on every call via wiring.app_config_from_runtime(), which reads
+    OLLAMA_KEEP_ALIVE straight from the environment -- the config this module
+    builds for retrieval (_eval_app_config) is a separate object that never
+    reaches that call, so the environment is the only lever available here.
+
+    Deliberately scoped to the phase 2 block (set after _release_gpu_models,
+    restored once generation finishes) rather than the whole run: phase 1
+    never touches Ollama, so it cannot benefit, and leaving it set past
+    main() would let a non-zero keep-alive leak into anything else importing
+    rag.chat_pdfs afterwards. Does not touch the product default -- see
+    issue #27: keep_alive=0 exists because the embedder and reranker
+    contend for the same 8 GB (issue #25), and raising it globally would
+    make that contention worse.
+    """
+    previous = os.environ.get("OLLAMA_KEEP_ALIVE")
+    os.environ["OLLAMA_KEEP_ALIVE"] = _EVAL_GENERATION_KEEP_ALIVE_SECONDS
+    try:
+        yield
+    finally:
+        if previous is None:
+            os.environ.pop("OLLAMA_KEEP_ALIVE", None)
+        else:
+            os.environ["OLLAMA_KEEP_ALIVE"] = previous
+
+
 def _release_gpu_models(*retrievers) -> None:
     """Free every retrieval model holding GPU memory, before generation starts.
 
@@ -636,10 +680,11 @@ def run_all_cases(
     _release_gpu_models(retrieve_dev, retrieve_blind)
 
     print(f"\n[phase 2/2] generation for {len(pending)} case(s) (Ollama alone on GPU)", flush=True)
-    for item in pending:
-        records.extend(
-            run_factual_case(rag, item["case"], item["fragments"], models, item["elapsed"])
-        )
+    with _generation_keep_alive():
+        for item in pending:
+            records.extend(
+                run_factual_case(rag, item["case"], item["fragments"], models, item["elapsed"])
+            )
     return records
 
 

--- a/tests/eval/test_generation_keep_alive.py
+++ b/tests/eval/test_generation_keep_alive.py
@@ -1,25 +1,56 @@
 """Tests for the eval runner's phase-2-only OLLAMA_KEEP_ALIVE override.
 
 No GPU or Ollama server needed: these check the environment-scoping
-mechanism itself and that it reaches the exact config path
-(AppConfig.from_env()) that generar_respuesta_silenciosa's fresh
-app_config_from_runtime() call reads at generation time (see issue #27).
+mechanism itself, that it reaches the exact config path (AppConfig.from_env())
+that generar_respuesta_silenciosa's fresh app_config_from_runtime() call reads
+at generation time (see issue #27), and the explicit unload that runs on
+block exit.
+
+``_release_ollama_models`` does its ``import requests`` lazily, same as the
+rest of run_eval.py's Ollama-HTTP calls -- this file participates in the fast
+CI gate (tests/conftest.py), which deliberately installs no project
+dependencies, so it cannot assume the real ``requests`` package exists. The
+``_stub_requests`` fixture below plants a fake module in ``sys.modules``
+instead of importing the real thing, which satisfies that lazy import
+whether or not `requests` is actually installed.
 """
 
 import os
 import sys
+import types
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from run_eval import _EVAL_GENERATION_KEEP_ALIVE_SECONDS, _generation_keep_alive  # noqa: E402
+import pytest  # noqa: E402
+
+import run_eval  # noqa: E402
+from run_eval import (  # noqa: E402
+    _EVAL_GENERATION_KEEP_ALIVE_SECONDS,
+    _generation_keep_alive,
+    _release_ollama_models,
+)
 
 from monkeygrab.config.app_config import AppConfig  # noqa: E402
 
 
+@pytest.fixture(autouse=True)
+def _stub_requests(monkeypatch):
+    """Give every test's ``_release_ollama_models`` call a captured, no-op
+    ``requests.post`` -- ``_generation_keep_alive`` calls it unconditionally
+    on exit, so this must be active even for tests that don't care about the
+    release calls themselves.
+    """
+    calls = []
+    fake_module = types.ModuleType("requests")
+    fake_module.post = lambda url, json, timeout: calls.append(json) or None
+    monkeypatch.setitem(sys.modules, "requests", fake_module)
+    return calls
+
+
 def test_keep_alive_is_set_during_the_block(monkeypatch):
     monkeypatch.delenv("OLLAMA_KEEP_ALIVE", raising=False)
-    with _generation_keep_alive():
+    with _generation_keep_alive(["some-model"]):
         assert os.environ["OLLAMA_KEEP_ALIVE"] == _EVAL_GENERATION_KEEP_ALIVE_SECONDS
         # Same call generar_respuesta_silenciosa makes via
         # wiring.app_config_from_runtime() -- this is the proof the override
@@ -29,14 +60,14 @@ def test_keep_alive_is_set_during_the_block(monkeypatch):
 
 def test_keep_alive_is_removed_after_the_block_when_previously_unset(monkeypatch):
     monkeypatch.delenv("OLLAMA_KEEP_ALIVE", raising=False)
-    with _generation_keep_alive():
+    with _generation_keep_alive(["some-model"]):
         pass
     assert "OLLAMA_KEEP_ALIVE" not in os.environ
 
 
 def test_keep_alive_restores_a_prior_value(monkeypatch):
     monkeypatch.setenv("OLLAMA_KEEP_ALIVE", "42")
-    with _generation_keep_alive():
+    with _generation_keep_alive(["some-model"]):
         assert os.environ["OLLAMA_KEEP_ALIVE"] == _EVAL_GENERATION_KEEP_ALIVE_SECONDS
     assert os.environ["OLLAMA_KEEP_ALIVE"] == "42"
 
@@ -44,8 +75,65 @@ def test_keep_alive_restores_a_prior_value(monkeypatch):
 def test_keep_alive_restores_even_if_generation_raises(monkeypatch):
     monkeypatch.delenv("OLLAMA_KEEP_ALIVE", raising=False)
     try:
-        with _generation_keep_alive():
+        with _generation_keep_alive(["some-model"]):
             raise RuntimeError("simulated generation failure")
     except RuntimeError:
         pass
     assert "OLLAMA_KEEP_ALIVE" not in os.environ
+
+
+def test_generation_keep_alive_releases_the_models_used_on_exit(_stub_requests):
+    """Restoring the env var only changes future requests -- Ollama's own
+    120s hold on the last-used models needs an explicit keep_alive=0 POST,
+    which must fire on block exit regardless (see the
+    _generation_keep_alive docstring)."""
+    with _generation_keep_alive(["gen-model:latest", "aux-model:latest"]):
+        pass
+
+    released = {c["model"] for c in _stub_requests}
+    assert released == {"gen-model:latest", "aux-model:latest"}
+    assert all(c["keep_alive"] == 0 for c in _stub_requests)
+
+
+def test_generation_keep_alive_releases_even_if_generation_raises(_stub_requests):
+    try:
+        with _generation_keep_alive(["some-model"]):
+            raise RuntimeError("simulated generation failure")
+    except RuntimeError:
+        pass
+
+    assert {c["model"] for c in _stub_requests} == {"some-model"}
+
+
+def test_release_deduplicates_model_names(_stub_requests):
+    _release_ollama_models(["m1", "m1", "m2"])
+
+    assert sorted(c["model"] for c in _stub_requests) == ["m1", "m2"]
+
+
+def test_release_posts_to_the_module_base_url(monkeypatch):
+    calls = []
+    fake_module = types.ModuleType("requests")
+    fake_module.post = lambda url, json, timeout: calls.append(url) or None
+    monkeypatch.setitem(sys.modules, "requests", fake_module)
+
+    _release_ollama_models(["m1"])
+
+    assert calls == [f"{run_eval.OLLAMA_BASE_URL}/api/generate"]
+
+
+def test_release_swallows_a_post_failure_for_one_model_and_continues(monkeypatch):
+    calls = []
+
+    def fake_post(url, json, timeout):
+        calls.append(json["model"])
+        if json["model"] == "flaky":
+            raise ConnectionError("simulated Ollama unreachable")
+
+    fake_module = types.ModuleType("requests")
+    fake_module.post = fake_post
+    monkeypatch.setitem(sys.modules, "requests", fake_module)
+
+    _release_ollama_models(["flaky", "other"])  # must not raise
+
+    assert set(calls) == {"flaky", "other"}

--- a/tests/eval/test_generation_keep_alive.py
+++ b/tests/eval/test_generation_keep_alive.py
@@ -1,0 +1,51 @@
+"""Tests for the eval runner's phase-2-only OLLAMA_KEEP_ALIVE override.
+
+No GPU or Ollama server needed: these check the environment-scoping
+mechanism itself and that it reaches the exact config path
+(AppConfig.from_env()) that generar_respuesta_silenciosa's fresh
+app_config_from_runtime() call reads at generation time (see issue #27).
+"""
+
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from run_eval import _EVAL_GENERATION_KEEP_ALIVE_SECONDS, _generation_keep_alive  # noqa: E402
+
+from monkeygrab.config.app_config import AppConfig  # noqa: E402
+
+
+def test_keep_alive_is_set_during_the_block(monkeypatch):
+    monkeypatch.delenv("OLLAMA_KEEP_ALIVE", raising=False)
+    with _generation_keep_alive():
+        assert os.environ["OLLAMA_KEEP_ALIVE"] == _EVAL_GENERATION_KEEP_ALIVE_SECONDS
+        # Same call generar_respuesta_silenciosa makes via
+        # wiring.app_config_from_runtime() -- this is the proof the override
+        # actually reaches generation, not just the retrieval-phase config.
+        assert AppConfig.from_env().models.ollama.keep_alive == int(_EVAL_GENERATION_KEEP_ALIVE_SECONDS)
+
+
+def test_keep_alive_is_removed_after_the_block_when_previously_unset(monkeypatch):
+    monkeypatch.delenv("OLLAMA_KEEP_ALIVE", raising=False)
+    with _generation_keep_alive():
+        pass
+    assert "OLLAMA_KEEP_ALIVE" not in os.environ
+
+
+def test_keep_alive_restores_a_prior_value(monkeypatch):
+    monkeypatch.setenv("OLLAMA_KEEP_ALIVE", "42")
+    with _generation_keep_alive():
+        assert os.environ["OLLAMA_KEEP_ALIVE"] == _EVAL_GENERATION_KEEP_ALIVE_SECONDS
+    assert os.environ["OLLAMA_KEEP_ALIVE"] == "42"
+
+
+def test_keep_alive_restores_even_if_generation_raises(monkeypatch):
+    monkeypatch.delenv("OLLAMA_KEEP_ALIVE", raising=False)
+    try:
+        with _generation_keep_alive():
+            raise RuntimeError("simulated generation failure")
+    except RuntimeError:
+        pass
+    assert "OLLAMA_KEEP_ALIVE" not in os.environ


### PR DESCRIPTION
## Summary

Fixes #27. Two related changes, scoped narrowly per the issue's own request.

**1. `tests/eval/run_eval.py`** -- phase 2 (factual-case generation) paid a
195-210s Ollama cold load per case, measured in issue #27's overnight run,
because `OLLAMA_KEEP_ALIVE` defaults to 0 and `run_all_cases` already frees
the embedder/reranker (`_release_gpu_models`) before phase 2 starts -- Ollama
owns the GPU alone from that point, so discarding its weights between one
case and the next buys nothing.

Scopes `OLLAMA_KEEP_ALIVE=120` to the runner's own process, only around the
phase-2 generation loop, restoring whatever was set (or unset) before once
it finishes. This has to be an environment override rather than a change to
the `AppConfig` this module already builds for retrieval
(`_eval_app_config`): `generar_respuesta_silenciosa` (the call phase 2
actually uses) builds its own fresh `AppConfig` per call through
`wiring.app_config_from_runtime()`, which reads `OLLAMA_KEEP_ALIVE` straight
from the environment and never sees this module's config object -- an
override on `_eval_app_config`'s config would never have reached generation
at all.

Does **not** touch the product default. `keep_alive=0` still ships;
`rag/chat_pdfs.py` and `src/monkeygrab/config/` are untouched. Raising it
globally would put the embedder and reranker back in contention for the
same 8GB (issue #25) -- this change only affects the evaluation harness's
own process, and only during the phase where Ollama already has the GPU to
itself.

**2. `docs/design/2026-07-28-loop-automejorable.md`** -- corrected the
~34min search-set / ~8min fast-tier estimates (wrong by ~4x per the issue's
own measurement) with a `[!WARNING]` callout explaining what was measured
vs. extrapolated, updated the partition table, the Mermaid diagram labels,
and the Proponente cost paragraph (`diez o quince candidatos` -> `tres o
cuatro`). The corrected numbers are marked as a factor correction, not a
fresh measurement of a search corpus that doesn't exist yet, and note that
the actual post-fix generation cost is pending measurement (the full eval
was deliberately not run tonight -- it costs hours).

## Verification

- `pytest -q`: 321 passed, 1 skipped (no regressions; +4 new tests).
- `ruff check .`: all checks passed.
- New tests in `tests/eval/test_generation_keep_alive.py` verify the
  env-scoping context manager sets/restores `OLLAMA_KEEP_ALIVE` correctly
  (including on an exception), and -- the load-bearing check -- that
  `AppConfig.from_env().models.ollama.keep_alive` (the exact call
  `app_config_from_runtime()` makes) reads `120` while the override is
  active. No GPU or Ollama server required.
- **Not verified:** an actual wall-clock latency improvement. The full gate
  was not run. A direct live check against a local idle Ollama timed out
  (unrelated cold-load contention on this machine) and was abandoned in
  favor of the config-level test above.

## Test plan

- [ ] CI fast gate (lint, unit, eval grader against doubles, frontend build)
- [ ] Reviewer confirms the env-var scoping reasoning in
      `_generation_keep_alive`'s docstring
- [ ] A future full-gate run (`workflow_dispatch`) measures the real
      post-fix phase-2 cost and updates the design doc's "pending
      measurement" note with an actual number