### PR TITLE
docs: record measured noise floor for eval gate (criterion 1)

### DIFF
--- a/docs/design/2026-07-28-loop-automejorable.md
+++ b/docs/design/2026-07-28-loop-automejorable.md
@@ -43,9 +43,9 @@ produce mejoras: produce basura reproducible.
 
 | # | Criterio | Cómo se comprueba |
 |---|---|---|
-| 1 | **Repetibilidad** | La misma configuración corrida dos veces aprueba el mismo conjunto de casos. Si no, la dispersión observada queda declarada como suelo de ruido y ningún delta por debajo cuenta como mejora. |
+| 1 | **Repetibilidad** (medido 2026-07-29, ver nota abajo) | La misma configuración corrida dos veces aprueba el mismo conjunto de casos. Si no, la dispersión observada queda declarada como suelo de ruido y ningún delta por debajo cuenta como mejora. |
 | 2 | **Sensibilidad** | Un sabotaje conocido y acotado (recuperar un solo fragmento; apagar el reranker) hace caer el gate de forma inequívoca. |
-| 3 | **No engañable** | Alterar el troceado obliga a reindexar en el run siguiente, en vez de reutilizar el índice por nombre de fichero. |
+| 3 | **No engañable** (evidencia de campo 2026-07-29, ver nota abajo) | Alterar el troceado obliga a reindexar en el run siguiente, en vez de reutilizar el índice por nombre de fichero. |
 | 4 | **Métricas separadas** | Un caso de figura que acierta la recuperación no cuenta como respuesta correcta. |
 | 5 | **Búsqueda efectiva** | Partiendo de una configuración deliberadamente empeorada, el loop recupera al menos hasta el rendimiento actual sin intervención. |
 | 6 | **Techo respetado** | Un candidato que acierta más pero excede la latencia se rechaza, y el informe registra el motivo. |
@@ -54,6 +54,29 @@ produce mejoras: produce basura reproducible.
 
 El criterio 5 se corre con dos proponentes (ver §4) para saber si el razonamiento
 del LLM aporta algo sobre un control determinista.
+
+> [!NOTE]
+> **Criterio 1, medido el 2026-07-29.** Dos runs del gate completo, misma
+> configuración y mismo código, mismo índice (los dos registraron `cache hit`
+> en el conjunto dev y en el ciego, así que ninguno reindexó):
+> `tests/eval/runs/20260729T020233Z_mineru-jina_clip-faiss.json` y
+> `tests/eval/runs/20260729T040824Z_mineru-jina_clip-faiss.json`, ambos
+> 44/51 = 0.8627 global. `compare_runs.py` sobre el par: `identical: 51 case(s)
+> unchanged`, delta de tasa de acierto +0.0000, es decir cero vuelcos. Eso acota
+> el suelo de ruido por debajo de un caso; no demuestra que el pipeline sea
+> determinista en general, y dos runs es una muestra pequeña, así que una
+> afirmación más amplia exige más pares. Dato llamativo: el generador corre a
+> temperatura 0.15, así que una salida idéntica en un run completo no estaba
+> garantizada de antemano. Con este suelo, un vuelco de un solo caso ya es
+> señal y no ruido, así que el margen de nueve casos que calcula este diseño
+> (§3) es aprovechable tal cual.
+>
+> **Criterio 3, evidencia de campo del mismo par de runs.** Los dos runs
+> registraron `cache hit` en ambos corpus (884 y 218 fragmentos), lo cual es
+> evidencia de que la huella del índice funciona sobre un corpus real y no
+> sólo bajo dobles de prueba, que era la única cobertura que tenía hasta
+> ahora. No se marca el criterio como cerrado por esto solo; sólo añade
+> evidencia de campo a la que ya daban los tests unitarios.
 
 ---
 

--- a/docs/design/2026-07-28-loop-automejorable.md
+++ b/docs/design/2026-07-28-loop-automejorable.md
@@ -60,23 +60,43 @@ del LLM aporta algo sobre un control determinista.
 > configuración y mismo código, mismo índice (los dos registraron `cache hit`
 > en el conjunto dev y en el ciego, así que ninguno reindexó):
 > `tests/eval/runs/20260729T020233Z_mineru-jina_clip-faiss.json` y
-> `tests/eval/runs/20260729T040824Z_mineru-jina_clip-faiss.json`, ambos
-> 44/51 = 0.8627 global. `compare_runs.py` sobre el par: `identical: 51 case(s)
-> unchanged`, delta de tasa de acierto +0.0000, es decir cero vuelcos. Eso acota
-> el suelo de ruido por debajo de un caso; no demuestra que el pipeline sea
+> `tests/eval/runs/20260729T040824Z_mineru-jina_clip-faiss.json`. Son
+> artefactos locales: `tests/eval/runs/` está en `.gitignore`, así que nadie
+> que clone el repo puede verificarlos por sí mismo. Ambos 44/51 = 0.8627
+> global. `compare_runs.py` sobre el par: `identical: 51 case(s) unchanged`,
+> delta de tasa de acierto +0.0000, cero vuelcos. `compare_runs.py` compara el
+> vector de aprobado/fallado por caso, no el texto generado, así que eso acota
+> la **clasificación**, no la salida del generador. Prueba directa en el
+> propio par: `planck-sigma8-es` falla en los dos runs y, al fallar, guarda la
+> respuesta generada -- los dos textos difieren (uno termina en "Planck
+> lensing", el otro añade una frase completa sobre las preferencias de
+> amplitud de Planck). El generador corre a temperatura 0.15 y varió, como
+> cabía esperar; lo medido es que el criterio de acierto de `grade.py` absorbe
+> esa variación, no que la salida fuera idéntica. Eso acota el suelo de ruido
+> de la clasificación por debajo de un caso; no demuestra que el pipeline sea
 > determinista en general, y dos runs es una muestra pequeña, así que una
-> afirmación más amplia exige más pares. Dato llamativo: el generador corre a
-> temperatura 0.15, así que una salida idéntica en un run completo no estaba
-> garantizada de antemano. Con este suelo, un vuelco de un solo caso ya es
-> señal y no ruido, así que el margen de nueve casos que calcula este diseño
-> (§3) es aprovechable tal cual.
+> afirmación más amplia exige más pares. El suelo queda medido para este
+> `grade.py`: un cambio en las reglas de puntuación puede moverlo y exigiría
+> remedirlo. Bajo este suelo, un vuelco de un solo caso deja de ser explicable
+> por ruido -- lo cual no es lo mismo que una diferencia entre dos
+> configuraciones sea demostrable: la sección 3 sitúa ese segundo umbral en
+> unos seis vuelcos netos, con un margen aprovechable de unos cinco casos
+> descontadas las figuras. Esta nota no retracta esa cuenta, sólo fija el
+> suelo bajo el que se interpreta; la inferencia, además, descansa en un único
+> par de runs.
 >
 > **Criterio 3, evidencia de campo del mismo par de runs.** Los dos runs
-> registraron `cache hit` en ambos corpus (884 y 218 fragmentos), lo cual es
-> evidencia de que la huella del índice funciona sobre un corpus real y no
-> sólo bajo dobles de prueba, que era la única cobertura que tenía hasta
-> ahora. No se marca el criterio como cerrado por esto solo; sólo añade
-> evidencia de campo a la que ya daban los tests unitarios.
+> registraron `cache hit` en ambos corpus; la línea `chunks={store.count()}`
+> que sigue a cada cache hit en el log es la que reportó 884 y 218 fragmentos
+> respectivamente -- el mensaje de cache hit en sí no cuenta fragmentos. Con
+> la configuración sin cambios, un cache hit ejerce la ruta de
+> **coincidencia** de la huella del índice, no la ruta de **detección** que
+> pide el criterio 3 (que alterar el troceado fuerce un reindexado en el run
+> siguiente). Es evidencia de que la huella no invalida en falso un índice
+> real, cobertura que hasta ahora sólo daban los dobles de prueba; no
+> ejercita el camino que el criterio exige. No se marca el criterio como
+> cerrado por esto solo; sólo añade esa evidencia de campo a la que ya daban
+> los tests unitarios.
 
 ---
 

--- a/tests/eval/README.md
+++ b/tests/eval/README.md
@@ -148,6 +148,20 @@ python tests/eval/compare_runs.py tests/eval/runs/<first>.json tests/eval/runs/<
 Every flip is noise. Record the observed number: no delta at or below it counts
 as a real change, and an optimisation loop must not treat one as an improvement.
 
+**Measured 2026-07-29**, two full-gate runs, identical configuration and code,
+same index (both logged `cache hit` on the dev and blind sets, so neither
+reindexed): `tests/eval/runs/20260729T020233Z_mineru-jina_clip-faiss.json` and
+`tests/eval/runs/20260729T040824Z_mineru-jina_clip-faiss.json`, both
+44/51 = 0.8627 overall. `compare_runs.py` over the pair reports
+`identical: 51 case(s) unchanged`, pass rate delta +0.0000, i.e. zero flips.
+This bounds the noise floor below one case; it does not prove the pipeline is
+deterministic in general, and two runs is a small sample, so a wider claim
+needs more pairs. Genuinely surprising given the generator runs at temperature
+0.15: identical output across a full run was not a given. Under this floor, a
+single-case flip in either direction is signal, not noise, so the nine-case
+headroom this design computes (`docs/design/2026-07-28-loop-automejorable.md`
+§3) is usable as-is.
+
 **Sensitivity.** Compare a healthy run (either one from the noise-floor pair
 above) against a deliberately degraded one:
 

--- a/tests/eval/README.md
+++ b/tests/eval/README.md
@@ -151,16 +151,29 @@ as a real change, and an optimisation loop must not treat one as an improvement.
 **Measured 2026-07-29**, two full-gate runs, identical configuration and code,
 same index (both logged `cache hit` on the dev and blind sets, so neither
 reindexed): `tests/eval/runs/20260729T020233Z_mineru-jina_clip-faiss.json` and
-`tests/eval/runs/20260729T040824Z_mineru-jina_clip-faiss.json`, both
-44/51 = 0.8627 overall. `compare_runs.py` over the pair reports
-`identical: 51 case(s) unchanged`, pass rate delta +0.0000, i.e. zero flips.
-This bounds the noise floor below one case; it does not prove the pipeline is
-deterministic in general, and two runs is a small sample, so a wider claim
-needs more pairs. Genuinely surprising given the generator runs at temperature
-0.15: identical output across a full run was not a given. Under this floor, a
-single-case flip in either direction is signal, not noise, so the nine-case
-headroom this design computes (`docs/design/2026-07-28-loop-automejorable.md`
-§3) is usable as-is.
+`tests/eval/runs/20260729T040824Z_mineru-jina_clip-faiss.json`. These are
+local, gitignored artifacts (`tests/eval/runs/`) -- nobody cloning the repo
+can reproduce this check from them directly. Both 44/51 = 0.8627 overall.
+`compare_runs.py` over the pair reports `identical: 51 case(s) unchanged`,
+pass rate delta +0.0000, zero flips. `compare_runs.py` compares the per-case
+pass/fail vector, not the generated text, so this bounds the
+**classification**, not the output. Direct counterevidence sits in the same
+pair: `planck-sigma8-es` fails in both runs, and a failure stores the
+generated answer -- the two texts differ (one ends on "Planck lensing", the
+other appends a full sentence on Planck's preferred amplitudes). The
+generator runs at temperature 0.15 and varied, as expected; what's measured
+is that `grade.py`'s literal-match criterion absorbs that variance, not that
+the output was identical. This bounds the noise floor of the classification
+below one case; it does not prove the pipeline is deterministic in general,
+and two runs is a small sample, so a wider claim needs more pairs. The floor
+is measured for this `grade.py`: changing the grading rules could move it
+and would require re-measuring. Under this floor, a single-case flip stops
+being explainable by noise, which is not the same as a difference between two
+configurations being demonstrable: design doc section 3 puts that second
+threshold at roughly six net flips, with a usable margin of about five cases
+once figure cases are excluded. This note does not retract that count, it
+only sets the floor it is interpreted against; the inference also rests on a
+single pair of runs.
 
 **Sensitivity.** Compare a healthy run (either one from the noise-floor pair
 above) against a deliberately degraded one:


### PR DESCRIPTION
## Summary
- Records the repeatability measurement (criterion 1) taken 2026-07-29: two identical full-gate runs, zero case flips (44/51 both times), confirmed independently with `compare_runs.py`.
- Adds a caveat: this bounds the noise floor below one case for this pair; it does not prove determinism in general, and a wider claim needs more pairs. Notes the generator runs at temperature 0.15, which makes identical output across a full run non-obvious.
- Adds field evidence toward criterion 3 (index fingerprint) from the same pair: both runs logged `cache hit` on the dev and blind corpora, which previously rested on unit tests alone.
- Criteria 2 and 4 are left untouched (not closed).

Documentation only — `tests/eval/README.md` and `docs/design/2026-07-28-loop-automejorable.md`. No code, no `grade.py`/`gold_cases.jsonl`/`run_eval.py`/`tests/characterization/` touched.

## Test plan
- [x] `python tests/eval/compare_runs.py tests/eval/runs/20260729T020233Z_mineru-jina_clip-faiss.json tests/eval/runs/20260729T040824Z_mineru-jina_clip-faiss.json` re-run, confirms `identical: 51 case(s) unchanged`, delta +0.0000
- [x] `C:/Users/nadiv/anaconda3/python.exe -m ruff check .` clean
- [x] `grep -c '—' docs/design/2026-07-28-loop-automejorable.md` = 0