### PR TITLE
Fix check-then-set race in wiring.py's module-level caches

### DIFF
--- a/rag/engine/wiring.py
+++ b/rag/engine/wiring.py
@@ -12,6 +12,7 @@ not cheap is cached here instead: the Cross-Encoder weights and the tokenized
 BM25 corpus would otherwise be rebuilt on every question.
 """
 
+import threading
 from typing import Any, Dict
 
 from monkeygrab.adapters.chat.ollama_chat import OllamaChatModel
@@ -68,25 +69,45 @@ def app_config_from_runtime() -> AppConfig:
 
 
 _store_cache: Dict[str, Any] = {"key": None, "store": None}
+_store_cache_lock = threading.Lock()
 _embedder_cache: Dict[str, Any] = {"embedder": None}
+_embedder_cache_lock = threading.Lock()
 
 
 def vector_store(config: AppConfig) -> VectorStore:
-    """Return the FAISS store for the active corpus."""
+    """Return the FAISS store for the active corpus.
+
+    Double-checked locking: two concurrent callers racing a corpus switch
+    must not both open the same FAISS index, so the key check is repeated
+    once the lock is held. The cheap, unlocked check outside the lock keeps
+    the common case (cache already valid) lock-free.
+    """
     key = (config.paths.path_db, config.paths.collection_name)
     if _store_cache["key"] != key:
-        _store_cache.update(key=key, store=build_vector_store(config))
+        with _store_cache_lock:
+            if _store_cache["key"] != key:
+                _store_cache.update(key=key, store=build_vector_store(config))
     return _store_cache["store"]
 
 
 def reset_vector_store_cache() -> None:
-    _store_cache.update(key=None, store=None)
+    with _store_cache_lock:
+        _store_cache.update(key=None, store=None)
 
 
 def embedder(config: AppConfig):
-    """Return the reusable jina-clip-v2 worker."""
+    """Return the reusable jina-clip-v2 worker.
+
+    Double-checked locking: building this spins up a worker subprocess and
+    loads a full model onto the GPU (~29s), so two concurrent first callers
+    must not both build one -- the loser would be orphaned, since its own
+    stdout/stderr pump threads keep it alive with nothing left to close it
+    (see #46).
+    """
     if _embedder_cache["embedder"] is None:
-        _embedder_cache["embedder"] = build_embedder(config)
+        with _embedder_cache_lock:
+            if _embedder_cache["embedder"] is None:
+                _embedder_cache["embedder"] = build_embedder(config)
     return _embedder_cache["embedder"]
 
 
@@ -162,7 +183,9 @@ def query_decomposer(config: AppConfig) -> OllamaChatModel:
 # module level because the interfaces call the pipeline as free functions and
 # have nowhere else to keep them for the life of the process.
 _lexical_cache: Dict[str, Any] = {"key": None, "index": None}
+_lexical_cache_lock = threading.Lock()
 _reranker_cache: Dict[str, Any] = {"reranker": None}
+_reranker_cache_lock = threading.Lock()
 
 
 def lexical_index(store: VectorStore, config: AppConfig) -> Bm25LexicalIndex:
@@ -172,6 +195,9 @@ def lexical_index(store: VectorStore, config: AppConfig) -> Bm25LexicalIndex:
     cache exists one level up, so that swapping corpora or retuning the BM25
     parameters gets a fresh index while ordinary queries reuse the tokenized
     one.
+
+    Double-checked locking: the key is re-read once the lock is held so two
+    concurrent callers racing the same new key build only one index (#46).
 
     Args:
         collection: Collection whose chunks form the BM25 corpus.
@@ -185,9 +211,11 @@ def lexical_index(store: VectorStore, config: AppConfig) -> Bm25LexicalIndex:
     key = (id(store), config.retrieval.bm25_k1, config.retrieval.bm25_b)
 
     if _lexical_cache["key"] != key:
-        _lexical_cache.update(
-            key=key, index=Bm25LexicalIndex(store, config.retrieval)
-        )
+        with _lexical_cache_lock:
+            if _lexical_cache["key"] != key:
+                _lexical_cache.update(
+                    key=key, index=Bm25LexicalIndex(store, config.retrieval)
+                )
     return _lexical_cache["index"]
 
 
@@ -198,6 +226,10 @@ def reranker(config: AppConfig) -> CrossEncoderReranker:
     weights each time. The fixed BGE adapter loads lazily, so holding one costs
     nothing until something is actually reranked.
 
+    Double-checked locking: two concurrent first callers must not both load
+    the weights -- that's hundreds of megabytes loaded twice on a shared GPU
+    (#46).
+
     Args:
         config: Current pipeline configuration.
 
@@ -206,7 +238,9 @@ def reranker(config: AppConfig) -> CrossEncoderReranker:
     """
     del config
     if _reranker_cache["reranker"] is None:
-        _reranker_cache["reranker"] = CrossEncoderReranker()
+        with _reranker_cache_lock:
+            if _reranker_cache["reranker"] is None:
+                _reranker_cache["reranker"] = CrossEncoderReranker()
     return _reranker_cache["reranker"]
 
 

--- a/rag/engine/wiring.py
+++ b/rag/engine/wiring.py
@@ -98,11 +98,11 @@ def reset_vector_store_cache() -> None:
 def embedder(config: AppConfig):
     """Return the reusable jina-clip-v2 worker.
 
-    Double-checked locking: building this spins up a worker subprocess and
-    loads a full model onto the GPU (~29s), so two concurrent first callers
-    must not both build one -- the loser would be orphaned, since its own
-    stdout/stderr pump threads keep it alive with nothing left to close it
-    (see #46).
+    Double-checked locking: two concurrent first callers must not both
+    construct one, since each duplicate later starts its own worker
+    subprocess and loads jina-clip on first use (~29s), and the losing
+    instance is unreachable yet pinned alive by its own stdout/stderr pump
+    threads once its worker has started, so nothing ever closes it (#46).
     """
     if _embedder_cache["embedder"] is None:
         with _embedder_cache_lock:
@@ -226,9 +226,10 @@ def reranker(config: AppConfig) -> CrossEncoderReranker:
     weights each time. The fixed BGE adapter loads lazily, so holding one costs
     nothing until something is actually reranked.
 
-    Double-checked locking: two concurrent first callers must not both load
-    the weights -- that's hundreds of megabytes loaded twice on a shared GPU
-    (#46).
+    Double-checked locking: two concurrent first callers must not both
+    construct one, since each duplicate would separately load hundreds of
+    megabytes of weights on first ``rerank()`` call, competing for the same
+    GPU (#46).
 
     Args:
         config: Current pipeline configuration.

--- a/tests/unit/test_wiring_cache_concurrency.py
+++ b/tests/unit/test_wiring_cache_concurrency.py
@@ -1,0 +1,148 @@
+"""Regression tests for the module-level caches in rag/engine/wiring.py (#46).
+
+Each of ``embedder``/``vector_store``/``lexical_index``/``reranker`` used an
+unguarded check-then-set: read the cache slot, and if empty, build. Two
+threads racing the first call can both see the slot empty and both construct
+the expensive object -- for the embedder and reranker specifically, that
+means a second worker subprocess or a second copy of model weights competing
+for the same 8GB card, with the loser orphaned (see the issue for why
+``__del__`` never runs).
+
+Each test below forces exactly that race deterministically: the constructor
+double blocks the first caller inside the "build" step on a
+``threading.Event``, gives a second caller time to attempt entry, then
+releases. Against the pre-fix check-then-set, both threads observe an empty
+slot and both call the constructor (2 builds). Against double-checked
+locking, the second thread blocks on the lock and, once let through,
+observes the slot already populated (1 build).
+"""
+
+import sys
+import threading
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import pytest
+
+import rag.chat_pdfs  # noqa: F401 -- import before rag.engine.wiring, see its module docstring
+from monkeygrab.config.app_config import AppConfig
+from rag.engine import wiring
+
+
+class BlockingBuilder:
+    """Constructor double that counts calls and blocks until released.
+
+    Simulates the slow, VRAM-hungry construction (JinaClipEmbedder,
+    CrossEncoderReranker, ...) that makes the race in #46 costly: the
+    ``threading.Event.wait()`` releases the GIL, so a second thread gets a
+    real chance to run concurrently while the first is still "building".
+    """
+
+    def __init__(self):
+        self.calls = 0
+        self._count_lock = threading.Lock()
+        self.release_event = threading.Event()
+
+    def __call__(self, *args, **kwargs):
+        with self._count_lock:
+            self.calls += 1
+        self.release_event.wait(timeout=5)
+        return object()
+
+
+def _race_two_callers(target, args, builder):
+    """Call ``target(*args)`` from two threads, racing a first-build window.
+
+    ``builder`` is the ``BlockingBuilder`` the caller already patched into
+    ``wiring`` in place of the real constructor. Returns the results each
+    thread got back; ``builder.calls`` tells the caller how many times the
+    underlying constructor actually ran.
+    """
+    results = [None, None]
+
+    def call(i):
+        results[i] = target(*args)
+
+    t1 = threading.Thread(target=call, args=(0,))
+    t2 = threading.Thread(target=call, args=(1,))
+
+    t1.start()
+    deadline = time.time() + 5
+    while builder.calls < 1 and time.time() < deadline:
+        time.sleep(0.001)
+    assert builder.calls == 1, "first thread never entered the constructor"
+
+    t2.start()
+    # Give t2 a real chance to reach the constructor too (buggy code) or to
+    # start blocking on the lock (fixed code) before we let t1 finish.
+    time.sleep(0.05)
+
+    builder.release_event.set()
+    t1.join(timeout=5)
+    t2.join(timeout=5)
+    assert not t1.is_alive() and not t2.is_alive(), "a caller thread hung"
+
+    return results
+
+
+@pytest.fixture(autouse=True)
+def _reset_wiring_caches():
+    """Isolate each test from cache state left by others in the same process."""
+    wiring._embedder_cache.update(embedder=None)
+    wiring._store_cache.update(key=None, store=None)
+    wiring._lexical_cache.update(key=None, index=None)
+    wiring._reranker_cache.update(reranker=None)
+    yield
+    wiring._embedder_cache.update(embedder=None)
+    wiring._store_cache.update(key=None, store=None)
+    wiring._lexical_cache.update(key=None, index=None)
+    wiring._reranker_cache.update(reranker=None)
+
+
+def test_concurrent_first_calls_build_embedder_exactly_once(monkeypatch):
+    builder = BlockingBuilder()
+    monkeypatch.setattr(wiring, "build_embedder", builder)
+
+    config = AppConfig()
+    results = _race_two_callers(wiring.embedder, (config,), builder)
+
+    assert builder.calls == 1
+    assert results[0] is results[1]
+
+
+def test_concurrent_first_calls_build_vector_store_exactly_once(monkeypatch):
+    builder = BlockingBuilder()
+    monkeypatch.setattr(wiring, "build_vector_store", builder)
+
+    config = AppConfig()
+    results = _race_two_callers(wiring.vector_store, (config,), builder)
+
+    assert builder.calls == 1
+    assert results[0] is results[1]
+
+
+def test_concurrent_first_calls_build_lexical_index_exactly_once(monkeypatch):
+    builder = BlockingBuilder()
+    monkeypatch.setattr(wiring, "Bm25LexicalIndex", builder)
+
+    config = AppConfig()
+    store = object()  # cache key uses id(store); a real VectorStore is not needed
+    results = _race_two_callers(wiring.lexical_index, (store, config), builder)
+
+    assert builder.calls == 1
+    assert results[0] is results[1]
+
+
+def test_concurrent_first_calls_build_reranker_exactly_once(monkeypatch):
+    builder = BlockingBuilder()
+    monkeypatch.setattr(wiring, "CrossEncoderReranker", builder)
+
+    config = AppConfig()
+    results = _race_two_callers(wiring.reranker, (config,), builder)
+
+    assert builder.calls == 1
+    assert results[0] is results[1]


### PR DESCRIPTION
## Summary
- `rag/engine/wiring.py` cached `_embedder_cache`, `_store_cache`, `_lexical_cache` and `_reranker_cache` with an unguarded check-then-set: two concurrent first callers could both see the slot empty and both build.
- Worst case is the embedder: each miss spins up a worker subprocess and loads jina-clip onto the GPU (~29s, a full model's worth of VRAM on an 8GB card also wanted by the reranker and Ollama). The losing instance is orphaned forever, since its stdout/stderr pump threads keep `self` alive for the worker's lifetime, so `__del__` never runs and nothing ever closes it. The reranker has the same cost profile (hundreds of megabytes of weights loaded twice).
- Fix: each cache gets its own `threading.Lock` with double-checked locking — the cheap unlocked read stays the fast path once populated, and the key/slot check repeats once the lock is held so a second racing caller observes the winner's result instead of building again.
- Locks are per-cache (not global), so an embedder build and a reranker build still proceed independently.
- Invalidation semantics are unchanged: the cache key is still recomputed from the live config on every call, so a runtime flag or model change still takes effect on the next query (per `.claude/CLAUDE.md` §2) — a new key just wins the rebuild race the same way it did before, only now serialized.

## Test plan
- [x] Added `tests/unit/test_wiring_cache_concurrency.py`: for each of the four caches, two threads race a monkeypatched constructor double that blocks on a `threading.Event` until both have had a chance to enter, then asserts exactly one construction happened and both callers got the same instance.
- [x] Confirmed all 4 tests FAIL against the pre-fix code (2 constructions each) before applying the fix.
- [x] All 4 tests PASS after the fix.
- [x] Full suite: `pytest -q -p no:randomly` → 331 passed, 1 skipped (327 baseline + 4 new tests, same 1 skip).
- [x] `ruff check .` → all checks passed.

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)