### PR TITLE
Extract evaluate() library API from run_eval.py's main() (#31)

### DIFF
--- a/tests/eval/run_eval.py
+++ b/tests/eval/run_eval.py
@@ -823,6 +823,173 @@ def _update_baseline(pass_rate: float) -> None:
 
 # LIBRARY API
 
+# The dotted AppConfig keys evaluate()'s threaded config_overrides carries end
+# to end via _eval_app_config -> Retrieve / Answer.select_evidence /
+# IndexCorpus, all built from the SAME config object ensure_indexed produces.
+# Being a real AppConfig field is not sufficient on its own to belong here --
+# e.g. retrieval.min_question_length is a real field nothing in
+# src/monkeygrab reads; see _UNREACHABLE_CONFIG_OVERRIDE_REASONS. Two fields
+# are conditional: models.contextual and chunking.contextual_doc_chars only
+# take effect when flags.usar_contextual_retrieval is also overridden True
+# (ensure_indexed forces it False otherwise).
+_APPCONFIG_OVERRIDE_KEYS = frozenset({
+    "models.contextual",
+    "chunking.chunk_size",
+    "chunking.chunk_overlap",
+    "chunking.min_chunk_length",
+    "chunking.contextual_doc_chars",
+    "retrieval.n_semantic_results",
+    "retrieval.n_keyword_results",
+    "retrieval.top_k_rerank_candidates",
+    "retrieval.top_k_final",
+    "retrieval.n_top_for_expansion",
+    "retrieval.rrf_k",
+    "retrieval.bm25_k1",
+    "retrieval.bm25_b",
+    "retrieval.weight_semantic_rrf",
+    "retrieval.weight_bm25_rrf",
+    "reranking.score_threshold",
+    "context.max_context_chars",
+    "flags.usar_contextual_retrieval",
+    "flags.usar_embeddings_imagen",
+    "flags.usar_busqueda_hibrida",
+    "flags.usar_reranker",
+    "flags.expandir_contexto",
+})
+
+# Generation-side flags reachable only by scoping rag.chat_pdfs's runtime
+# globals for the duration of case execution (_generation_config_overrides):
+# generar_respuesta_silenciosa builds its own AppConfig per call via
+# wiring.app_config_from_runtime(), which reads these two flags straight from
+# rag.chat_pdfs -- the threaded config _eval_app_config builds never reaches
+# that call (see evaluate()'s docstring). Values are the exact
+# PIPELINE_RUNTIME_FLAGS name set_pipeline_flags expects. This is the
+# sanctioned use of repo rule 6 (don't flip pipeline flags without agreement):
+# scoped to one evaluate() call and restored on exit, per the owner's
+# authorization of block C (docs/design/2026-07-28-loop-automejorable.md
+# section 6.1) -- not a change to the product's own defaults.
+_GENERATION_FLAG_OVERRIDE_KEYS = {
+    "flags.usar_recomp_synthesis": "USAR_RECOMP_SYNTHESIS",
+    "flags.usar_optimizacion_contexto": "USAR_OPTIMIZACION_CONTEXTO",
+}
+
+# Known AppConfig fields evaluate() cannot honour end to end, with why -- so
+# the error _validate_config_overrides raises names the field instead of
+# leaving a caller to guess. A field missing from this dict still raises (via
+# the generic fallback message in _validate_config_overrides), just without a
+# specific reason -- this map is for a better message, not the source of
+# truth for what is rejected.
+_UNREACHABLE_CONFIG_OVERRIDE_REASONS = {
+    "models.rag": (
+        "generation uses the `models` parameter's per-case role switch; the "
+        "Answer object built from the threaded config is never invoked"
+    ),
+    "models.chat": "ensure_indexed hardcodes query_decomposer=None, so this role is never read",
+    "models.recomp": (
+        "reachable via the same runtime-setter mechanism as "
+        "flags.usar_recomp_synthesis, but not wired -- out of scope for this pass"
+    ),
+    "models.desc": "derived automatically from models.rag; nothing evaluate() runs reads it",
+    "models.ollama.rag_num_ctx": (
+        "AppConfig.with_overrides supports one level of section.field nesting; "
+        "models.ollama.* would need replacing the whole models.ollama object"
+    ),
+    "models.ollama.query_num_ctx": "see models.ollama.rag_num_ctx",
+    "models.ollama.recomp_num_ctx": "see models.ollama.rag_num_ctx",
+    "models.ollama.contextual_num_ctx": "see models.ollama.rag_num_ctx",
+    "models.ollama.request_timeout": "see models.ollama.rag_num_ctx",
+    "models.ollama.keep_alive": (
+        "see models.ollama.rag_num_ctx; run_eval.py scopes its own keep-alive "
+        "separately (_generation_keep_alive), unrelated to config_overrides"
+    ),
+    "models.ollama.generate_retries": "see models.ollama.rag_num_ctx",
+    "models.ollama.generate_retry_delay": "see models.ollama.rag_num_ctx",
+    "retrieval.min_question_length": "not read anywhere in src/monkeygrab -- Retrieve.run() has no question-length gate",
+    "flags.usar_llm_query_decomposition": (
+        "ensure_indexed hardcodes query_decomposer=None, so this flag can "
+        "never trigger decomposition regardless of its value"
+    ),
+    "flags.logging_metricas": "generar_respuesta_silenciosa never calls the debug-dump path this flag gates",
+    "flags.guardar_debug_rag": "generar_respuesta_silenciosa skips the debug dump entirely",
+    "paths.base_dir": "underlies every derived path; not something a candidate config should touch",
+    "paths.data_dir": "see paths.base_dir",
+    "paths.docs_folder": (
+        "_eval_app_config sets this to isolate the eval's FAISS collection "
+        "from the product's live store (see EVAL_DEV_LABEL); overriding it "
+        "risks reading or writing the wrong store"
+    ),
+    "paths.path_db": "see paths.docs_folder",
+    "paths.collection_name": "see paths.docs_folder",
+    "paths.historial_path": "CLI /chat history; unrelated to anything evaluate() runs",
+    "paths.max_historial_mensajes": "see paths.historial_path",
+    "paths.carpeta_debug_rag": "generar_respuesta_silenciosa skips the debug dump entirely",
+}
+
+
+def _validate_config_overrides(config_overrides: Optional[Mapping[str, Any]]) -> None:
+    """Raise on any config_overrides key evaluate() cannot honour end to end.
+
+    Silently accepting a key outside evaluate()'s reachable surface would let
+    a run change nothing while still reporting a pass rate -- the "measuring
+    instrument that lies" failure docs/design/2026-07-28-loop-automejorable.md
+    section 2 warns a search loop cannot recover from. See
+    _APPCONFIG_OVERRIDE_KEYS / _GENERATION_FLAG_OVERRIDE_KEYS for what IS
+    honoured, and by which route.
+
+    Args:
+        config_overrides: evaluate()'s config_overrides argument.
+
+    Raises:
+        ValueError: One or more keys are outside the honoured set, naming
+            each and, when known, why.
+    """
+    if not config_overrides:
+        return
+    honored = _APPCONFIG_OVERRIDE_KEYS | set(_GENERATION_FLAG_OVERRIDE_KEYS)
+    unreachable = {
+        key: _UNREACHABLE_CONFIG_OVERRIDE_REASONS.get(key, "not part of evaluate()'s honoured override surface")
+        for key in config_overrides
+        if key not in honored
+    }
+    if unreachable:
+        detail = "; ".join(f"{key!r}: {reason}" for key, reason in sorted(unreachable.items()))
+        raise ValueError(
+            f"config_overrides has {len(unreachable)} key(s) evaluate() cannot honour end to end: {detail}"
+        )
+
+
+@contextlib.contextmanager
+def _generation_config_overrides(rag, config_overrides: Optional[Mapping[str, Any]]):
+    """Scope _GENERATION_FLAG_OVERRIDE_KEYS onto rag.chat_pdfs's live globals.
+
+    generar_respuesta_silenciosa builds its own AppConfig per call via
+    wiring.app_config_from_runtime(), which reads these two flags straight
+    from rag.chat_pdfs -- the threaded config _eval_app_config builds never
+    reaches that call (see evaluate()'s docstring). Restoration runs in a
+    finally so a failed evaluation cannot leak an overridden flag into
+    whatever runs next in the same process.
+
+    Args:
+        rag: The imported rag.chat_pdfs module.
+        config_overrides: evaluate()'s config_overrides argument; only the
+            keys in _GENERATION_FLAG_OVERRIDE_KEYS are applied here -- the
+            rest were already validated (and rejected, if unreachable) by
+            _validate_config_overrides.
+    """
+    overrides = {
+        _GENERATION_FLAG_OVERRIDE_KEYS[key]: value
+        for key, value in (config_overrides or {}).items()
+        if key in _GENERATION_FLAG_OVERRIDE_KEYS
+    }
+    if not overrides:
+        yield
+        return
+    previous = rag.set_pipeline_flags(overrides)
+    try:
+        yield
+    finally:
+        rag.set_pipeline_flags({name: previous[name] for name in overrides})
+
 
 def evaluate(
     *,
@@ -849,18 +1016,19 @@ def evaluate(
             after loading, before any corpus is staged or indexed, so a
             subset that only touches one corpus (dev or blind) never forces
             the other one to be staged/indexed.
-        config_overrides: Dotted ``"section.field"`` overrides
-            (``AppConfig.with_overrides``) applied to the retrieval/indexing
-            ``AppConfig`` this run builds via ``_eval_app_config``.
-            Generation does not read this config: ``generar_respuesta_silenciosa``
-            builds its own ``AppConfig`` per call via
-            ``wiring.app_config_from_runtime()``, which reads model roles and
-            flags straight from ``rag.chat_pdfs``'s module globals and the
-            process environment (see ``_generation_keep_alive``'s
-            docstring). An override meant to change what the generator sees
-            has no effect through this parameter -- use
-            ``rag.set_model_roles_runtime`` / ``rag.set_pipeline_flags`` or
-            the matching env var instead.
+        config_overrides: Dotted ``"section.field"`` overrides. Only keys in
+            ``_APPCONFIG_OVERRIDE_KEYS`` (applied via ``AppConfig.with_overrides``
+            to the retrieval/indexing config ``_eval_app_config`` builds) or
+            ``_GENERATION_FLAG_OVERRIDE_KEYS`` (``flags.usar_recomp_synthesis``,
+            ``flags.usar_optimizacion_contexto`` -- scoped onto
+            ``rag.chat_pdfs``'s runtime globals for case execution via
+            ``_generation_config_overrides``, since
+            ``generar_respuesta_silenciosa`` builds its own ``AppConfig`` per
+            call via ``wiring.app_config_from_runtime()`` and never sees the
+            threaded one) are accepted; anything else raises ``ValueError``
+            naming the key rather than being silently ignored -- an override
+            with no observable effect would let a run report a pass rate for
+            a candidate it never actually measured.
         update_baseline: Raise ``baseline_min_pass_rate.txt`` to this run's
             pass rate minus ``BASELINE_MARGIN``, same as ``--update-baseline``
             -- only when the run is conclusive (no infrastructure errors);
@@ -886,7 +1054,8 @@ def evaluate(
         EvalSetupError: A prerequisite (Ollama, a required model, an index)
             is missing. Raised before any case runs, same as the CLI.
         ValueError: ``case_ids`` names an id that is not in
-            ``gold_cases.jsonl``.
+            ``gold_cases.jsonl``, or ``config_overrides`` names a key
+            evaluate() cannot honour end to end.
     """
     run_started = time.perf_counter()
 
@@ -897,6 +1066,7 @@ def evaluate(
         unknown = wanted - {c["id"] for c in cases}
         if unknown:
             raise ValueError(f"unknown gold case id(s): {sorted(unknown)}")
+    _validate_config_overrides(config_overrides)
 
     required_models = set(models) | {AUX_MODEL}
     stack_slug = "mineru-jina_clip-faiss"
@@ -956,9 +1126,10 @@ def evaluate(
             f"up to {len(models)} model(s)\n",
             flush=True,
         )
-        records = run_all_cases(
-            rag, cases, retrieve_dev, retrieve_blind, evidence_dev, evidence_blind, models
-        )
+        with _generation_config_overrides(rag, config_overrides):
+            records = run_all_cases(
+                rag, cases, retrieve_dev, retrieve_blind, evidence_dev, evidence_blind, models
+            )
     finally:
         for stack in stacks_to_close:
             closer = getattr(stack.embedder, "close", None)

--- a/tests/eval/run_eval.py
+++ b/tests/eval/run_eval.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import argparse
 import contextlib
+import dataclasses
 import json
 import math
 import os
@@ -39,7 +40,7 @@ import sys
 import time
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional, Sequence
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence
 
 # CONSTANTS
 
@@ -250,6 +251,7 @@ def ensure_indexed(
     required_pdfs: Iterable[str],
     label: str,
     path_label: Optional[Path] = None,
+    config_overrides: Optional[Mapping[str, Any]] = None,
 ):
     """Index missing PDFs into the multimodal stack; return its use cases.
 
@@ -260,10 +262,14 @@ def ensure_indexed(
         label: Short name for log lines ("dev set", "blind set").
         path_label: Forwarded to _eval_app_config to isolate the FAISS
             collection from carpeta's own basename (see EVAL_DEV_LABEL).
+        config_overrides: Forwarded to _eval_app_config -- lets evaluate()
+            reshape the retrieval/indexing AppConfig for this corpus without
+            mutating rag's module globals.
 
     Returns:
-        ``(Retrieve, Stack)`` for this corpus. Caller should ``close()`` the
-        stack embedder when finished if it exposes that method.
+        ``(Retrieve, Answer, Stack)`` for this corpus. Caller should
+        ``close()`` the stack embedder when finished if it exposes that
+        method.
 
     Raises:
         EvalSetupError: A required PDF is still missing after indexing.
@@ -281,7 +287,9 @@ def ensure_indexed(
     required = set(required_pdfs)
     rag.set_docs_folder_runtime(str(carpeta))
     try:
-        config = _eval_app_config(rag, carpeta, path_label=path_label)
+        config = _eval_app_config(
+            rag, carpeta, path_label=path_label, config_overrides=config_overrides
+        )
         stack = build_stack(config)
         store = stack.vector_store
         expected_fingerprint = compute_index_fingerprint(config)
@@ -417,7 +425,12 @@ def _fragment_to_dict(fragment) -> Dict[str, Any]:
     return fragment_to_dict(fragment)
 
 
-def _eval_app_config(rag, carpeta: Path, path_label: Optional[Path] = None):
+def _eval_app_config(
+    rag,
+    carpeta: Path,
+    path_label: Optional[Path] = None,
+    config_overrides: Optional[Mapping[str, Any]] = None,
+):
     """Build the fixed multimodal evaluation configuration.
 
     Args:
@@ -427,6 +440,11 @@ def _eval_app_config(rag, carpeta: Path, path_label: Optional[Path] = None):
             name from this path's basename instead of carpeta's, without
             changing which folder is actually indexed. See EVAL_DEV_LABEL for
             why the dev set needs this and the blind set does not.
+        config_overrides: Dotted ``"section.field"`` overrides applied last,
+            on top of every override above -- lets a caller (evaluate())
+            reshape the retrieval/indexing config without touching rag's
+            module globals. Does not reach generation's own config; see
+            evaluate()'s docstring for why that path is separate.
     """
     from monkeygrab.config.app_config import AppConfig
     from monkeygrab.config.paths import derive_db_paths
@@ -454,6 +472,8 @@ def _eval_app_config(rag, carpeta: Path, path_label: Optional[Path] = None):
         config = config.with_overrides(
             **{"paths.path_db": path_db, "paths.collection_name": collection_name}
         )
+    if config_overrides:
+        config = config.with_overrides(**config_overrides)
     return config
 
 
@@ -801,6 +821,227 @@ def _update_baseline(pass_rate: float) -> None:
     print(f"[baseline] {verb} to {candidate:.2f} (observed {pass_rate:.4f} minus {BASELINE_MARGIN:.2f} margin)")
 
 
+# LIBRARY API
+
+
+def evaluate(
+    *,
+    models: Sequence[str],
+    case_ids: Optional[Sequence[str]] = None,
+    config_overrides: Optional[Mapping[str, Any]] = None,
+    update_baseline: bool = False,
+    write_report: bool = True,
+) -> Dict[str, Any]:
+    """Run the gate and return its record instead of only printing it.
+
+    This is main()'s own implementation, factored out so a caller other than
+    the CLI -- e.g. the search harness a self-improving loop drives (see
+    docs/design/2026-07-28-loop-automejorable.md section 6.1) -- can run an
+    evaluation in-process and get a return value back, instead of parsing
+    stdout or a report file off disk. ``main()`` is a thin wrapper around
+    this function: the CLI's own behavior (stdout, report file, exit code,
+    baseline semantics) is unchanged by this refactor.
+
+    Args:
+        models: Ollama generator models to evaluate.
+        case_ids: ``gold_cases.jsonl`` ``"id"`` values to run. ``None`` runs
+            every case (the CLI's behavior). Filtering happens immediately
+            after loading, before any corpus is staged or indexed, so a
+            subset that only touches one corpus (dev or blind) never forces
+            the other one to be staged/indexed.
+        config_overrides: Dotted ``"section.field"`` overrides
+            (``AppConfig.with_overrides``) applied to the retrieval/indexing
+            ``AppConfig`` this run builds via ``_eval_app_config``.
+            Generation does not read this config: ``generar_respuesta_silenciosa``
+            builds its own ``AppConfig`` per call via
+            ``wiring.app_config_from_runtime()``, which reads model roles and
+            flags straight from ``rag.chat_pdfs``'s module globals and the
+            process environment (see ``_generation_keep_alive``'s
+            docstring). An override meant to change what the generator sees
+            has no effect through this parameter -- use
+            ``rag.set_model_roles_runtime`` / ``rag.set_pipeline_flags`` or
+            the matching env var instead.
+        update_baseline: Raise ``baseline_min_pass_rate.txt`` to this run's
+            pass rate minus ``BASELINE_MARGIN``, same as ``--update-baseline``
+            -- only when the run is conclusive (no infrastructure errors);
+            an inconclusive run leaves the baseline untouched regardless of
+            this flag, exactly like the CLI.
+        write_report: Write the timestamped JSON report under
+            ``tests/eval/runs/``. ``False`` writes nothing to disk, so a
+            caller can decide where its own evidence lives.
+
+    Returns:
+        A dict with ``summary`` (``build_summary()``'s blocks), ``records``
+        (every per-case result dict), ``models``, ``aux_model``,
+        ``num_cases``, ``num_records``, ``elapsed_seconds``, ``pass_rate``,
+        ``baseline`` (the threshold this run was compared against, or
+        ``None``), ``infrastructure_errors``, ``baseline_updated``,
+        ``exit_code`` (what the CLI would have returned), ``report_path``
+        (``str`` or ``None``), and ``config`` -- ``{"dev": ..., "blind":
+        ...}``, each the effective ``AppConfig`` as a plain dict
+        (``dataclasses.asdict``), or ``None`` if that corpus was never
+        staged/indexed for this run.
+
+    Raises:
+        EvalSetupError: A prerequisite (Ollama, a required model, an index)
+            is missing. Raised before any case runs, same as the CLI.
+        ValueError: ``case_ids`` names an id that is not in
+            ``gold_cases.jsonl``.
+    """
+    run_started = time.perf_counter()
+
+    cases = load_gold_cases()
+    if case_ids is not None:
+        wanted = set(case_ids)
+        cases = [c for c in cases if c["id"] in wanted]
+        unknown = wanted - {c["id"] for c in cases}
+        if unknown:
+            raise ValueError(f"unknown gold case id(s): {sorted(unknown)}")
+
+    required_models = set(models) | {AUX_MODEL}
+    stack_slug = "mineru-jina_clip-faiss"
+
+    stacks_to_close = []
+    config_effective: Dict[str, Any] = {"dev": None, "blind": None}
+    try:
+        preflight_ollama(required_models)
+
+        # Heavy import (FAISS, sentence-transformers, rank-bm25...) only
+        # after the cheap network/model preflight has already passed.
+        import rag.chat_pdfs as rag
+
+        rag.set_model_roles_runtime({
+            "chat": AUX_MODEL, "contextual": AUX_MODEL, "recomp": AUX_MODEL,
+        })
+
+        blind_required = stage_blind_papers(cases)
+        dev_required = set(_required_pdfs(cases, "corpus"))
+
+        retrieve_dev = evidence_dev = stack_dev = None
+        retrieve_blind = evidence_blind = stack_blind = None
+
+        # Dev indexing is skipped, not just left idle, when a case_ids subset
+        # references no "corpus"-source case -- unlike the blind set, it was
+        # unconditional before case_ids existed, since the unfiltered run
+        # (main()'s only caller) always has at least one such case.
+        if dev_required:
+            retrieve_dev, evidence_dev, stack_dev = ensure_indexed(
+                rag, DEV_DOCS_DIR, dev_required, "dev set",
+                path_label=EVAL_DEV_LABEL, config_overrides=config_overrides,
+            )
+            stacks_to_close.append(stack_dev)
+            config_effective["dev"] = dataclasses.asdict(
+                _eval_app_config(
+                    rag, DEV_DOCS_DIR, path_label=EVAL_DEV_LABEL, config_overrides=config_overrides
+                )
+            )
+        if blind_required:
+            retrieve_blind, evidence_blind, stack_blind = ensure_indexed(
+                rag, BLIND_DOCS_DIR, set(blind_required), "blind set",
+                config_overrides=config_overrides,
+            )
+            stacks_to_close.append(stack_blind)
+            config_effective["blind"] = dataclasses.asdict(
+                _eval_app_config(rag, BLIND_DOCS_DIR, config_overrides=config_overrides)
+            )
+
+        verify_all_papers_indexed(
+            cases,
+            _sources_in_store(stack_dev.vector_store) if stack_dev else set(),
+            _sources_in_store(stack_blind.vector_store) if stack_blind else set(),
+        )
+
+        print(
+            f"\n[run] stack={stack_slug} {len(cases)} cases x "
+            f"up to {len(models)} model(s)\n",
+            flush=True,
+        )
+        records = run_all_cases(
+            rag, cases, retrieve_dev, retrieve_blind, evidence_dev, evidence_blind, models
+        )
+    finally:
+        for stack in stacks_to_close:
+            closer = getattr(stack.embedder, "close", None)
+            if callable(closer):
+                try:
+                    closer()
+                except Exception:
+                    pass
+
+    summary = build_summary(records)
+    elapsed_total = time.perf_counter() - run_started
+
+    report_path: Optional[Path] = None
+    if write_report:
+        RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        report_path = RESULTS_DIR / f"{timestamp}_{stack_slug}.json"
+        report_path.write_text(json.dumps({
+            "run": {
+                "timestamp": timestamp,
+                "stack": stack_slug,
+                "models": list(models),
+                "aux_model": AUX_MODEL,
+                "num_cases": len(cases),
+                "num_records": len(records),
+                "elapsed_seconds": round(elapsed_total, 1),
+                "retrieval_path": "monkeygrab.application.retrieve.Retrieve",
+            },
+            "summary": summary,
+            "results": records,
+        }, indent=2, ensure_ascii=False), encoding="utf-8")
+
+    print_summary(summary)
+    if report_path is not None:
+        print(f"\nfull results: {report_path}")
+    print(f"total elapsed: {elapsed_total / 60:.1f} min")
+
+    pass_rate = summary["overall"]["pass_rate"]
+    threshold = _read_baseline()
+    broken = [r for r in records if r.get("infrastructure_error")]
+    baseline_updated = False
+
+    if broken:
+        print(f"\n[gate] INCONCLUSIVE: {len(broken)} case(s) could not be evaluated")
+        for record in broken[:5]:
+            print(f"        {record['id']}: {record['reason']}")
+        if len(broken) > 5:
+            print(f"        ... and {len(broken) - 5} more")
+        print("        Not compared against the baseline: this run measured nothing.")
+        exit_code = 1
+    else:
+        if threshold is None:
+            print("\n[gate] no baseline yet (tests/eval/baseline_min_pass_rate.txt missing) -- not gating this run")
+            exit_code = 0
+        elif pass_rate < threshold:
+            print(f"\n[gate] FAILED: pass_rate {pass_rate:.4f} < baseline {threshold:.2f}")
+            exit_code = 1
+        else:
+            print(f"\n[gate] PASSED: pass_rate {pass_rate:.4f} >= baseline {threshold:.2f}")
+            exit_code = 0
+
+        if update_baseline:
+            _update_baseline(pass_rate)
+            baseline_updated = True
+
+    return {
+        "summary": summary,
+        "records": records,
+        "models": list(models),
+        "aux_model": AUX_MODEL,
+        "num_cases": len(cases),
+        "num_records": len(records),
+        "elapsed_seconds": round(elapsed_total, 1),
+        "pass_rate": pass_rate,
+        "baseline": threshold,
+        "infrastructure_errors": broken,
+        "baseline_updated": baseline_updated,
+        "exit_code": exit_code,
+        "report_path": str(report_path) if report_path is not None else None,
+        "config": config_effective,
+    }
+
+
 # CLI
 
 
@@ -823,118 +1064,12 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
 
 def main(argv: Optional[List[str]] = None) -> int:
     args = parse_args(argv)
-    run_started = time.perf_counter()
-
-    cases = load_gold_cases()
-    required_models = set(args.models) | {AUX_MODEL}
-    stack_slug = "mineru-jina_clip-faiss"
-
-    stacks_to_close = []
     try:
-        preflight_ollama(required_models)
-
-        # Heavy import (FAISS, sentence-transformers, rank-bm25...) only
-        # after the cheap network/model preflight has already passed.
-        import rag.chat_pdfs as rag
-
-        rag.set_model_roles_runtime({
-            "chat": AUX_MODEL, "contextual": AUX_MODEL, "recomp": AUX_MODEL,
-        })
-
-        blind_required = stage_blind_papers(cases)
-        dev_required = set(_required_pdfs(cases, "corpus"))
-
-        retrieve_dev, evidence_dev, stack_dev = ensure_indexed(
-            rag, DEV_DOCS_DIR, dev_required, "dev set", path_label=EVAL_DEV_LABEL
-        )
-        stacks_to_close.append(stack_dev)
-        retrieve_blind = None
-        evidence_blind = None
-        stack_blind = None
-        if blind_required:
-            retrieve_blind, evidence_blind, stack_blind = ensure_indexed(
-                rag, BLIND_DOCS_DIR, set(blind_required), "blind set"
-            )
-            stacks_to_close.append(stack_blind)
-
-        verify_all_papers_indexed(
-            cases,
-            _sources_in_store(stack_dev.vector_store),
-            _sources_in_store(stack_blind.vector_store) if stack_blind else set(),
-        )
-
-        print(
-            f"\n[run] stack={stack_slug} {len(cases)} cases x "
-            f"up to {len(args.models)} model(s)\n",
-            flush=True,
-        )
-        records = run_all_cases(
-            rag, cases, retrieve_dev, retrieve_blind, evidence_dev, evidence_blind, args.models
-        )
+        result = evaluate(models=args.models, update_baseline=args.update_baseline)
     except EvalSetupError as exc:
         print(f"\nSETUP FAILED: {exc}", file=sys.stderr)
         return 1
-    finally:
-        for stack in stacks_to_close:
-            closer = getattr(stack.embedder, "close", None)
-            if callable(closer):
-                try:
-                    closer()
-                except Exception:
-                    pass
-
-    summary = build_summary(records)
-    elapsed_total = time.perf_counter() - run_started
-
-    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
-    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
-    out_path = RESULTS_DIR / f"{timestamp}_{stack_slug}.json"
-    out_path.write_text(json.dumps({
-        "run": {
-            "timestamp": timestamp,
-            "stack": stack_slug,
-            "models": args.models,
-            "aux_model": AUX_MODEL,
-            "num_cases": len(cases),
-            "num_records": len(records),
-            "elapsed_seconds": round(elapsed_total, 1),
-            "retrieval_path": "monkeygrab.application.retrieve.Retrieve",
-        },
-        "summary": summary,
-        "results": records,
-    }, indent=2, ensure_ascii=False), encoding="utf-8")
-
-    print_summary(summary)
-    print(f"\nfull results: {out_path}")
-    print(f"total elapsed: {elapsed_total / 60:.1f} min")
-
-    pass_rate = summary["overall"]["pass_rate"]
-    threshold = _read_baseline()
-
-    broken = [r for r in records if r.get("infrastructure_error")]
-    if broken:
-        print(f"\n[gate] INCONCLUSIVE: {len(broken)} case(s) could not be evaluated")
-        for record in broken[:5]:
-            print(f"        {record['id']}: {record['reason']}")
-        if len(broken) > 5:
-            print(f"        ... and {len(broken) - 5} more")
-        print("        Not compared against the baseline: this run measured nothing.")
-        return 1
-
-    if threshold is None:
-        print("\n[gate] no baseline yet (tests/eval/baseline_min_pass_rate.txt missing) -- not gating this run")
-        gate_exit = 0
-    elif pass_rate < threshold:
-        print(f"\n[gate] FAILED: pass_rate {pass_rate:.4f} < baseline {threshold:.2f}")
-        gate_exit = 1
-    else:
-        print(f"\n[gate] PASSED: pass_rate {pass_rate:.4f} >= baseline {threshold:.2f}")
-        gate_exit = 0
-
-    if args.update_baseline:
-        _update_baseline(pass_rate)
-
-    return gate_exit
+    return result["exit_code"]
 
 
 if __name__ == "__main__":

--- a/tests/eval/run_eval.py
+++ b/tests/eval/run_eval.py
@@ -874,9 +874,9 @@ _GENERATION_FLAG_OVERRIDE_KEYS = {
 }
 
 # Known AppConfig fields evaluate() cannot honour end to end, with why -- so
-# the error _validate_config_overrides raises names the field instead of
+# the error validate_config_overrides raises names the field instead of
 # leaving a caller to guess. A field missing from this dict still raises (via
-# the generic fallback message in _validate_config_overrides), just without a
+# the generic fallback message in validate_config_overrides), just without a
 # specific reason -- this map is for a better message, not the source of
 # truth for what is rejected.
 _UNREACHABLE_CONFIG_OVERRIDE_REASONS = {
@@ -884,7 +884,10 @@ _UNREACHABLE_CONFIG_OVERRIDE_REASONS = {
         "generation uses the `models` parameter's per-case role switch; the "
         "Answer object built from the threaded config is never invoked"
     ),
-    "models.chat": "ensure_indexed hardcodes query_decomposer=None, so this role is never read",
+    "models.chat": (
+        "ensure_indexed hardcodes query_decomposer=None, so this role is "
+        "never read (see #64)"
+    ),
     "models.recomp": (
         "reachable via the same runtime-setter mechanism as "
         "flags.usar_recomp_synthesis, but not wired -- out of scope for this pass"
@@ -907,7 +910,7 @@ _UNREACHABLE_CONFIG_OVERRIDE_REASONS = {
     "retrieval.min_question_length": "not read anywhere in src/monkeygrab -- Retrieve.run() has no question-length gate",
     "flags.usar_llm_query_decomposition": (
         "ensure_indexed hardcodes query_decomposer=None, so this flag can "
-        "never trigger decomposition regardless of its value"
+        "never trigger decomposition regardless of its value (see #64)"
     ),
     "flags.logging_metricas": "generar_respuesta_silenciosa never calls the debug-dump path this flag gates",
     "flags.guardar_debug_rag": "generar_respuesta_silenciosa skips the debug dump entirely",
@@ -926,18 +929,24 @@ _UNREACHABLE_CONFIG_OVERRIDE_REASONS = {
 }
 
 
-def _validate_config_overrides(config_overrides: Optional[Mapping[str, Any]]) -> None:
+def validate_config_overrides(config_overrides: Optional[Mapping[str, Any]]) -> None:
     """Raise on any config_overrides key evaluate() cannot honour end to end.
+
+    Public so a caller (the block-C search harness) can validate its
+    declared search space against evaluate()'s actual reachable surface
+    without importing this module's private key sets -- evaluate() calls
+    this same function internally, so there is exactly one place this
+    contract is enforced.
 
     Silently accepting a key outside evaluate()'s reachable surface would let
     a run change nothing while still reporting a pass rate -- the "measuring
     instrument that lies" failure docs/design/2026-07-28-loop-automejorable.md
     section 2 warns a search loop cannot recover from. See
-    _APPCONFIG_OVERRIDE_KEYS / _GENERATION_FLAG_OVERRIDE_KEYS for what IS
-    honoured, and by which route.
+    describe_config_overrides() for the full map of what IS honoured, and by
+    which route.
 
     Args:
-        config_overrides: evaluate()'s config_overrides argument.
+        config_overrides: A candidate evaluate() config_overrides argument.
 
     Raises:
         ValueError: One or more keys are outside the honoured set, naming
@@ -958,6 +967,31 @@ def _validate_config_overrides(config_overrides: Optional[Mapping[str, Any]]) ->
         )
 
 
+def describe_config_overrides() -> Dict[str, Any]:
+    """Public map of evaluate()'s config_overrides surface, for a harness's
+    own startup reachability check against its declared search space.
+
+    Returns:
+        A dict with:
+            "honoured": ``{dotted_key: route}``, route one of
+                ``"appconfig"`` (threaded through _eval_app_config -- reaches
+                retrieval/indexing) or ``"runtime_setter"`` (scoped onto
+                rag.chat_pdfs's globals for case execution -- reaches
+                generation).
+            "unreachable": ``{dotted_key: reason}`` for every known field
+                validate_config_overrides rejects. A key present in AppConfig
+                but absent from both dicts here is a gap in this map, not a
+                third category -- see the equivalence test that pins the two
+                dicts against dataclasses.fields(AppConfig) recursively.
+    """
+    honored = {key: "appconfig" for key in _APPCONFIG_OVERRIDE_KEYS}
+    honored.update({key: "runtime_setter" for key in _GENERATION_FLAG_OVERRIDE_KEYS})
+    return {
+        "honoured": honored,
+        "unreachable": dict(_UNREACHABLE_CONFIG_OVERRIDE_REASONS),
+    }
+
+
 @contextlib.contextmanager
 def _generation_config_overrides(rag, config_overrides: Optional[Mapping[str, Any]]):
     """Scope _GENERATION_FLAG_OVERRIDE_KEYS onto rag.chat_pdfs's live globals.
@@ -974,7 +1008,7 @@ def _generation_config_overrides(rag, config_overrides: Optional[Mapping[str, An
         config_overrides: evaluate()'s config_overrides argument; only the
             keys in _GENERATION_FLAG_OVERRIDE_KEYS are applied here -- the
             rest were already validated (and rejected, if unreachable) by
-            _validate_config_overrides.
+            validate_config_overrides.
     """
     overrides = {
         _GENERATION_FLAG_OVERRIDE_KEYS[key]: value
@@ -989,6 +1023,31 @@ def _generation_config_overrides(rag, config_overrides: Optional[Mapping[str, An
         yield
     finally:
         rag.set_pipeline_flags({name: previous[name] for name in overrides})
+
+
+@contextlib.contextmanager
+def _scoped_model_roles(rag, overrides: Dict[str, str]):
+    """Apply model-role overrides to rag.chat_pdfs's globals for the
+    duration of the block, restoring the previous roles in a finally.
+
+    evaluate() sets the aux roles ("chat"/"contextual"/"recomp") once up
+    front, and run_factual_case (inside run_all_cases, called within this
+    block) reassigns "rag" per case/model on top of that -- both mutate the
+    same rag.chat_pdfs globals _generation_config_overrides already protects
+    for its two flags, and neither role change was being undone: a second
+    in-process evaluate() call inherited whichever roles the previous one
+    left behind.
+
+    Args:
+        rag: The imported rag.chat_pdfs module.
+        overrides: Passed straight to set_model_roles_runtime.
+    """
+    previous = rag.get_model_roles()
+    rag.set_model_roles_runtime(overrides)
+    try:
+        yield
+    finally:
+        rag.set_model_roles_runtime(previous)
 
 
 def evaluate(
@@ -1008,6 +1067,11 @@ def evaluate(
     stdout or a report file off disk. ``main()`` is a thin wrapper around
     this function: the CLI's own behavior (stdout, report file, exit code,
     baseline semantics) is unchanged by this refactor.
+
+    Not re-entrant and not thread-safe: it mutates rag.chat_pdfs's model-role
+    and pipeline-flag globals for its duration (restored on exit, including
+    on an exception) -- two overlapping calls in the same process corrupt
+    each other's restore.
 
     Args:
         models: Ollama generator models to evaluate.
@@ -1046,9 +1110,16 @@ def evaluate(
         ``None``), ``infrastructure_errors``, ``baseline_updated``,
         ``exit_code`` (what the CLI would have returned), ``report_path``
         (``str`` or ``None``), and ``config`` -- ``{"dev": ..., "blind":
-        ...}``, each the effective ``AppConfig`` as a plain dict
-        (``dataclasses.asdict``), or ``None`` if that corpus was never
-        staged/indexed for this run.
+        ...}``, each the retrieval/indexing ``AppConfig`` ``_eval_app_config``
+        built, as a plain dict (``dataclasses.asdict``), or ``None`` if that
+        corpus was never staged/indexed for this run. This is NOT the
+        authoritative record of the generator: fields
+        describe_config_overrides()'s "unreachable" map lists (notably
+        ``config[...]["models"]["rag"]``) reflect rag.chat_pdfs's state at
+        the moment ``_eval_app_config`` ran, not what actually generated any
+        answer -- read ``result["models"]`` (the generators this run
+        evaluated) and ``records[*]["model"]`` (which one produced that
+        record) instead.
 
     Raises:
         EvalSetupError: A prerequisite (Ollama, a required model, an index)
@@ -1066,9 +1137,20 @@ def evaluate(
         unknown = wanted - {c["id"] for c in cases}
         if unknown:
             raise ValueError(f"unknown gold case id(s): {sorted(unknown)}")
-    _validate_config_overrides(config_overrides)
+    validate_config_overrides(config_overrides)
 
     required_models = set(models) | {AUX_MODEL}
+    # An overridden models.contextual is otherwise invisible to preflight:
+    # ensure_indexed builds an OllamaChatModel from it unconditionally once
+    # flags.usar_contextual_retrieval is on, and IndexCorpus swallows that
+    # call's failure (an unpulled model raises there) into an empty
+    # situational-context string instead of aborting -- then writes a
+    # fingerprint claiming the enrichment succeeded. Every later run on the
+    # same corpus gets a cache hit on an index labelled enriched that isn't.
+    if config_overrides and config_overrides.get("flags.usar_contextual_retrieval"):
+        contextual_override = config_overrides.get("models.contextual")
+        if contextual_override:
+            required_models.add(contextual_override)
     stack_slug = "mineru-jina_clip-faiss"
 
     stacks_to_close = []
@@ -1080,56 +1162,56 @@ def evaluate(
         # after the cheap network/model preflight has already passed.
         import rag.chat_pdfs as rag
 
-        rag.set_model_roles_runtime({
-            "chat": AUX_MODEL, "contextual": AUX_MODEL, "recomp": AUX_MODEL,
-        })
+        with _scoped_model_roles(
+            rag, {"chat": AUX_MODEL, "contextual": AUX_MODEL, "recomp": AUX_MODEL}
+        ):
+            blind_required = stage_blind_papers(cases)
+            dev_required = set(_required_pdfs(cases, "corpus"))
 
-        blind_required = stage_blind_papers(cases)
-        dev_required = set(_required_pdfs(cases, "corpus"))
+            retrieve_dev = evidence_dev = stack_dev = None
+            retrieve_blind = evidence_blind = stack_blind = None
 
-        retrieve_dev = evidence_dev = stack_dev = None
-        retrieve_blind = evidence_blind = stack_blind = None
-
-        # Dev indexing is skipped, not just left idle, when a case_ids subset
-        # references no "corpus"-source case -- unlike the blind set, it was
-        # unconditional before case_ids existed, since the unfiltered run
-        # (main()'s only caller) always has at least one such case.
-        if dev_required:
-            retrieve_dev, evidence_dev, stack_dev = ensure_indexed(
-                rag, DEV_DOCS_DIR, dev_required, "dev set",
-                path_label=EVAL_DEV_LABEL, config_overrides=config_overrides,
-            )
-            stacks_to_close.append(stack_dev)
-            config_effective["dev"] = dataclasses.asdict(
-                _eval_app_config(
-                    rag, DEV_DOCS_DIR, path_label=EVAL_DEV_LABEL, config_overrides=config_overrides
+            # Dev indexing is skipped, not just left idle, when a case_ids
+            # subset references no "corpus"-source case -- unlike the blind
+            # set, it was unconditional before case_ids existed, since the
+            # unfiltered run (main()'s only caller) always has at least one
+            # such case.
+            if dev_required:
+                retrieve_dev, evidence_dev, stack_dev = ensure_indexed(
+                    rag, DEV_DOCS_DIR, dev_required, "dev set",
+                    path_label=EVAL_DEV_LABEL, config_overrides=config_overrides,
                 )
-            )
-        if blind_required:
-            retrieve_blind, evidence_blind, stack_blind = ensure_indexed(
-                rag, BLIND_DOCS_DIR, set(blind_required), "blind set",
-                config_overrides=config_overrides,
-            )
-            stacks_to_close.append(stack_blind)
-            config_effective["blind"] = dataclasses.asdict(
-                _eval_app_config(rag, BLIND_DOCS_DIR, config_overrides=config_overrides)
+                stacks_to_close.append(stack_dev)
+                config_effective["dev"] = dataclasses.asdict(
+                    _eval_app_config(
+                        rag, DEV_DOCS_DIR, path_label=EVAL_DEV_LABEL, config_overrides=config_overrides
+                    )
+                )
+            if blind_required:
+                retrieve_blind, evidence_blind, stack_blind = ensure_indexed(
+                    rag, BLIND_DOCS_DIR, set(blind_required), "blind set",
+                    config_overrides=config_overrides,
+                )
+                stacks_to_close.append(stack_blind)
+                config_effective["blind"] = dataclasses.asdict(
+                    _eval_app_config(rag, BLIND_DOCS_DIR, config_overrides=config_overrides)
+                )
+
+            verify_all_papers_indexed(
+                cases,
+                _sources_in_store(stack_dev.vector_store) if stack_dev else set(),
+                _sources_in_store(stack_blind.vector_store) if stack_blind else set(),
             )
 
-        verify_all_papers_indexed(
-            cases,
-            _sources_in_store(stack_dev.vector_store) if stack_dev else set(),
-            _sources_in_store(stack_blind.vector_store) if stack_blind else set(),
-        )
-
-        print(
-            f"\n[run] stack={stack_slug} {len(cases)} cases x "
-            f"up to {len(models)} model(s)\n",
-            flush=True,
-        )
-        with _generation_config_overrides(rag, config_overrides):
-            records = run_all_cases(
-                rag, cases, retrieve_dev, retrieve_blind, evidence_dev, evidence_blind, models
+            print(
+                f"\n[run] stack={stack_slug} {len(cases)} cases x "
+                f"up to {len(models)} model(s)\n",
+                flush=True,
             )
+            with _generation_config_overrides(rag, config_overrides):
+                records = run_all_cases(
+                    rag, cases, retrieve_dev, retrieve_blind, evidence_dev, evidence_blind, models
+                )
     finally:
         for stack in stacks_to_close:
             closer = getattr(stack.embedder, "close", None)

--- a/tests/eval/test_evaluate_cli_wrapper.py
+++ b/tests/eval/test_evaluate_cli_wrapper.py
@@ -1,0 +1,66 @@
+"""Pins main() as a thin wrapper over evaluate() (issue #31).
+
+evaluate() itself needs the full engine to run a real evaluation (see
+test_evaluate_library_api.py), but main()'s own job -- parse argv, call
+evaluate() with the right arguments, translate its result into stdout/exit
+code -- does not. These tests patch evaluate() away entirely, so nothing
+here imports rag or monkeygrab.adapters and the file participates in the
+dependency-free fast CI gate (tests/conftest.py).
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import run_eval  # noqa: E402
+
+
+def test_main_forwards_parsed_models_and_update_baseline(monkeypatch):
+    captured = {}
+
+    def _fake_evaluate(**kwargs):
+        captured.update(kwargs)
+        return {"exit_code": 0}
+
+    monkeypatch.setattr(run_eval, "evaluate", _fake_evaluate)
+
+    run_eval.main(["--models", "modelA", "modelB", "--update-baseline"])
+
+    assert captured == {"models": ["modelA", "modelB"], "update_baseline": True}
+
+
+def test_main_default_args_route_through_evaluate(monkeypatch):
+    captured = {}
+
+    def _fake_evaluate(**kwargs):
+        captured.update(kwargs)
+        return {"exit_code": 0}
+
+    monkeypatch.setattr(run_eval, "evaluate", _fake_evaluate)
+
+    run_eval.main([])
+
+    assert captured == {"models": run_eval.DEFAULT_MODELS, "update_baseline": False}
+
+
+def test_main_returns_evaluates_exit_code(monkeypatch):
+    monkeypatch.setattr(run_eval, "evaluate", lambda **_kwargs: {"exit_code": 1})
+
+    assert run_eval.main([]) == 1
+
+    monkeypatch.setattr(run_eval, "evaluate", lambda **_kwargs: {"exit_code": 0})
+
+    assert run_eval.main([]) == 0
+
+
+def test_main_prints_setup_failed_and_returns_1_on_eval_setup_error(monkeypatch, capsys):
+    def _raise(**_kwargs):
+        raise run_eval.EvalSetupError("Ollama is not reachable")
+
+    monkeypatch.setattr(run_eval, "evaluate", _raise)
+
+    code = run_eval.main([])
+
+    assert code == 1
+    assert "SETUP FAILED: Ollama is not reachable" in capsys.readouterr().err

--- a/tests/eval/test_evaluate_library_api.py
+++ b/tests/eval/test_evaluate_library_api.py
@@ -75,15 +75,24 @@ def _capture_run_all_cases(monkeypatch, seen_cases):
 def _stub_pipeline(monkeypatch):
     """Fake Ollama preflight, blind-set staging and the post-index paper
     check, and neutralize the one call that mutates rag.chat_pdfs's real
-    module globals -- evaluate() calls set_model_roles_runtime
-    unconditionally, and leaving that mutation in place would leak into
-    whatever test runs next in the same process (e.g.
+    module globals unconditionally -- evaluate() always calls
+    set_model_roles_runtime, and leaving that mutation in place would leak
+    into whatever test runs next in the same process (e.g.
     tests/unit/test_app_config_defaults.py, which reads those same globals).
+
+    Pipeline flags (set_pipeline_flags) are NOT neutralized here -- several
+    tests below exercise _generation_config_overrides, which calls the real
+    set_pipeline_flags on purpose. Snapshotting and restoring them instead
+    means a bug in that restoration shows up as THIS test's own assertions
+    failing, not as unrelated flakiness two files later.
     """
     monkeypatch.setattr(run_eval, "preflight_ollama", lambda *_a, **_kw: None)
     monkeypatch.setattr(run_eval, "stage_blind_papers", lambda cases: {})
     monkeypatch.setattr(run_eval, "verify_all_papers_indexed", lambda *_a, **_kw: None)
     monkeypatch.setattr(rag.chat_pdfs, "set_model_roles_runtime", lambda *_a, **_kw: None)
+    previous_flags = rag.chat_pdfs.get_pipeline_flags()
+    yield
+    rag.chat_pdfs.set_pipeline_flags(previous_flags)
 
 
 def test_case_ids_runs_exactly_those_cases(monkeypatch):
@@ -226,3 +235,107 @@ def test_config_is_none_for_a_corpus_never_staged(monkeypatch):
 
     assert result["config"]["dev"] is not None
     assert result["config"]["blind"] is None
+
+
+def test_config_overrides_rejects_a_single_unreachable_key(monkeypatch):
+    ensure_calls = []
+    _capture_ensure_indexed(monkeypatch, ensure_calls)
+    seen = []
+    _capture_run_all_cases(monkeypatch, seen)
+
+    with pytest.raises(ValueError, match="models.rag"):
+        evaluate(
+            models=["m"], case_ids=[_DEV_CASE_ID],
+            config_overrides={"models.rag": "other-model"}, write_report=False,
+        )
+
+    # Fails before any staging/indexing/execution -- a caller-usage error,
+    # not a partial run.
+    assert ensure_calls == []
+    assert seen == []
+
+
+def test_config_overrides_rejects_every_unreachable_key_by_name(monkeypatch):
+    _capture_ensure_indexed(monkeypatch, [])
+    _capture_run_all_cases(monkeypatch, [])
+
+    with pytest.raises(ValueError) as excinfo:
+        evaluate(
+            models=["m"], case_ids=[_DEV_CASE_ID],
+            config_overrides={
+                "models.rag": "x",
+                "paths.docs_folder": "/tmp/y",
+                "models.ollama.keep_alive": 30,
+            },
+            write_report=False,
+        )
+
+    message = str(excinfo.value)
+    assert "models.rag" in message
+    assert "paths.docs_folder" in message
+    assert "models.ollama.keep_alive" in message
+
+
+def test_config_overrides_accepts_every_key_evaluate_claims_to_honour(monkeypatch):
+    """_APPCONFIG_OVERRIDE_KEYS / _GENERATION_FLAG_OVERRIDE_KEYS is the map
+    reported alongside this test; this pins that _validate_config_overrides
+    agrees with it (a key present in the map but rejected here would be a
+    silent regression the map itself would not catch)."""
+    _capture_ensure_indexed(monkeypatch, [])
+    _capture_run_all_cases(monkeypatch, [])
+    honored = run_eval._APPCONFIG_OVERRIDE_KEYS | set(run_eval._GENERATION_FLAG_OVERRIDE_KEYS)
+
+    run_eval._validate_config_overrides({key: None for key in honored})  # must not raise
+
+
+def test_generation_flag_override_reaches_rag_chat_pdfs_during_case_execution(monkeypatch):
+    """The AppConfig path is already covered by
+    test_config_overrides_reach_the_appconfig_and_ensure_indexed; this is the
+    runtime-setter path's equivalent proof, for the two flags
+    generar_respuesta_silenciosa can only see through rag.chat_pdfs's live
+    globals (see evaluate()'s docstring)."""
+    observed = {}
+
+    def _fake_run_all_cases(rag_module, cases, retrieve_dev, retrieve_blind, evidence_dev, evidence_blind, models):
+        observed["usar_recomp_synthesis"] = rag_module.USAR_RECOMP_SYNTHESIS
+        observed["usar_optimizacion_contexto"] = rag_module.USAR_OPTIMIZACION_CONTEXTO
+        return []
+
+    monkeypatch.setattr(run_eval, "run_all_cases", _fake_run_all_cases)
+    _capture_ensure_indexed(monkeypatch, [])
+    before = (rag.chat_pdfs.USAR_RECOMP_SYNTHESIS, rag.chat_pdfs.USAR_OPTIMIZACION_CONTEXTO)
+
+    evaluate(
+        models=["m"], case_ids=[_DEV_CASE_ID],
+        config_overrides={
+            "flags.usar_recomp_synthesis": not before[0],
+            "flags.usar_optimizacion_contexto": not before[1],
+        },
+        write_report=False,
+    )
+
+    assert observed == {
+        "usar_recomp_synthesis": not before[0],
+        "usar_optimizacion_contexto": not before[1],
+    }
+    # Restored once evaluate() returns.
+    assert (rag.chat_pdfs.USAR_RECOMP_SYNTHESIS, rag.chat_pdfs.USAR_OPTIMIZACION_CONTEXTO) == before
+
+
+def test_generation_flag_override_restores_on_exception_mid_evaluation(monkeypatch):
+    _capture_ensure_indexed(monkeypatch, [])
+    before = rag.chat_pdfs.get_pipeline_flags()
+
+    def _raise(*_a, **_kw):
+        raise RuntimeError("simulated failure mid-evaluation")
+
+    monkeypatch.setattr(run_eval, "run_all_cases", _raise)
+
+    with pytest.raises(RuntimeError, match="simulated failure"):
+        evaluate(
+            models=["m"], case_ids=[_DEV_CASE_ID],
+            config_overrides={"flags.usar_recomp_synthesis": not before["USAR_RECOMP_SYNTHESIS"]},
+            write_report=False,
+        )
+
+    assert rag.chat_pdfs.get_pipeline_flags() == before

--- a/tests/eval/test_evaluate_library_api.py
+++ b/tests/eval/test_evaluate_library_api.py
@@ -1,0 +1,228 @@
+"""Equivalence tests for run_eval.evaluate() -- the library API extracted
+from main()'s body so a harness can drive an evaluation in-process (issue
+#31, docs/design/2026-07-28-loop-automejorable.md section 6.1).
+
+evaluate() imports the real rag.chat_pdfs internally (the one step no
+amount of faking run_eval's own helpers avoids), so it needs the full engine
+installed -- the ``import rag.chat_pdfs`` below is what lets
+tests/conftest.py's heuristic skip this file in the dependency-free fast
+gate. Everything downstream of that import (Ollama preflight, corpus
+staging, indexing, case execution) is faked, so no GPU, Ollama server or
+network access is needed to run these.
+"""
+
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import pytest  # noqa: E402
+
+import rag.chat_pdfs  # noqa: E402,F401  (see module docstring)
+import run_eval  # noqa: E402
+from run_eval import evaluate  # noqa: E402
+
+_DEV_CASE_ID = "att-bleu-ende"  # source: "corpus"
+_BLIND_CASE_ID = "resnet-top1-34layer"  # source: "arxiv"
+
+
+def _fake_stack():
+    return SimpleNamespace(
+        vector_store=SimpleNamespace(get_page=lambda *_a, **_kw: []),
+        embedder=None,
+    )
+
+
+def _capture_ensure_indexed(monkeypatch, calls):
+    """Replace ensure_indexed with a double that records every call and
+    returns a stack cheap enough that evaluate()'s teardown is a no-op."""
+
+    def _fake(rag, carpeta, required_pdfs, label, path_label=None, config_overrides=None):
+        calls.append({
+            "carpeta": carpeta,
+            "required_pdfs": set(required_pdfs),
+            "label": label,
+            "path_label": path_label,
+            "config_overrides": config_overrides,
+        })
+        return (object(), object(), _fake_stack())
+
+    monkeypatch.setattr(run_eval, "ensure_indexed", _fake)
+
+
+def _capture_run_all_cases(monkeypatch, seen_cases):
+    """Replace run_all_cases with a double that records which cases it was
+    asked to run and grades every one of them a pass, so a run this test
+    file drives never needs Ollama."""
+
+    def _fake(rag, cases, retrieve_dev, retrieve_blind, evidence_dev, evidence_blind, models):
+        seen_cases.extend(cases)
+        return [
+            {
+                "id": c["id"], "paper": c["paper"], "case_type": c["case_type"],
+                "lang": c["lang"], "model": None, "passed": True, "reason": "stub",
+                "elapsed_seconds": 0.0,
+            }
+            for c in cases
+        ]
+
+    monkeypatch.setattr(run_eval, "run_all_cases", _fake)
+
+
+@pytest.fixture(autouse=True)
+def _stub_pipeline(monkeypatch):
+    """Fake Ollama preflight, blind-set staging and the post-index paper
+    check, and neutralize the one call that mutates rag.chat_pdfs's real
+    module globals -- evaluate() calls set_model_roles_runtime
+    unconditionally, and leaving that mutation in place would leak into
+    whatever test runs next in the same process (e.g.
+    tests/unit/test_app_config_defaults.py, which reads those same globals).
+    """
+    monkeypatch.setattr(run_eval, "preflight_ollama", lambda *_a, **_kw: None)
+    monkeypatch.setattr(run_eval, "stage_blind_papers", lambda cases: {})
+    monkeypatch.setattr(run_eval, "verify_all_papers_indexed", lambda *_a, **_kw: None)
+    monkeypatch.setattr(rag.chat_pdfs, "set_model_roles_runtime", lambda *_a, **_kw: None)
+
+
+def test_case_ids_runs_exactly_those_cases(monkeypatch):
+    _capture_ensure_indexed(monkeypatch, [])
+    seen = []
+    _capture_run_all_cases(monkeypatch, seen)
+    wanted = [_DEV_CASE_ID, "att-bleu-enfr"]
+
+    result = evaluate(models=["m"], case_ids=wanted, write_report=False)
+
+    assert {c["id"] for c in seen} == set(wanted)
+    assert result["num_cases"] == len(wanted)
+
+
+def test_case_ids_none_selects_every_gold_case(monkeypatch):
+    _capture_ensure_indexed(monkeypatch, [])
+    seen = []
+    _capture_run_all_cases(monkeypatch, seen)
+    all_cases = run_eval.load_gold_cases()
+
+    result = evaluate(models=["m"], write_report=False)
+
+    assert len(seen) == len(all_cases)
+    assert {c["id"] for c in seen} == {c["id"] for c in all_cases}
+    assert result["num_cases"] == len(all_cases)
+
+
+def test_unknown_case_id_raises_value_error(monkeypatch):
+    _capture_ensure_indexed(monkeypatch, [])
+    _capture_run_all_cases(monkeypatch, [])
+
+    with pytest.raises(ValueError):
+        evaluate(models=["m"], case_ids=["not-a-real-case"], write_report=False)
+
+
+def test_dev_only_subset_never_stages_or_indexes_blind(monkeypatch):
+    ensure_calls = []
+    _capture_ensure_indexed(monkeypatch, ensure_calls)
+    _capture_run_all_cases(monkeypatch, [])
+    staged = []
+    monkeypatch.setattr(run_eval, "stage_blind_papers", lambda cases: staged.append(cases) or {})
+
+    evaluate(models=["m"], case_ids=[_DEV_CASE_ID], write_report=False)
+
+    assert {c["label"] for c in ensure_calls} == {"dev set"}
+    assert [c["id"] for c in staged[0]] == [_DEV_CASE_ID]
+
+
+def test_blind_only_subset_never_indexes_dev(monkeypatch):
+    ensure_calls = []
+    _capture_ensure_indexed(monkeypatch, ensure_calls)
+    _capture_run_all_cases(monkeypatch, [])
+    # A real stage_blind_papers would hit the network (fetch_papers); this
+    # double reproduces only its {"<paper>.pdf": arxiv_id} return shape.
+    monkeypatch.setattr(
+        run_eval, "stage_blind_papers",
+        lambda cases: {f"{c['paper']}.pdf": c.get("arxiv_id", "") for c in cases},
+    )
+
+    evaluate(models=["m"], case_ids=[_BLIND_CASE_ID], write_report=False)
+
+    assert {c["label"] for c in ensure_calls} == {"blind set"}
+
+
+def test_write_report_false_writes_nothing_to_disk(monkeypatch, tmp_path):
+    monkeypatch.setattr(run_eval, "RESULTS_DIR", tmp_path)
+    _capture_ensure_indexed(monkeypatch, [])
+    _capture_run_all_cases(monkeypatch, [])
+
+    result = evaluate(models=["m"], case_ids=[_DEV_CASE_ID], write_report=False)
+
+    assert result["report_path"] is None
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_write_report_true_writes_the_expected_json(monkeypatch, tmp_path):
+    monkeypatch.setattr(run_eval, "RESULTS_DIR", tmp_path)
+    _capture_ensure_indexed(monkeypatch, [])
+    _capture_run_all_cases(monkeypatch, [])
+
+    result = evaluate(models=["m"], case_ids=[_DEV_CASE_ID], write_report=True)
+
+    files = list(tmp_path.iterdir())
+    assert len(files) == 1
+    assert result["report_path"] == str(files[0])
+    payload = json.loads(files[0].read_text(encoding="utf-8"))
+    assert payload["run"]["num_cases"] == 1
+
+
+def test_update_baseline_false_leaves_the_baseline_file_byte_identical(monkeypatch, tmp_path):
+    baseline_file = tmp_path / "baseline_min_pass_rate.txt"
+    baseline_file.write_text("0.61\n", encoding="utf-8")
+    monkeypatch.setattr(run_eval, "BASELINE_FILE", baseline_file)
+    _capture_ensure_indexed(monkeypatch, [])
+    _capture_run_all_cases(monkeypatch, [])
+    before = baseline_file.read_bytes()
+
+    result = evaluate(
+        models=["m"], case_ids=[_DEV_CASE_ID], write_report=False, update_baseline=False
+    )
+
+    assert baseline_file.read_bytes() == before
+    assert result["baseline_updated"] is False
+
+
+def test_update_baseline_true_raises_it_when_the_run_is_conclusive(monkeypatch, tmp_path):
+    baseline_file = tmp_path / "baseline_min_pass_rate.txt"
+    baseline_file.write_text("0.10\n", encoding="utf-8")
+    monkeypatch.setattr(run_eval, "BASELINE_FILE", baseline_file)
+    _capture_ensure_indexed(monkeypatch, [])
+    _capture_run_all_cases(monkeypatch, [])  # every stubbed case passes
+
+    result = evaluate(
+        models=["m"], case_ids=[_DEV_CASE_ID], write_report=False, update_baseline=True
+    )
+
+    assert result["baseline_updated"] is True
+    assert baseline_file.read_text(encoding="utf-8").strip() != "0.10"
+
+
+def test_config_overrides_reach_the_appconfig_and_ensure_indexed(monkeypatch):
+    ensure_calls = []
+    _capture_ensure_indexed(monkeypatch, ensure_calls)
+    _capture_run_all_cases(monkeypatch, [])
+    overrides = {"retrieval.top_k_final": 3}
+
+    result = evaluate(
+        models=["m"], case_ids=[_DEV_CASE_ID], config_overrides=overrides, write_report=False
+    )
+
+    assert result["config"]["dev"]["retrieval"]["top_k_final"] == 3
+    assert ensure_calls[0]["config_overrides"] == overrides
+
+
+def test_config_is_none_for_a_corpus_never_staged(monkeypatch):
+    _capture_ensure_indexed(monkeypatch, [])
+    _capture_run_all_cases(monkeypatch, [])
+
+    result = evaluate(models=["m"], case_ids=[_DEV_CASE_ID], write_report=False)
+
+    assert result["config"]["dev"] is not None
+    assert result["config"]["blind"] is None

--- a/tests/eval/test_evaluate_library_api.py
+++ b/tests/eval/test_evaluate_library_api.py
@@ -11,6 +11,7 @@ staging, indexing, case execution) is faked, so no GPU, Ollama server or
 network access is needed to run these.
 """
 
+import dataclasses
 import json
 import sys
 from pathlib import Path
@@ -22,7 +23,24 @@ import pytest  # noqa: E402
 
 import rag.chat_pdfs  # noqa: E402,F401  (see module docstring)
 import run_eval  # noqa: E402
+from monkeygrab.config.app_config import AppConfig  # noqa: E402
 from run_eval import evaluate  # noqa: E402
+
+
+def _iter_appconfig_dotted_fields(obj=None, prefix=""):
+    """Yield every leaf dotted field path AppConfig actually has, recursing
+    into nested dataclass fields (e.g. models.ollama.keep_alive) -- the same
+    granularity tests/unit/test_app_config_defaults.py's _FIELD_MAP uses for
+    the same structure."""
+    if obj is None:
+        obj = AppConfig()
+    for f in dataclasses.fields(obj):
+        value = getattr(obj, f.name)
+        dotted = f"{prefix}{f.name}"
+        if dataclasses.is_dataclass(value):
+            yield from _iter_appconfig_dotted_fields(value, prefix=f"{dotted}.")
+        else:
+            yield dotted
 
 _DEV_CASE_ID = "att-bleu-ende"  # source: "corpus"
 _BLIND_CASE_ID = "resnet-top1-34layer"  # source: "arxiv"
@@ -74,24 +92,24 @@ def _capture_run_all_cases(monkeypatch, seen_cases):
 @pytest.fixture(autouse=True)
 def _stub_pipeline(monkeypatch):
     """Fake Ollama preflight, blind-set staging and the post-index paper
-    check, and neutralize the one call that mutates rag.chat_pdfs's real
-    module globals unconditionally -- evaluate() always calls
-    set_model_roles_runtime, and leaving that mutation in place would leak
-    into whatever test runs next in the same process (e.g.
-    tests/unit/test_app_config_defaults.py, which reads those same globals).
+    check.
 
-    Pipeline flags (set_pipeline_flags) are NOT neutralized here -- several
-    tests below exercise _generation_config_overrides, which calls the real
-    set_pipeline_flags on purpose. Snapshotting and restoring them instead
-    means a bug in that restoration shows up as THIS test's own assertions
-    failing, not as unrelated flakiness two files later.
+    Model roles (set_model_roles_runtime) and pipeline flags
+    (set_pipeline_flags) are NOT neutralized -- evaluate()'s own
+    _scoped_model_roles / _generation_config_overrides are what restore both
+    on exit now, and several tests below exercise that restoration on
+    purpose. Snapshotting and restoring both here as well means a bug in
+    evaluate()'s own restoration shows up as THIS test's own assertions
+    failing, not as unrelated flakiness two files later (e.g.
+    tests/unit/test_app_config_defaults.py, which reads these same globals).
     """
     monkeypatch.setattr(run_eval, "preflight_ollama", lambda *_a, **_kw: None)
     monkeypatch.setattr(run_eval, "stage_blind_papers", lambda cases: {})
     monkeypatch.setattr(run_eval, "verify_all_papers_indexed", lambda *_a, **_kw: None)
-    monkeypatch.setattr(rag.chat_pdfs, "set_model_roles_runtime", lambda *_a, **_kw: None)
+    previous_roles = rag.chat_pdfs.get_model_roles()
     previous_flags = rag.chat_pdfs.get_pipeline_flags()
     yield
+    rag.chat_pdfs.set_model_roles_runtime(previous_roles)
     rag.chat_pdfs.set_pipeline_flags(previous_flags)
 
 
@@ -276,16 +294,51 @@ def test_config_overrides_rejects_every_unreachable_key_by_name(monkeypatch):
     assert "models.ollama.keep_alive" in message
 
 
-def test_config_overrides_accepts_every_key_evaluate_claims_to_honour(monkeypatch):
-    """_APPCONFIG_OVERRIDE_KEYS / _GENERATION_FLAG_OVERRIDE_KEYS is the map
-    reported alongside this test; this pins that _validate_config_overrides
-    agrees with it (a key present in the map but rejected here would be a
-    silent regression the map itself would not catch)."""
-    _capture_ensure_indexed(monkeypatch, [])
-    _capture_run_all_cases(monkeypatch, [])
-    honored = run_eval._APPCONFIG_OVERRIDE_KEYS | set(run_eval._GENERATION_FLAG_OVERRIDE_KEYS)
+def test_config_override_key_sets_are_complete_and_every_honoured_key_is_real():
+    """Pins the classification the PR's reachability map is built from,
+    against a future AppConfig field being added, renamed or reclassified.
 
-    run_eval._validate_config_overrides({key: None for key in honored})  # must not raise
+    The previous version of this test fed
+    ``_APPCONFIG_OVERRIDE_KEYS | _GENERATION_FLAG_OVERRIDE_KEYS`` straight
+    into a validator whose entire job is membership in that same set --
+    S subseteq S, structurally unable to fail. This checks the actual
+    claims instead: every honoured key is a real AppConfig field that
+    survives ``with_overrides`` (not just a plausible-looking string), and
+    honoured + unreachable together cover every field AppConfig has -- no
+    field silently unclassified, none claimed twice.
+    """
+    honored = run_eval._APPCONFIG_OVERRIDE_KEYS | set(run_eval._GENERATION_FLAG_OVERRIDE_KEYS)
+    unreachable = set(run_eval._UNREACHABLE_CONFIG_OVERRIDE_REASONS)
+    all_fields = set(_iter_appconfig_dotted_fields())
+
+    assert honored & unreachable == set(), "a key cannot be both honoured and unreachable"
+    assert honored | unreachable == all_fields, (
+        f"map/AppConfig drift -- missing: {all_fields - (honored | unreachable)}, "
+        f"stale: {(honored | unreachable) - all_fields}"
+    )
+
+    run_eval.validate_config_overrides({key: None for key in honored})  # must not raise
+
+    default = AppConfig()
+    for key in honored:
+        section, field = key.split(".", 1)
+        current_value = getattr(getattr(default, section), field)
+        updated = default.with_overrides(**{key: current_value})
+        assert getattr(getattr(updated, section), field) == current_value
+
+
+def test_describe_config_overrides_matches_the_internal_classification():
+    """describe_config_overrides() is the public accessor a harness uses
+    instead of importing the underscore-private key sets directly; this
+    pins that it actually reflects them."""
+    described = run_eval.describe_config_overrides()
+
+    assert set(described["honoured"]) == (
+        run_eval._APPCONFIG_OVERRIDE_KEYS | set(run_eval._GENERATION_FLAG_OVERRIDE_KEYS)
+    )
+    assert set(described["unreachable"]) == set(run_eval._UNREACHABLE_CONFIG_OVERRIDE_REASONS)
+    assert described["honoured"]["retrieval.top_k_final"] == "appconfig"
+    assert described["honoured"]["flags.usar_recomp_synthesis"] == "runtime_setter"
 
 
 def test_generation_flag_override_reaches_rag_chat_pdfs_during_case_execution(monkeypatch):
@@ -339,3 +392,87 @@ def test_generation_flag_override_restores_on_exception_mid_evaluation(monkeypat
         )
 
     assert rag.chat_pdfs.get_pipeline_flags() == before
+
+
+def test_model_roles_change_during_the_run_and_are_restored_after(monkeypatch):
+    """run_factual_case reassigns the "rag" role per case/model on top of
+    evaluate()'s own aux-role assignment -- both must be undone once
+    evaluate() returns, not just the aux one. Asserts the change actually
+    happened first, so this cannot pass vacuously if a future default
+    happens to already match."""
+    _capture_ensure_indexed(monkeypatch, [])
+    observed = {}
+
+    def _fake_run_all_cases(rag_module, cases, retrieve_dev, retrieve_blind, evidence_dev, evidence_blind, models):
+        rag_module.set_model_roles_runtime({"rag": models[0]})
+        observed["during"] = rag_module.get_model_roles()
+        return []
+
+    monkeypatch.setattr(run_eval, "run_all_cases", _fake_run_all_cases)
+    before = rag.chat_pdfs.get_model_roles()
+
+    evaluate(models=["a-generator-nobody-defaults-to"], case_ids=[_DEV_CASE_ID], write_report=False)
+
+    assert observed["during"] != before
+    assert rag.chat_pdfs.get_model_roles() == before
+
+
+def test_model_roles_restore_on_exception_mid_evaluation(monkeypatch):
+    _capture_ensure_indexed(monkeypatch, [])
+    before = rag.chat_pdfs.get_model_roles()
+
+    def _raise(*_a, **_kw):
+        raise RuntimeError("simulated failure mid-evaluation")
+
+    monkeypatch.setattr(run_eval, "run_all_cases", _raise)
+
+    with pytest.raises(RuntimeError, match="simulated failure"):
+        evaluate(models=["m"], case_ids=[_DEV_CASE_ID], write_report=False)
+
+    assert rag.chat_pdfs.get_model_roles() == before
+
+
+def test_models_contextual_override_is_preflighted_when_contextual_retrieval_is_on(monkeypatch):
+    """HIGH finding: an overridden models.contextual that preflight never
+    sees lets ensure_indexed call an unpulled model, whose swallowed
+    RuntimeError (IndexCorpus._generate_situational_context) writes an empty
+    situational context under a fingerprint that claims enrichment
+    succeeded -- a silent, cached lie. required_models must include the
+    override whenever contextual retrieval will actually be on."""
+    preflight_calls = []
+    monkeypatch.setattr(
+        run_eval, "preflight_ollama", lambda required: preflight_calls.append(set(required))
+    )
+    _capture_ensure_indexed(monkeypatch, [])
+    _capture_run_all_cases(monkeypatch, [])
+
+    evaluate(
+        models=["m"], case_ids=[_DEV_CASE_ID],
+        config_overrides={
+            "flags.usar_contextual_retrieval": True,
+            "models.contextual": "definitely-not-pulled:0b",
+        },
+        write_report=False,
+    )
+
+    assert preflight_calls == [{"m", run_eval.AUX_MODEL, "definitely-not-pulled:0b"}]
+
+
+def test_models_contextual_override_not_preflighted_when_contextual_retrieval_stays_off(monkeypatch):
+    """The override is still honoured in the threaded AppConfig (see the map:
+    models.contextual only takes effect when usar_contextual_retrieval is
+    also True) -- preflight has nothing to add when that never happens."""
+    preflight_calls = []
+    monkeypatch.setattr(
+        run_eval, "preflight_ollama", lambda required: preflight_calls.append(set(required))
+    )
+    _capture_ensure_indexed(monkeypatch, [])
+    _capture_run_all_cases(monkeypatch, [])
+
+    evaluate(
+        models=["m"], case_ids=[_DEV_CASE_ID],
+        config_overrides={"models.contextual": "definitely-not-pulled:0b"},
+        write_report=False,
+    )
+
+    assert preflight_calls == [{"m", run_eval.AUX_MODEL}]


### PR DESCRIPTION
## Summary

- Extracts `evaluate()` from `main()`'s body in `tests/eval/run_eval.py`, as explicitly authorized by `docs/design/2026-07-28-loop-automejorable.md` section 6.1 (block-C search harness needs to drive the gold eval gate in-process). `grade.py`, `gold_cases.jsonl` and `baseline_min_pass_rate.txt` are untouched — no grading rule changed.
- `evaluate(*, models, case_ids=None, config_overrides=None, update_baseline=False, write_report=True) -> Dict[str, Any]` runs the same setup/index/execute/report/gate pipeline `main()` always did, parameterized:
  - `case_ids` filters cases right after loading, before any corpus staging/indexing decision — a subset that only needs one corpus never forces the other to be staged/indexed (dev-set indexing, previously unconditional, is now gated the same way blind-set indexing already was).
  - `config_overrides` reshapes the retrieval/indexing `AppConfig` via `with_overrides()`, threaded through `_eval_app_config`/`ensure_indexed`. It does **not** reach generation's own config — `generar_respuesta_silenciosa` builds a fresh `AppConfig` per call via `wiring.app_config_from_runtime()`, which reads `rag.chat_pdfs`'s module globals directly. Documented explicitly in `evaluate()`'s docstring rather than silently working around it.
  - `write_report=False` writes nothing to `tests/eval/runs/`.
  - `update_baseline=False` never touches `baseline_min_pass_rate.txt` — matches the CLI default exactly, including that an inconclusive (infrastructure-error) run never updates the baseline regardless of the flag.
  - Returns summary, per-case records, timings, models, and the effective `AppConfig` per corpus (plain dict) — enough for the evidence ledger (design doc section 4) to reconstruct the run.
- `main()` is now a thin wrapper: `parse_args` → `evaluate()` → same stdout / report file / exit code / baseline semantics as before.

## Test plan

- [x] `pytest -q -p no:randomly` (full suite): **342 passed, 1 skipped** (baseline was 327 passed, 1 skipped — 15 new tests, zero regressions).
- [x] `ruff check` clean on all changed/added files.
- [x] `python tests/eval/run_eval.py --help` unchanged.
- [x] New `tests/eval/test_evaluate_cli_wrapper.py` (4 tests): `main()` forwards parsed args to `evaluate()` and returns its `exit_code`; `EvalSetupError` still prints `SETUP FAILED: ...` and returns 1. `evaluate()` is patched, so this needs nothing but stdlib — runs in **both** the fast "architecture" job and the "engine" job.
- [x] New `tests/eval/test_evaluate_library_api.py` (11 tests): `case_ids` exact-subset / `None`-means-all / unknown-id-raises / dev-only-skips-blind / blind-only-skips-dev, `config_overrides` reaching the real `AppConfig`, `write_report=False` writes nothing, `update_baseline` False/True. Only the GPU/Ollama-bound leaves (`preflight_ollama`, `stage_blind_papers`, `ensure_indexed`, `run_all_cases`) are faked — `evaluate()`'s own orchestration, the real `rag.chat_pdfs` import and the real `_eval_app_config` run for real. Needs the full engine installed (same reasoning as the existing `test_ensure_indexed_fingerprint.py`), so it's **"engine" job only**.
- [x] A real, unmocked `evaluate(models=["gemma4:e2b"], case_ids=["att-bleu-ende"], write_report=False)` call ran for 35s against the live local Ollama: preflight passed, `case_ids` correctly skipped blind-set staging, the real engine import and `AppConfig` built — then hard-failed on this worktree's missing `.venv-mineru` (MinerU's isolated venv). That's a pre-existing environment gap in this sandboxed worktree, not something this change introduces or could work around; noted here rather than claiming an untested full run works.

This is the prerequisite only — the search harness itself is still to come, so this does not close #31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)