### PR TITLE
Fix non-atomic FAISS incremental save (#35)

### DIFF
--- a/src/monkeygrab/adapters/vectorstore/faiss_store.py
+++ b/src/monkeygrab/adapters/vectorstore/faiss_store.py
@@ -110,7 +110,12 @@ def _load_or_init(store_dir: str) -> Tuple[Optional["faiss.Index"], List[_Row]]:
     valid empty store (``add`` has simply never been called yet) -- returns
     ``(None, [])``. Any other partial combination of the three files is
     corruption: a complete store is always all-three-or-none, because
-    ``_save`` only ever leaves the directory in one of those two states.
+    ``_save`` and ``_rewrite`` both stage every file to a temp path before
+    replacing any of the real ones, so an ordinary write failure never
+    leaves the directory in a partial state -- only a process crash between
+    two of the ``os.replace`` calls can, and that residual case is still
+    caught below, either here (a missing file) or by the count check
+    further down (``index.ntotal != len(rows)``).
     """
     index_path = os.path.join(store_dir, _INDEX_FILENAME)
     meta_path = os.path.join(store_dir, _META_FILENAME)
@@ -373,31 +378,39 @@ class FaissVectorStore:
                 os.remove(path)
 
     def _save(self) -> None:
-        """Persist the current state by staging both files, then replacing.
+        """Persist the current state by staging all three files, then replacing.
 
         The index has no incremental on-disk append, so each ``add`` rewrites
         it whole; the sidecar is now rewritten whole too (``_write_meta_file``
         over ``self._rows``, which already includes the row this ``add`` just
-        appended) instead of being opened in append mode. Both are written to
-        temp paths first -- ``index.faiss.tmp`` and ``meta.jsonl.tmp`` -- and
-        only then ``os.replace``d into place, index first then sidecar,
-        mirroring ``_rewrite``'s own ordering.
+        appended) instead of being opened in append mode, and the version
+        marker is written unconditionally rather than only when absent. All
+        three are written to temp paths first -- ``index.faiss.tmp``,
+        ``meta.jsonl.tmp``, ``version.txt.tmp`` -- and only then
+        ``os.replace``d into place, in the same order ``_rewrite`` already
+        uses: index, sidecar, version.
 
-        Staging both before touching either real file is what closes the
+        Staging all three before touching any real file is what closes the
         window #35 reported: previously the index was replaced immediately,
         then the sidecar was appended to in place, so a failed sidecar write
-        (e.g. a full disk) left a durably-replaced index.faiss with N+1
+        (e.g. a full disk) left an atomically-replaced index.faiss with N+1
         vectors next to a meta.jsonl still at N rows -- caught, but only by
-        refusing to ever load the store again. Now a write failure on either
-        temp file leaves both real files untouched, exactly as they were
-        before this ``add``: still consistent and reloadable, just missing
-        the chunk that failed to persist. The only remaining window is
-        between the two ``os.replace`` calls themselves; each is individually
-        atomic, so only a hard crash in that exact instant -- not an ordinary
-        write failure -- can still leave the counts mismatched. That is the
-        same residual risk ``_rewrite`` already carries, and it is still
-        caught loudly by the ``index.ntotal != len(rows)`` check on the next
-        load rather than silently accepted.
+        refusing to ever load the store again. Now a write failure on any of
+        the three temp files leaves every real file untouched, exactly as
+        they were before this ``add``: still consistent and reloadable, just
+        missing the chunk that failed to persist. The only remaining window
+        is between the three ``os.replace`` calls themselves; each is
+        individually atomic, so only a hard crash in one of those exact
+        instants -- not an ordinary write failure -- can still leave the
+        directory in a partial state. That is the same residual risk
+        ``_rewrite`` already carries, and it is still caught loudly on the
+        next load (missing-file or ``index.ntotal != len(rows)``) rather than
+        silently accepted.
+
+        Note "atomically replaced" is not "durably written": nothing in this
+        adapter calls ``fsync``, so a power loss (as opposed to a process
+        crash) can still surface a stale or zero-length file despite every
+        ``os.replace`` here being atomic at the filesystem level.
         """
         try:
             index_tmp = self._index_path + ".tmp"
@@ -406,12 +419,13 @@ class FaissVectorStore:
             meta_tmp = self._meta_path + ".tmp"
             _write_meta_file(meta_tmp, self._rows)
 
+            version_tmp = self._version_path + ".tmp"
+            with open(version_tmp, "w", encoding="utf-8") as f:
+                f.write(_FORMAT_VERSION)
+
             os.replace(index_tmp, self._index_path)
             os.replace(meta_tmp, self._meta_path)
-
-            if not os.path.exists(self._version_path):
-                with open(self._version_path, "w", encoding="utf-8") as f:
-                    f.write(_FORMAT_VERSION)
+            os.replace(version_tmp, self._version_path)
         except OSError as e:
             raise RuntimeError(f"failed to persist FAISS store at {self._dir!r}: {e}") from e
 

--- a/src/monkeygrab/adapters/vectorstore/faiss_store.py
+++ b/src/monkeygrab/adapters/vectorstore/faiss_store.py
@@ -74,6 +74,23 @@ def _metadata_from_dict(meta: Dict[str, Any]) -> ChunkMetadata:
     )
 
 
+def _write_meta_file(path: str, rows: List[_Row]) -> None:
+    """Write every row in ``rows`` to ``path`` as JSONL, one object per line.
+
+    Shared by ``_save`` and ``_rewrite``: both stage a full sidecar snapshot
+    to a temp path before any ``os.replace``, rather than mutating
+    ``meta.jsonl`` in place.
+    """
+    with open(path, "w", encoding="utf-8") as f:
+        for chunk_id, doc, metadata in rows:
+            f.write(json.dumps({
+                "id": chunk_id,
+                "doc": doc,
+                "metadata": _metadata_to_dict(metadata),
+            }))
+            f.write("\n")
+
+
 # DISK I/O
 
 
@@ -240,7 +257,7 @@ class FaissVectorStore:
         row: _Row = (chunk.id, chunk.text, chunk.metadata)
         self._rows.append(row)
         self._id_to_pos[chunk.id] = position
-        self._save(row)
+        self._save()
 
     def query(self, embedding: Sequence[float], n_results: int) -> List[Fragment]:
         if self._index is None or self._index.ntotal == 0:
@@ -355,26 +372,42 @@ class FaissVectorStore:
             if os.path.exists(path):
                 os.remove(path)
 
-    def _save(self, new_row: _Row) -> None:
-        """Persist the just-added row: rewrite the index, append to the sidecar.
+    def _save(self) -> None:
+        """Persist the current state by staging both files, then replacing.
 
         The index has no incremental on-disk append, so each ``add`` rewrites
-        it whole (written to a temp path, then ``os.replace``d in, so a failed
-        write never leaves a half-written ``index.faiss``); the JSONL sidecar
-        only ever grows, so it is opened in append mode. If the index write
-        fails, this raises before the sidecar is touched, leaving the
-        directory exactly as it was before this ``add`` -- still consistent
-        and reloadable, just missing the chunk that failed to persist.
+        it whole; the sidecar is now rewritten whole too (``_write_meta_file``
+        over ``self._rows``, which already includes the row this ``add`` just
+        appended) instead of being opened in append mode. Both are written to
+        temp paths first -- ``index.faiss.tmp`` and ``meta.jsonl.tmp`` -- and
+        only then ``os.replace``d into place, index first then sidecar,
+        mirroring ``_rewrite``'s own ordering.
+
+        Staging both before touching either real file is what closes the
+        window #35 reported: previously the index was replaced immediately,
+        then the sidecar was appended to in place, so a failed sidecar write
+        (e.g. a full disk) left a durably-replaced index.faiss with N+1
+        vectors next to a meta.jsonl still at N rows -- caught, but only by
+        refusing to ever load the store again. Now a write failure on either
+        temp file leaves both real files untouched, exactly as they were
+        before this ``add``: still consistent and reloadable, just missing
+        the chunk that failed to persist. The only remaining window is
+        between the two ``os.replace`` calls themselves; each is individually
+        atomic, so only a hard crash in that exact instant -- not an ordinary
+        write failure -- can still leave the counts mismatched. That is the
+        same residual risk ``_rewrite`` already carries, and it is still
+        caught loudly by the ``index.ntotal != len(rows)`` check on the next
+        load rather than silently accepted.
         """
         try:
-            tmp_path = self._index_path + ".tmp"
-            faiss.write_index(self._index, tmp_path)
-            os.replace(tmp_path, self._index_path)
+            index_tmp = self._index_path + ".tmp"
+            faiss.write_index(self._index, index_tmp)
 
-            with open(self._meta_path, "a", encoding="utf-8") as f:
-                chunk_id, doc, metadata = new_row
-                f.write(json.dumps({"id": chunk_id, "doc": doc, "metadata": _metadata_to_dict(metadata)}))
-                f.write("\n")
+            meta_tmp = self._meta_path + ".tmp"
+            _write_meta_file(meta_tmp, self._rows)
+
+            os.replace(index_tmp, self._index_path)
+            os.replace(meta_tmp, self._meta_path)
 
             if not os.path.exists(self._version_path):
                 with open(self._version_path, "w", encoding="utf-8") as f:
@@ -391,14 +424,7 @@ class FaissVectorStore:
             meta_tmp = self._meta_path + ".tmp"
             version_tmp = self._version_path + ".tmp"
             faiss.write_index(self._index, index_tmp)
-            with open(meta_tmp, "w", encoding="utf-8") as f:
-                for chunk_id, doc, metadata in self._rows:
-                    f.write(json.dumps({
-                        "id": chunk_id,
-                        "doc": doc,
-                        "metadata": _metadata_to_dict(metadata),
-                    }))
-                    f.write("\n")
+            _write_meta_file(meta_tmp, self._rows)
             with open(version_tmp, "w", encoding="utf-8") as f:
                 f.write(_FORMAT_VERSION)
             os.replace(index_tmp, self._index_path)

--- a/tests/unit/adapters/test_faiss_store.py
+++ b/tests/unit/adapters/test_faiss_store.py
@@ -6,6 +6,7 @@ a write failure that cannot be reliably reproduced with a real disk.
 """
 
 import math
+import os
 import sys
 from pathlib import Path
 
@@ -235,6 +236,46 @@ def test_add_hard_fails_when_persistence_write_fails(tmp_path, monkeypatch):
 
     with pytest.raises(RuntimeError, match="failed to persist"):
         store.add(_chunk("x.pdf", 0, 0), _unit([1.0, 0.0]))
+
+
+def test_reopening_after_sidecar_write_failure_loads_consistently(tmp_path, monkeypatch):
+    """Regression test for #35.
+
+    Injects an OSError into whatever write touches the meta.jsonl sidecar
+    during a second ``add`` -- while the FAISS index write itself succeeds --
+    and asserts the directory is still load-consistent afterwards. On the
+    pre-fix code, the index write lands on disk before the sidecar write is
+    even attempted, so this failure leaves index.faiss at N+1 vectors and
+    meta.jsonl at N rows; reopening then hits the store's own
+    ``index.ntotal != len(rows)`` check and hard-fails with "corrupted",
+    which is exactly the bug #35 reports.
+    """
+    import builtins
+
+    paths = _paths(tmp_path, "sidecarfail")
+    store = FaissVectorStore(paths)
+    store.add(_chunk("a.pdf", 0, 0), _unit([1.0, 0.0]))
+    assert store.count() == 1
+
+    real_open = builtins.open
+
+    def _flaky_open(file, mode="r", *args, **kwargs):
+        # Only the sidecar's own write path is faulted -- reads (e.g. of
+        # meta.jsonl on a later, successful reopen) must go through untouched.
+        if "meta.jsonl" in os.fspath(file) and "r" not in mode:
+            raise OSError("disk full")
+        return real_open(file, mode, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", _flaky_open)
+
+    with pytest.raises(RuntimeError, match="failed to persist"):
+        store.add(_chunk("b.pdf", 0, 0), _unit([0.0, 1.0]))
+
+    monkeypatch.setattr(builtins, "open", real_open)
+
+    reopened = FaissVectorStore(paths)
+    assert reopened.count() == 1
+    assert [f.id for f in reopened.get_page(None, 0)] == ["a.pdf_pag0_chunk0"]
 
 
 def test_delete_source_rebuilds_index_and_persists(tmp_path):

--- a/tests/unit/adapters/test_faiss_store.py
+++ b/tests/unit/adapters/test_faiss_store.py
@@ -249,6 +249,13 @@ def test_reopening_after_sidecar_write_failure_loads_consistently(tmp_path, monk
     meta.jsonl at N rows; reopening then hits the store's own
     ``index.ntotal != len(rows)`` check and hard-fails with "corrupted",
     which is exactly the bug #35 reports.
+
+    Also covers the recovery path this fix buys: rag/engine/indexing.py
+    catches per-PDF exceptions and keeps indexing on the *same* store
+    instance, so the chunk whose ``add`` raised is still sitting in
+    ``self._rows`` in memory. The next successful ``add`` rewrites both
+    real files from that full in-memory state, which must persist the
+    previously-failed chunk too -- not just the new one.
     """
     import builtins
 
@@ -276,6 +283,20 @@ def test_reopening_after_sidecar_write_failure_loads_consistently(tmp_path, monk
     reopened = FaissVectorStore(paths)
     assert reopened.count() == 1
     assert [f.id for f in reopened.get_page(None, 0)] == ["a.pdf_pag0_chunk0"]
+
+    # The failed b.pdf add still mutated the *same* store's in-memory state
+    # (self._rows/self._index), which is exactly what rag/engine/indexing.py
+    # relies on when it catches a per-PDF exception and keeps going. The next
+    # successful add must heal the on-disk gap, persisting b.pdf as well.
+    store.add(_chunk("c.pdf", 0, 0), _unit([0.5, 0.5]))
+
+    healed = FaissVectorStore(paths)
+    assert healed.count() == 3
+    assert {f.id for f in healed.get_page(None, 0)} == {
+        "a.pdf_pag0_chunk0",
+        "b.pdf_pag0_chunk0",
+        "c.pdf_pag0_chunk0",
+    }
 
 
 def test_delete_source_rebuilds_index_and_persists(tmp_path):


### PR DESCRIPTION
## Summary
- `FaissVectorStore._save` used to replace `index.faiss` durably before appending to `meta.jsonl`. A failed append (e.g. full disk) left the index at N+1 vectors against a sidecar still at N rows -- caught by the store's own `index.ntotal != len(rows)` load-time check, but the whole index was then unusable and had to be rebuilt from scratch.
- Fix: both `index.faiss` and `meta.jsonl` are now written to `.tmp` paths first (the sidecar is now rewritten whole per `add`, via a new `_write_meta_file` helper shared with `_rewrite`, rather than appended in place -- no new complexity cost, since `write_index` already rewrites the whole index every `add`), and only once both writes succeed are the real files replaced, index first then sidecar, mirroring `_rewrite`'s existing replace order.
- A write failure on either temp file now leaves both real files exactly as they were before the `add`: still consistent and reloadable, just missing the chunk that didn't persist. The only remaining window is between the two `os.replace` calls themselves (each individually atomic), matching the residual risk `_rewrite` already documents and accepts.
- Updated `_save`'s docstring, which previously only documented the opposite (and non-existent) failure ordering.

## Test plan
- [x] New regression test `test_reopening_after_sidecar_write_failure_loads_consistently` added first; confirmed it fails against pre-fix code with `RuntimeError: ... is corrupted (index has 2 vectors but meta.jsonl has 1 rows)`.
- [x] Same test passes against the fix; full `tests/unit/adapters/test_faiss_store.py` + `test_faiss_store_fingerprint.py` (23 tests) pass.
- [x] Full suite: `328 passed, 1 skipped` (baseline was 327 passed, 1 skipped -- the +1 is the new regression test; no other deviation).
- [x] `ruff check .` clean.

Closes #35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)