### PR TITLE
Fix Jina CLIP worker thread-safety (concurrent requests kill the worker)

### DIFF
--- a/src/monkeygrab/adapters/embedding/jina_clip_embedder.py
+++ b/src/monkeygrab/adapters/embedding/jina_clip_embedder.py
@@ -114,6 +114,17 @@ class JinaClipEmbedder:
         self._stderr_tail: List[str] = []
         self._next_id = itertools.count(1)
         self._dead_reason: Optional[str] = None
+        # Serialises the whole request path (worker startup + stdin write +
+        # matching response pop), not just the write: two overlapping callers
+        # racing through _ensure_worker/_start_worker could each spawn or
+        # consume a worker, and even with one worker, an unserialised writer
+        # could pop the OTHER caller's response off _responses -- the id
+        # check then reports "protocol desynchronized" and _fail_dead kills
+        # the worker, so a concurrency bug shows up as a permanent outage.
+        # Plain Lock, not RLock: nothing inside the critical section
+        # (including _fail_dead) re-enters it, and a stray re-entrant
+        # acquire here should deadlock loudly rather than mask a bug.
+        self._lock = threading.Lock()
 
     # lifecycle
 
@@ -224,18 +235,24 @@ class JinaClipEmbedder:
         raise RuntimeError(reason)
 
     def close(self) -> None:
-        """Terminate the worker process, if one is running. Safe to call more than once."""
-        process, self._process = self._process, None
-        if process is None or process.poll() is not None:
-            return
-        try:
-            process.stdin.close()
-        except Exception:
-            pass
-        try:
-            process.wait(timeout=5)
-        except subprocess.TimeoutExpired:
-            process.kill()
+        """Terminate the worker process, if one is running. Safe to call more than once.
+
+        Takes the same lock as ``_request`` so a concurrent close() waits for
+        an in-flight request to finish instead of closing stdin underneath
+        an in-progress write.
+        """
+        with self._lock:
+            process, self._process = self._process, None
+            if process is None or process.poll() is not None:
+                return
+            try:
+                process.stdin.close()
+            except Exception:
+                pass
+            try:
+                process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                process.kill()
 
     def __del__(self):
         # Best-effort only: an orphaned GPU process is worse than a slightly
@@ -248,45 +265,53 @@ class JinaClipEmbedder:
     # request/response
 
     def _request(self, op: str, payload: Dict[str, str]) -> List[float]:
-        self._ensure_worker()
-        request_id = next(self._next_id)
-        message = {"id": request_id, "op": op, **payload}
+        # Held across worker startup, the stdin write and the matching
+        # response pop: this is the whole round-trip that must not
+        # interleave with another caller's (see _lock's comment in __init__).
+        # `with` releases on any exit path, including _fail_dead raising
+        # partway through, so a failed request never leaves the lock held.
+        with self._lock:
+            self._ensure_worker()
+            request_id = next(self._next_id)
+            message = {"id": request_id, "op": op, **payload}
 
-        try:
-            self._process.stdin.write(json.dumps(message) + "\n")
-            self._process.stdin.flush()
-        except (BrokenPipeError, OSError) as exc:
-            self._fail_dead(f"jina-clip worker's stdin pipe is broken: {exc}")
+            try:
+                self._process.stdin.write(json.dumps(message) + "\n")
+                self._process.stdin.flush()
+            except (BrokenPipeError, OSError) as exc:
+                self._fail_dead(f"jina-clip worker's stdin pipe is broken: {exc}")
 
-        response = self._await_message(self._request_timeout_s, phase=f"handling op={op!r}")
-
-        if "event" in response:
-            # A startup-shaped message ("fatal", or a non-JSON line the reader
-            # thread couldn't parse) arriving mid-request is a protocol
-            # violation, not a normal id-keyed response -- report it as such
-            # instead of falling through to a confusing id-mismatch error.
-            self._fail_dead(
-                f"jina-clip worker protocol violation while handling op={op!r}: "
-                f"{response.get('error', response)}"
-            )
-        if response.get("id") != request_id:
-            self._fail_dead(
-                f"jina-clip worker response id {response.get('id')!r} does not match "
-                f"request id {request_id!r} -- protocol desynchronized"
-            )
-        if not response.get("ok"):
-            raise RuntimeError(
-                f"jina-clip worker reported an error for op={op!r}: {response.get('error')}"
+            response = self._await_message(
+                self._request_timeout_s, phase=f"handling op={op!r}"
             )
 
-        vector = response.get("vector")
-        if not isinstance(vector, list) or len(vector) != _TRUNCATE_DIM:
-            got = len(vector) if isinstance(vector, list) else type(vector).__name__
-            raise RuntimeError(
-                f"jina-clip worker returned a vector of unexpected shape for op={op!r}: "
-                f"expected {_TRUNCATE_DIM} floats, got {got}"
-            )
-        return vector
+            if "event" in response:
+                # A startup-shaped message ("fatal", or a non-JSON line the reader
+                # thread couldn't parse) arriving mid-request is a protocol
+                # violation, not a normal id-keyed response -- report it as such
+                # instead of falling through to a confusing id-mismatch error.
+                self._fail_dead(
+                    f"jina-clip worker protocol violation while handling op={op!r}: "
+                    f"{response.get('error', response)}"
+                )
+            if response.get("id") != request_id:
+                self._fail_dead(
+                    f"jina-clip worker response id {response.get('id')!r} does not match "
+                    f"request id {request_id!r} -- protocol desynchronized"
+                )
+            if not response.get("ok"):
+                raise RuntimeError(
+                    f"jina-clip worker reported an error for op={op!r}: {response.get('error')}"
+                )
+
+            vector = response.get("vector")
+            if not isinstance(vector, list) or len(vector) != _TRUNCATE_DIM:
+                got = len(vector) if isinstance(vector, list) else type(vector).__name__
+                raise RuntimeError(
+                    f"jina-clip worker returned a vector of unexpected shape for op={op!r}: "
+                    f"expected {_TRUNCATE_DIM} floats, got {got}"
+                )
+            return vector
 
     # ADAPTER
 
@@ -344,6 +369,13 @@ class JinaClipEmbedder:
         if not os.path.isfile(image_path):
             raise RuntimeError(f"jina-clip: image file not found: {image_path!r}")
 
+        # These two _request calls are each individually locked but not
+        # atomic AS A PAIR -- another caller's request can run between them.
+        # That's fine: every request carries its own id and is matched to
+        # its own response before _request returns, so an interleaved
+        # request from another thread can never hand this call the wrong
+        # vector. The only effect of interleaving is ordering on the wire,
+        # not correctness.
         image_vector = _l2_normalize(self._request("image", {"path": image_path}))
 
         caption = caption.strip()

--- a/tests/unit/adapters/test_jina_clip_embedder.py
+++ b/tests/unit/adapters/test_jina_clip_embedder.py
@@ -10,6 +10,7 @@ timeout code path the real worker talks to, just without a real pipe.
 import json
 import queue
 import sys
+import threading
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[3]
@@ -383,6 +384,84 @@ def test_l2_normalize_returns_a_unit_vector():
 def test_l2_normalize_rejects_a_zero_vector():
     with pytest.raises(RuntimeError, match="zero vector"):
         module._l2_normalize([0.0, 0.0, 0.0])
+
+
+def test_concurrent_embed_calls_each_get_their_own_vector_and_the_worker_survives(monkeypatch):
+    """Two overlapping embed() calls must not race on the shared response queue (issue #24).
+
+    Without a lock around the whole request round-trip (worker start, stdin
+    write, and the matching queue pop), a second caller's write can land
+    while a first caller's reply is still unclaimed; the shared queue does
+    not know whose reply is whose, so a caller can pop the OTHER caller's
+    message. The id check then reports "protocol desynchronized" and
+    _fail_dead kills the worker -- an availability bug, not a wrong-vector
+    one, but a real one: every later call fails until the process restarts.
+
+    This is made deterministic with events instead of sleeps: call-a's fake
+    reply handler waits (bounded) to see whether call-b's write ever lands
+    while call-a's own request is still open. Only an unsynchronized
+    caller can make that observable within the window; under the fix,
+    call-b is blocked on the lock before it ever reaches the write, so the
+    wait always times out and both calls simply succeed in isolation. If
+    call-b's write DOES land early, call-a's handler queues only call-a's
+    reply and lets call-b's write() return -- so call-b's very next step,
+    popping the queue, steals it. That is exactly how the real bug
+    manifests, reproduced without hoping two OS threads happen to collide.
+    """
+    a_write_seen = threading.Event()
+    b_write_seen = threading.Event()
+    b_may_return = threading.Event()
+    vector_a = _vector(0.11)
+    vector_b = _vector(0.22)
+
+    def behavior(process, request):
+        text = request.get("text")
+        if text == "call-a":
+            a_write_seen.set()
+            interleaved = b_write_seen.wait(timeout=0.3)
+            process.stdout.push(
+                json.dumps({"id": request["id"], "ok": True, "vector": vector_a}) + "\n"
+            )
+            if interleaved:
+                b_may_return.set()  # let call-b's write() return -- it will steal this reply
+        elif text == "call-b":
+            b_write_seen.set()
+            if b_may_return.wait(timeout=0.3):
+                return  # a's reply is already queued for us to steal; nothing to push
+            process.stdout.push(
+                json.dumps({"id": request["id"], "ok": True, "vector": vector_b}) + "\n"
+            )
+        else:
+            # The priming call below, or the final aliveness check -- plain echo.
+            process.stdout.push(
+                json.dumps({"id": request["id"], "ok": True, "vector": _vector()}) + "\n"
+            )
+
+    embedder, _ = _embedder(monkeypatch, behavior, request_timeout_s=2.0)
+    embedder.embed("prime the worker")  # start the worker before the race, out of band
+
+    results = {}
+    errors = {}
+
+    def run(label, text):
+        try:
+            results[label] = embedder.embed(text)
+        except Exception as exc:  # noqa: BLE001 -- captured for the assertion below
+            errors[label] = exc
+
+    t_a = threading.Thread(target=run, args=("a", "call-a"))
+    t_b = threading.Thread(target=run, args=("b", "call-b"))
+    t_a.start()
+    t_b.start()
+    t_a.join(timeout=5)
+    t_b.join(timeout=5)
+
+    assert not errors, f"concurrent embed() calls raised: {errors}"
+    assert results["a"] == vector_a
+    assert results["b"] == vector_b
+
+    assert embedder._dead_reason is None
+    assert embedder.embed("still alive") == _vector()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What breaks today

`rag/engine/wiring.py` caches one `JinaClipEmbedder` for the whole process, and the
Flask app serves requests concurrently. `JinaClipEmbedder._request` wrote a line to
the worker's stdin and popped a single message off a shared `queue.Queue`, with no
synchronisation. Two overlapping callers can interleave: one caller's write can land
while the other's reply is still unclaimed in the queue, which has no notion of whose
reply belongs to whom.

The per-request id check catches the resulting mismatch, so it never returns a wrong
embedding — but the consequence is `_fail_dead`, which kills the worker and marks it
permanently unusable by deliberate design (crash loops must stay visible, per the
class docstring). So this is an **availability** bug: one race turns every later
`/api` query in that process into a failure until restart, not a correctness bug.

## Why a lock, not a protocol redesign

The id-keyed protocol already guarantees a caller can never be handed *another*
caller's vector without detecting it — that's exactly why the failure mode is
"worker killed" rather than "silently wrong embedding." The actual defect is narrower:
nothing serialises the write-then-pop round trip (or worker startup, which also
mutates shared state), so two callers can race on the same queue. Serialising that
round trip with a lock removes the race entirely without touching the wire protocol.

`embed_image`'s two `_request` calls (image, then optional caption) are deliberately
left independently locked rather than atomic as a pair: each call's response is
matched against its own request id before it returns, so a third caller's request
interleaving between them cannot corrupt either vector — only wire-level ordering
fairness would change, not correctness.

## Change

- `src/monkeygrab/adapters/embedding/jina_clip_embedder.py`: added a `threading.Lock`
  covering `_ensure_worker`/`_start_worker` + the stdin write + the matching response
  pop in `_request`, and the same lock in `close()` (so a concurrent close can't tear
  down the process mid-write). Still imports nothing but the standard library.
- `tests/unit/adapters/test_jina_clip_embedder.py`: new
  `test_concurrent_embed_calls_each_get_their_own_vector_and_the_worker_survives`,
  doubling `subprocess.Popen` like the rest of the file. Uses `threading.Event`s (no
  sleeps) to deterministically give an unsynchronized caller's write a window to land
  while another caller's request is still open — confirmed to fail before the fix and
  pass after, by actually stashing the fix and running both ways.

## Verification

- `pytest -q`: 326 passed / 1 skipped on `main` before this change → 327 passed / 1
  skipped after (same 2 pre-existing FAISS/SWIG deprecation warnings).
- `ruff check .`: all checks passed.
- New test against the unfixed code (stashed): fails with a queue race between the
  two callers (times out or hits "protocol desynchronized" depending on which
  caller's read wins) — proving it isn't a test that passes either way.
- No `tests/characterization/` test touched or affected.

Fixes #24

## Test plan

- [x] `pytest -q` green
- [x] `ruff check .` green
- [x] New test fails on unfixed code, passes on fixed code (verified both ways)