### PR TITLE
Record acceptance criterion 2 (sensitivity) as measured

### DIFF
--- a/docs/design/2026-07-28-loop-automejorable.md
+++ b/docs/design/2026-07-28-loop-automejorable.md
@@ -91,8 +91,13 @@ del LLM aporta algo sobre un control determinista.
 > `tests/eval/runs/20260729T020233Z_mineru-jina_clip-faiss.json` (44/51 =
 > 0.8627), degradado
 > `tests/eval/runs/20260729T081129Z_mineru-jina_clip-faiss.json` (39/51 =
-> 0.7647, 121.1 min). Mismo código, mismo índice: los dos registraron `cache
-> hit`. Son artefactos locales, igual que en la nota del criterio 1:
+> 0.7647, 121.1 min). Los dos registraron `cache hit`, lo cual acota el
+> índice, no el código: que entre ambos runs sólo medie un commit de
+> documentación es cierto, pero nada citado aquí lo respalda, y ningún informe
+> registra el valor de `RAG_TOP_K_FINAL` con el que corrió cada uno, así que la
+> configuración degradada queda afirmada, no capturada -- exactamente el hueco
+> que el libro de evidencias (§4) y el criterio 7 existen para cerrar. Son
+> artefactos locales, igual que en la nota del criterio 1:
 > `tests/eval/runs/` está en `.gitignore`, nadie que clone el repo puede
 > verlos directamente. `compare_runs.py` sobre el par: **2 vuelcos a PASS, 7
 > vuelcos a FAIL, 42 sin cambio, delta de tasa de acierto -0.0980**. Los siete
@@ -103,7 +108,14 @@ del LLM aporta algo sobre un control determinista.
 > recuperación sola pasa de 11/15 (0.7333) a 4/15 (0.2667); respuesta pasa de
 > 33/36 (0.9167) a 35/36 (0.9722). El run degradado también incumple el suelo
 > de `baseline_min_pass_rate.txt` (0.7647 < 0.77), que es el gate
-> comportándose correctamente ante una degradación conocida.
+> comportándose correctamente ante una degradación conocida -- pero por un
+> margen de 0.0053, frente a los 0.0196 que vale un solo caso: con 40/51 =
+> 0.7843 (recuperación en 5/15 en vez de 4/15, igual de hundida) el gate
+> habría aprobado la misma degradación catastrófica. El agregado cayó 0.098
+> mientras que la recuperación cayó 0.47; es la evidencia más nítida del punto
+> que ya hace el párrafo de consecuencia más abajo: un agregado que apenas
+> nota un desplome de recuperación de esta magnitud es justo lo que vuelve
+> peligroso a un loop que lo maximiza.
 >
 > Esta medición sólo es interpretable porque el suelo de ruido que fija la
 > nota del criterio 1, con el mismo par de runs sanos, es cero vuelcos. Siete
@@ -111,9 +123,14 @@ del LLM aporta algo sobre un control determinista.
 > distinto de cero habría que descontarlo antes de leer nada.
 >
 > Recuperación y respuesta se movieron en direcciones opuestas: recuperación
-> se desploma, respuesta mejora. Una lectura plausible es que menos contexto
-> distrae menos en preguntas factuales concretas -- pero eso es una hipótesis,
-> no un hallazgo: nada en esta medición la puso a prueba.
+> se desploma con 7 vuelcos -- por encima del umbral de unos seis vuelcos
+> netos que la nota del criterio 1 cita (fijado en la sección 3) para que una
+> diferencia sea demostrable --, mientras que respuesta mejora con sólo 2
+> vuelcos netos: por encima del suelo de ruido de cero pero por debajo de ese
+> mismo umbral, así que esta medición no demuestra que la mejora en respuesta
+> sea real. Una lectura plausible es que menos contexto distrae menos en
+> preguntas factuales concretas -- pero eso es una hipótesis, no un hallazgo:
+> nada en esta medición la puso a prueba.
 >
 > Se probó una única configuración degradada (`RAG_TOP_K_FINAL=1`), no un
 > barrido; el otro sabotaje que enumera el criterio (apagar el reranker) sigue
@@ -127,7 +144,10 @@ del LLM aporta algo sobre un control determinista.
 > factual sin que nadie lo note -- el agregado por sí solo no distingue esa
 > compensación de una mejora real. Las métricas separadas del criterio 4 son
 > las que hacen visible el intercambio; hoy la función objetivo del diseño
-> sigue apuntando al agregado.
+> sigue apuntando al agregado. Cinco de los siete vuelcos a FAIL son casos de
+> figura, y la sección 3 (Margen inalcanzable) ya deja parte de esos casos
+> fuera del escalar que el loop maximiza -- lo que hace la advertencia más
+> fuerte, no menos.
 >
 > **Criterio 3, evidencia de campo del mismo par de runs.** Los dos runs
 > registraron `cache hit` en ambos corpus; la línea `chunks={store.count()}`

--- a/docs/design/2026-07-28-loop-automejorable.md
+++ b/docs/design/2026-07-28-loop-automejorable.md
@@ -44,7 +44,7 @@ produce mejoras: produce basura reproducible.
 | # | Criterio | Cómo se comprueba |
 |---|---|---|
 | 1 | **Repetibilidad** (medido 2026-07-29, ver nota abajo) | La misma configuración corrida dos veces aprueba el mismo conjunto de casos. Si no, la dispersión observada queda declarada como suelo de ruido y ningún delta por debajo cuenta como mejora. |
-| 2 | **Sensibilidad** | Un sabotaje conocido y acotado (recuperar un solo fragmento; apagar el reranker) hace caer el gate de forma inequívoca. |
+| 2 | **Sensibilidad** (medido 2026-07-29, ver nota abajo) | Un sabotaje conocido y acotado (recuperar un solo fragmento; apagar el reranker) hace caer el gate de forma inequívoca. |
 | 3 | **No engañable** (evidencia de campo 2026-07-29, ver nota abajo) | Alterar el troceado obliga a reindexar en el run siguiente, en vez de reutilizar el índice por nombre de fichero. |
 | 4 | **Métricas separadas** | Un caso de figura que acierta la recuperación no cuenta como respuesta correcta. |
 | 5 | **Búsqueda efectiva** | Partiendo de una configuración deliberadamente empeorada, el loop recupera al menos hasta el rendimiento actual sin intervención. |
@@ -84,6 +84,50 @@ del LLM aporta algo sobre un control determinista.
 > descontadas las figuras. Esta nota no retracta esa cuenta, sólo fija el
 > suelo bajo el que se interpreta; la inferencia, además, descansa en un único
 > par de runs.
+>
+> **Criterio 2, medido el 2026-07-29.** Un run degradado a propósito
+> (`RAG_TOP_K_FINAL=1`, recuperación devuelve un solo fragmento) comparado
+> contra el run sano del mismo par que mide el criterio 1: sano
+> `tests/eval/runs/20260729T020233Z_mineru-jina_clip-faiss.json` (44/51 =
+> 0.8627), degradado
+> `tests/eval/runs/20260729T081129Z_mineru-jina_clip-faiss.json` (39/51 =
+> 0.7647, 121.1 min). Mismo código, mismo índice: los dos registraron `cache
+> hit`. Son artefactos locales, igual que en la nota del criterio 1:
+> `tests/eval/runs/` está en `.gitignore`, nadie que clone el repo puede
+> verlos directamente. `compare_runs.py` sobre el par: **2 vuelcos a PASS, 7
+> vuelcos a FAIL, 42 sin cambio, delta de tasa de acierto -0.0980**. Los siete
+> que empeoraron son todos casos de sólo recuperación: `att-arch-figure`,
+> `att-arch-figure-es`, `att-bleu-table`, `dpo-pipeline-figure`,
+> `resnet-block-figure`, `vit-comparison-table`, `vit-overview-figure`. Los
+> dos que mejoraron: `planck-sigma8-es`, `resnet-top1-34layer`. Por métrica:
+> recuperación sola pasa de 11/15 (0.7333) a 4/15 (0.2667); respuesta pasa de
+> 33/36 (0.9167) a 35/36 (0.9722). El run degradado también incumple el suelo
+> de `baseline_min_pass_rate.txt` (0.7647 < 0.77), que es el gate
+> comportándose correctamente ante una degradación conocida.
+>
+> Esta medición sólo es interpretable porque el suelo de ruido que fija la
+> nota del criterio 1, con el mismo par de runs sanos, es cero vuelcos. Siete
+> vuelcos contra un suelo de cero es señal inequívoca; contra un suelo
+> distinto de cero habría que descontarlo antes de leer nada.
+>
+> Recuperación y respuesta se movieron en direcciones opuestas: recuperación
+> se desploma, respuesta mejora. Una lectura plausible es que menos contexto
+> distrae menos en preguntas factuales concretas -- pero eso es una hipótesis,
+> no un hallazgo: nada en esta medición la puso a prueba.
+>
+> Se probó una única configuración degradada (`RAG_TOP_K_FINAL=1`), no un
+> barrido; el otro sabotaje que enumera el criterio (apagar el reranker) sigue
+> sin medir. Esta nota usa la separación entre recuperación y respuesta que ya
+> reporta `run_eval.py`, pero mide sólo el criterio 2: no declara cerrado el
+> criterio 4 por usarla.
+>
+> Consecuencia para el arnés: la función objetivo de la sección 1 maximiza un
+> único número agregado. Un loop que maximizara sólo ese agregado podría
+> favorecer configuraciones que cambian calidad de recuperación por acierto
+> factual sin que nadie lo note -- el agregado por sí solo no distingue esa
+> compensación de una mejora real. Las métricas separadas del criterio 4 son
+> las que hacen visible el intercambio; hoy la función objetivo del diseño
+> sigue apuntando al agregado.
 >
 > **Criterio 3, evidencia de campo del mismo par de runs.** Los dos runs
 > registraron `cache hit` en ambos corpus; la línea `chunks={store.count()}`

--- a/tests/eval/README.md
+++ b/tests/eval/README.md
@@ -203,8 +203,13 @@ an improvement either.
 `tests/eval/runs/20260729T020233Z_mineru-jina_clip-faiss.json` (44/51 =
 0.8627, the same run used for the noise-floor pair above) against degraded run
 `tests/eval/runs/20260729T081129Z_mineru-jina_clip-faiss.json`
-(`RAG_TOP_K_FINAL=1`, 39/51 = 0.7647, 121.1 min). Same code, same index (both
-logged `cache hit`). These are local, gitignored artifacts (`tests/eval/runs/`)
+(`RAG_TOP_K_FINAL=1`, 39/51 = 0.7647, 121.1 min). Both logged `cache hit`,
+which bounds the index, not the code: that only a docs-only commit sits
+between the two runs is true, but nothing cited here supports it, and neither
+report records the `RAG_TOP_K_FINAL` value each run actually used, so the
+degraded configuration is asserted, not captured -- exactly the gap the
+evidence ledger (design doc section 4) and acceptance criterion 7 exist to
+close. These are local, gitignored artifacts (`tests/eval/runs/`)
 same as the noise-floor pair -- nobody cloning the repo can reproduce this
 check from them directly. `compare_runs.py` over the pair: 2 flipped to PASS,
 7 flipped to FAIL, 42 unchanged, pass rate delta -0.0980. All seven flips to
@@ -214,14 +219,26 @@ FAIL are retrieval-only cases (`att-arch-figure`, `att-arch-figure-es`,
 `planck-sigma8-es` and `resnet-top1-34layer`. By metric: retrieval-only fell
 from 11/15 (0.7333) to 4/15 (0.2667); answer rose from 33/36 (0.9167) to 35/36
 (0.9722). The degraded run also failed the baseline floor (0.7647 < 0.77),
-which is the gate behaving correctly under a known degradation.
+which is the gate behaving correctly under a known degradation -- but by a
+margin of 0.0053, against 0.0196 for a single case: at 40/51 = 0.7843
+(retrieval-only at 5/15 instead of 4/15, still just as collapsed) the gate
+would have passed the same catastrophic degradation. The aggregate fell 0.098
+while retrieval fell 0.47; this is the sharpest evidence for the point the
+consequence paragraph below already makes: an aggregate that barely notices a
+retrieval collapse this severe is precisely what makes a loop maximising it
+dangerous.
 
 This result is only interpretable because the noise floor measured above is
 zero flips -- seven flips against a floor of zero is unambiguous signal.
 Retrieval and answering moved in opposite directions: retrieval collapsed
-while answering improved slightly. A plausible reading is that less context
-distracts less on narrow factual questions, but that is a hypothesis, not a
-finding -- nothing here tested it. One degraded configuration was tested
+with 7 flips -- above the roughly six net flips the criterion-1 note cites
+(set in design doc section 3) as the bar for a difference to be demonstrable
+-- while answering improved slightly with only 2 net flips: above the
+zero-flip noise floor but below that same bar, so this measurement does not
+demonstrate the answer-side gain is real. A plausible reading is that less
+context distracts less on narrow factual questions, but that is a
+hypothesis, not a finding -- nothing here tested it. One degraded
+configuration was tested
 (`RAG_TOP_K_FINAL=1`), not a sweep; the design also lists disabling the
 reranker as a separate sabotage, still unmeasured. This uses the
 retrieval/answer split `run_eval.py` already reports, but it measures
@@ -235,4 +252,7 @@ that aggregate could favor configurations that trade retrieval quality for
 factual-answering accuracy without anyone noticing -- the aggregate alone does
 not distinguish a genuine improvement from that trade. Separated metrics are
 what make the trade visible; the design's objective function currently
-targets the aggregate, not the split.
+targets the aggregate, not the split. Five of the seven flips to FAIL are
+figure-retrieval cases, and design doc section 3 ("Margen inalcanzable")
+already places part of those cases outside the scalar the loop maximises --
+which makes the warning stronger, not weaker.

--- a/tests/eval/README.md
+++ b/tests/eval/README.md
@@ -198,3 +198,41 @@ python tests/eval/compare_runs.py tests/eval/runs/<healthy>.json tests/eval/runs
 The degraded run must flip a clearly larger number of cases to FAIL than the
 noise floor. A gate that barely moves under a known degradation cannot detect
 an improvement either.
+
+**Measured 2026-07-29.** Healthy run
+`tests/eval/runs/20260729T020233Z_mineru-jina_clip-faiss.json` (44/51 =
+0.8627, the same run used for the noise-floor pair above) against degraded run
+`tests/eval/runs/20260729T081129Z_mineru-jina_clip-faiss.json`
+(`RAG_TOP_K_FINAL=1`, 39/51 = 0.7647, 121.1 min). Same code, same index (both
+logged `cache hit`). These are local, gitignored artifacts (`tests/eval/runs/`)
+same as the noise-floor pair -- nobody cloning the repo can reproduce this
+check from them directly. `compare_runs.py` over the pair: 2 flipped to PASS,
+7 flipped to FAIL, 42 unchanged, pass rate delta -0.0980. All seven flips to
+FAIL are retrieval-only cases (`att-arch-figure`, `att-arch-figure-es`,
+`att-bleu-table`, `dpo-pipeline-figure`, `resnet-block-figure`,
+`vit-comparison-table`, `vit-overview-figure`); the two flips to PASS are
+`planck-sigma8-es` and `resnet-top1-34layer`. By metric: retrieval-only fell
+from 11/15 (0.7333) to 4/15 (0.2667); answer rose from 33/36 (0.9167) to 35/36
+(0.9722). The degraded run also failed the baseline floor (0.7647 < 0.77),
+which is the gate behaving correctly under a known degradation.
+
+This result is only interpretable because the noise floor measured above is
+zero flips -- seven flips against a floor of zero is unambiguous signal.
+Retrieval and answering moved in opposite directions: retrieval collapsed
+while answering improved slightly. A plausible reading is that less context
+distracts less on narrow factual questions, but that is a hypothesis, not a
+finding -- nothing here tested it. One degraded configuration was tested
+(`RAG_TOP_K_FINAL=1`), not a sweep; the design also lists disabling the
+reranker as a separate sabotage, still unmeasured. This uses the
+retrieval/answer split `run_eval.py` already reports, but it measures
+sensitivity only -- it does not by itself close acceptance criterion 4
+(separated metrics).
+
+Consequence for the optimisation loop:
+`docs/design/2026-07-28-loop-automejorable.md` section 1 defines the
+objective function as a single aggregate pass rate. A loop maximising only
+that aggregate could favor configurations that trade retrieval quality for
+factual-answering accuracy without anyone noticing -- the aggregate alone does
+not distinguish a genuine improvement from that trade. Separated metrics are
+what make the trade visible; the design's objective function currently
+targets the aggregate, not the split.


### PR DESCRIPTION
## Summary
- Re-derives the sensitivity comparison with `compare_runs.py` on the existing runs `tests/eval/runs/20260729T020233Z_mineru-jina_clip-faiss.json` (healthy) and `tests/eval/runs/20260729T081129Z_mineru-jina_clip-faiss.json` (degraded, `RAG_TOP_K_FINAL=1`): 2 flipped to PASS, 7 flipped to FAIL, 42 unchanged, pass rate delta -0.0980.
- Marks acceptance criterion 2 (sensitivity) as measured in `docs/design/2026-07-28-loop-automejorable.md`, with the same dependency on the criterion-1 zero-flip noise floor made explicit, and the retrieval-vs-answer divergence flagged as a hypothesis, not a finding.
- Appends the observed number to `tests/eval/README.md`'s sensitivity section, below the existing how-to instructions (which are unchanged).
- Notes the consequence for the loop's objective function (single aggregate pass rate can mask a retrieval-for-answer trade).
- Qualifies two magnitude claims per review: the answer-side gain (+2 net flips) sits below the ~6-flip demonstrability threshold the doc itself cites, and the gate's pass/fail margin on the degraded run was 0.0053 (a quarter of one case) against a 0.0196 per-case unit, not decisive evidence of sensitivity on its own.

Documentation only. No code, test, or config file touched.

## Test plan
- [x] Re-derived `compare_runs.py tests/eval/runs/20260729T020233Z_mineru-jina_clip-faiss.json tests/eval/runs/20260729T081129Z_mineru-jina_clip-faiss.json` directly and confirmed the numbers.
- [x] `C:/Users/nadiv/anaconda3/python.exe -m ruff check .` passes.
- [x] `docs/design/2026-07-28-loop-automejorable.md` has 0 em dash characters (`—`), before and after.
- [x] `tests/eval/README.md` em dash count unchanged at 10.