### PR TITLE
Add index recipe_version, contextual_num_ctx, and close #37 follow-ups

### DIFF
--- a/src/monkeygrab/adapters/vectorstore/faiss_store.py
+++ b/src/monkeygrab/adapters/vectorstore/faiss_store.py
@@ -335,11 +335,25 @@ class FaissVectorStore:
         interprets it. What it means lives in
         ``monkeygrab.application.index_fingerprint``.
 
+        Written to a temp path then ``os.replace``d in, same as every other
+        write in this class, and a failed write raises the same wrapped
+        ``RuntimeError`` naming the store directory instead of a raw
+        ``OSError`` -- consistent with ``_save``/``_rewrite`` rather than a
+        third persistence convention for one file.
+
         Args:
             fingerprint: The digest to record.
+
+        Raises:
+            RuntimeError: The write failed (e.g. disk full, permissions).
         """
-        with open(self._fingerprint_path, "w", encoding="utf-8") as f:
-            f.write(fingerprint + "\n")
+        try:
+            tmp_path = self._fingerprint_path + ".tmp"
+            with open(tmp_path, "w", encoding="utf-8") as f:
+                f.write(fingerprint + "\n")
+            os.replace(tmp_path, self._fingerprint_path)
+        except OSError as e:
+            raise RuntimeError(f"failed to persist FAISS store at {self._dir!r}: {e}") from e
 
     def delete_source(self, source: str) -> int:
         positions = [

--- a/src/monkeygrab/application/index_fingerprint.py
+++ b/src/monkeygrab/application/index_fingerprint.py
@@ -8,6 +8,13 @@ whatever it happened to change last. This module names exactly which
 configuration decides an index's content, so a mismatch can force a rebuild
 instead of being discovered as an unexplained score.
 
+Configuration is not the only thing that decides stored content, though --
+the CODE that turns a config into stored text can change too, and nothing
+above catches that: editing the chunking algorithm or the contextual-
+enrichment prompt changes what gets stored without moving a single config
+value. ``_RECIPE_VERSION`` closes that gap (see its docstring for what counts
+as a version bump and what does not).
+
 Pure: no I/O and no infrastructure imports. Persisting the value is the vector
 store's job; deciding what it means is this module's.
 """
@@ -24,6 +31,27 @@ from monkeygrab.config.app_config import AppConfig
 # that has to invalidate every index built before it.
 _EXTRACTOR_ID = "mineru"
 _EMBEDDING_ID = "jinaai/jina-clip-v2@512"
+
+# Bumped BY HAND when the code that turns a recipe into stored content
+# changes -- never for a configuration change, since every config value this
+# module cares about already has its own recipe key and invalidates on its
+# own. Counts as a bump: the chunking algorithm (how text is split into
+# chunks), the contextual-enrichment prompt template, the image-extraction
+# logic -- anything that can make the SAME configuration produce different
+# stored text or vectors than it used to. Does not count: a comment, a log
+# line, a refactor that leaves stored output byte-identical, or adding a new
+# *configuration* field (that already invalidates through its own recipe key,
+# e.g. contextual_num_ctx below).
+#
+# Serialized by omission at version 1: version 1 is defined as "the recipe
+# exactly as it existed before recipe_version was introduced", so the key is
+# left out of the dict entirely while this constant is 1 -- adding it costs
+# zero reindexing on its own. The key starts appearing only once a human
+# bumps this past 1, which is also the point every existing index legitimately
+# needs rebuilding. See
+# tests/unit/application/test_index_fingerprint.py::test_recipe_version_is_omitted_at_v1_and_matches_pre_change_main
+# for the test that makes this safe rather than clever.
+_RECIPE_VERSION = 1
 
 _FINGERPRINT_CHARS = 16
 
@@ -51,12 +79,16 @@ def index_recipe(config: AppConfig) -> Dict[str, Any]:
         "contextual_retrieval": config.flags.usar_contextual_retrieval,
         "image_embeddings": config.flags.usar_embeddings_imagen,
     }
-    # The contextual model and its document sample only reach stored text when
-    # that stage actually runs. Including them unconditionally would make an
-    # index built with the stage OFF depend on a model that never got called.
+    if _RECIPE_VERSION != 1:
+        recipe["recipe_version"] = _RECIPE_VERSION
+    # The contextual model, its context window and its document sample only
+    # reach stored text when that stage actually runs. Including them
+    # unconditionally would make an index built with the stage OFF depend on
+    # a model call that never happened.
     if config.flags.usar_contextual_retrieval:
         recipe["contextual_model"] = config.models.contextual
         recipe["contextual_doc_chars"] = config.chunking.contextual_doc_chars
+        recipe["contextual_num_ctx"] = config.models.ollama.contextual_num_ctx
     return recipe
 
 

--- a/src/monkeygrab/application/index_fingerprint.py
+++ b/src/monkeygrab/application/index_fingerprint.py
@@ -50,7 +50,16 @@ _EMBEDDING_ID = "jinaai/jina-clip-v2@512"
 # bumps this past 1, which is also the point every existing index legitimately
 # needs rebuilding. See
 # tests/unit/application/test_index_fingerprint.py::test_recipe_version_is_omitted_at_v1_and_matches_pre_change_main
-# for the test that makes this safe rather than clever.
+# for the test that makes this safe rather than clever, and
+# ::test_recipe_version_bump_actually_changes_the_recipe_and_the_fingerprint
+# for proof the mechanism itself is live, not just its state at v1.
+#
+# When you bump this: test_recipe_version_is_omitted_at_v1_and_matches_pre_change_main
+# will fail on its hardcoded hash -- DELETE it, do not "fix" it by pasting in
+# the new hash. Its only job was to pin v1's zero-cost guarantee, which no
+# longer applies once this is 2+. ::test_default_app_config_fingerprint_is_pinned
+# is a different kind of pin (the default config's current fingerprint, not
+# v1's zero-cost property) and DOES need its hash updated, not deleted.
 _RECIPE_VERSION = 1
 
 _FINGERPRINT_CHARS = 16

--- a/tests/eval/compare_runs.py
+++ b/tests/eval/compare_runs.py
@@ -65,12 +65,22 @@ def _reject_unusable(report: Dict[str, Any], label: str) -> None:
         )
 
 
-def compare(report_a: Dict[str, Any], report_b: Dict[str, Any]) -> Dict[str, Any]:
+def compare(
+    report_a: Dict[str, Any],
+    report_b: Dict[str, Any],
+    *,
+    label_a: str = "report_a",
+    label_b: str = "report_b",
+) -> Dict[str, Any]:
     """Compare two run reports case by case.
 
     Args:
         report_a: The earlier/reference run, parsed.
         report_b: The later/candidate run, parsed.
+        label_a: Name for ``report_a`` in a rejection message -- ``main()``
+            passes the actual file path so a failure names the file, not the
+            generic parameter name.
+        label_b: Same, for ``report_b``.
 
     Returns:
         ``flipped_to_pass`` and ``flipped_to_fail`` (sorted case keys),
@@ -82,8 +92,8 @@ def compare(report_a: Dict[str, Any], report_b: Dict[str, Any]) -> Dict[str, Any
             or either run is inconclusive or empty -- a run that measured
             nothing must not be treated as a noise-free result.
     """
-    _reject_unusable(report_a, "report_a")
-    _reject_unusable(report_b, "report_b")
+    _reject_unusable(report_a, label_a)
+    _reject_unusable(report_b, label_b)
     a, b = _outcomes(report_a), _outcomes(report_b)
     if a.keys() != b.keys():
         difference = sorted(set(a) ^ set(b))
@@ -94,7 +104,11 @@ def compare(report_a: Dict[str, Any], report_b: Dict[str, Any]) -> Dict[str, Any
     flipped_to_pass = sorted(k for k in a if not a[k] and b[k])
     flipped_to_fail = sorted(k for k in a if a[k] and not b[k])
     total = len(a)
-    delta = (sum(b.values()) - sum(a.values())) / total if total else 0.0
+    # total is always >= 1 here: _reject_unusable already raised above if
+    # report_a's results were empty, and a non-empty results list always
+    # yields at least one outcome key -- so there is no zero-total case left
+    # for this division to guard against.
+    delta = (sum(b.values()) - sum(a.values())) / total
     return {
         "flipped_to_pass": flipped_to_pass,
         "flipped_to_fail": flipped_to_fail,
@@ -127,7 +141,7 @@ def main(argv: List[str] | None = None) -> int:
 
     report_a = json.loads(args.report_a.read_text(encoding="utf-8"))
     report_b = json.loads(args.report_b.read_text(encoding="utf-8"))
-    _print(compare(report_a, report_b))
+    _print(compare(report_a, report_b, label_a=str(args.report_a), label_b=str(args.report_b)))
     return 0
 
 

--- a/tests/eval/test_compare_runs.py
+++ b/tests/eval/test_compare_runs.py
@@ -52,6 +52,16 @@ def test_cases_missing_from_one_run_are_rejected():
         compare(a, b)
 
 
+def test_cases_missing_from_one_run_are_rejected_the_other_way_too():
+    # Mirror of the above with the extra case on b instead of a -- the
+    # symmetric-difference check must catch either direction, not just "b is
+    # missing something a has".
+    a = _report({"x": True})
+    b = _report({"x": True, "y": True})
+    with pytest.raises(ValueError, match="y / m"):
+        compare(a, b)
+
+
 def test_inconclusive_run_is_rejected():
     # A record with infrastructure_error is a case that never ran -- an
     # Ollama timeout or dead server, not a real pass/fail. Comparing it as an
@@ -63,6 +73,17 @@ def test_inconclusive_run_is_rejected():
         compare(a, b)
 
 
+def test_inconclusive_run_is_rejected_on_the_other_side_too():
+    # Mirror of the above with the infrastructure error on a instead of b --
+    # _reject_unusable is called for both reports, but only one side had
+    # coverage.
+    a = _report({"x": True, "y": True})
+    b = _report({"x": True, "y": True})
+    a["results"][1]["infrastructure_error"] = True
+    with pytest.raises(ValueError, match="report_a.*inconclusive"):
+        compare(a, b)
+
+
 def test_empty_run_is_rejected():
     # Zero cases is the most complete crash of all -- it must not compare as
     # "0 case(s) unchanged", which reads as a clean, noise-free result.
@@ -70,3 +91,21 @@ def test_empty_run_is_rejected():
     b = _report({"x": True})
     with pytest.raises(ValueError, match="report_a.*no cases"):
         compare(a, b)
+
+
+def test_empty_run_is_rejected_on_the_other_side_too():
+    # Mirror of the above with the empty report on b instead of a.
+    a = _report({"x": True})
+    b = _report({})
+    with pytest.raises(ValueError, match="report_b.*no cases"):
+        compare(a, b)
+
+
+def test_rejection_messages_name_the_files_when_labels_are_given():
+    # compare_runs.main() passes the real report paths as labels so a
+    # rejection names the actual file instead of the generic parameter name
+    # "report_a"/"report_b".
+    a = _report({})
+    b = _report({"x": True})
+    with pytest.raises(ValueError, match="runs/2026-01-01.json"):
+        compare(a, b, label_a="runs/2026-01-01.json", label_b="runs/2026-01-02.json")

--- a/tests/eval/test_summary_split.py
+++ b/tests/eval/test_summary_split.py
@@ -41,3 +41,18 @@ def test_overall_keeps_its_existing_meaning():
 def test_empty_buckets_do_not_divide_by_zero():
     summary = build_summary([_record("figure_retrieval", True)])
     assert summary["answer"] == {"total": 0, "passed": 0, "pass_rate": 0.0}
+
+
+def test_overall_equals_retrieval_plus_answer_for_an_unknown_case_type():
+    # A case_type this module has never seen is not one of
+    # _RETRIEVAL_ONLY_CASE_TYPES, so it must land in "answer" -- the
+    # partition has to stay exhaustive for a case type added later, or it
+    # would silently vanish from both buckets while still counting in
+    # "overall".
+    records = [
+        _record("figure_retrieval", True),
+        _record("some_future_case_type", True, "m"),
+    ]
+    summary = build_summary(records)
+    assert summary["overall"]["total"] == summary["retrieval_only"]["total"] + summary["answer"]["total"]
+    assert summary["answer"]["total"] == 1

--- a/tests/unit/adapters/test_faiss_store_fingerprint.py
+++ b/tests/unit/adapters/test_faiss_store_fingerprint.py
@@ -88,3 +88,24 @@ def test_write_fingerprint_hard_fails_when_persistence_write_fails(tmp_path, mon
 
     with pytest.raises(RuntimeError, match="failed to persist"):
         store.write_fingerprint("abc123")
+
+
+def test_write_fingerprint_failure_does_not_destroy_the_previous_value(tmp_path, monkeypatch):
+    # This is the actual reason write_fingerprint moved to temp-file-then-
+    # os.replace: a failed write must leave the last successfully recorded
+    # fingerprint in place, not a corrupted or half-written file.
+    from monkeygrab.adapters.vectorstore import faiss_store as module
+
+    store = _store(tmp_path)
+    store.write_fingerprint("abc123")
+
+    def _boom(*args, **kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(module.os, "replace", _boom)
+
+    with pytest.raises(RuntimeError, match="failed to persist"):
+        store.write_fingerprint("def456")
+
+    assert store.read_fingerprint() == "abc123"
+    assert _store(tmp_path).read_fingerprint() == "abc123"

--- a/tests/unit/adapters/test_faiss_store_fingerprint.py
+++ b/tests/unit/adapters/test_faiss_store_fingerprint.py
@@ -1,5 +1,7 @@
 """Tests for the FAISS store's opaque fingerprint sidecar."""
 
+import pytest
+
 from monkeygrab.adapters.vectorstore.faiss_store import FaissVectorStore
 from monkeygrab.config.paths import PathsConfig
 from monkeygrab.domain.chunk import Chunk
@@ -51,3 +53,38 @@ def test_a_store_without_a_fingerprint_still_loads(tmp_path):
     reopened = _store(tmp_path)
     assert reopened.count() == 1
     assert reopened.read_fingerprint() is None
+
+
+def test_write_fingerprint_overwrites_a_previous_value(tmp_path):
+    store = _store(tmp_path)
+    store.write_fingerprint("abc123")
+    store.write_fingerprint("def456")
+    assert store.read_fingerprint() == "def456"
+    assert _store(tmp_path).read_fingerprint() == "def456"
+
+
+def test_deleting_the_last_source_drops_the_fingerprint(tmp_path):
+    # delete_source rewrites via _rewrite, which clear()s the whole store
+    # once no rows are left -- the fingerprint must go with it, since a
+    # recipe fingerprint for zero content is meaningless.
+    store = _store(tmp_path)
+    store.add(_chunk(), [0.1, 0.2, 0.3])
+    store.write_fingerprint("abc123")
+
+    assert store.delete_source("a.pdf") == 1
+    assert store.read_fingerprint() is None
+    assert _store(tmp_path).read_fingerprint() is None
+
+
+def test_write_fingerprint_hard_fails_when_persistence_write_fails(tmp_path, monkeypatch):
+    from monkeygrab.adapters.vectorstore import faiss_store as module
+
+    store = _store(tmp_path)
+
+    def _boom(*args, **kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(module.os, "replace", _boom)
+
+    with pytest.raises(RuntimeError, match="failed to persist"):
+        store.write_fingerprint("abc123")

--- a/tests/unit/application/test_index_corpus.py
+++ b/tests/unit/application/test_index_corpus.py
@@ -7,6 +7,7 @@ against hand-written port fakes, so no Ollama server, PDF or vector store is
 touched.
 """
 
+import hashlib
 import sys
 from pathlib import Path
 
@@ -194,6 +195,39 @@ def test_contextual_model_failure_falls_back_to_no_enrichment():
     assert len(store.added) == 1
     chunk, _embedding = store.added[0]
     assert chunk.text == "Enough content here to clear the small test threshold easily."
+
+
+def test_contextual_prompt_template_is_pinned(monkeypatch):
+    """Pins the situational-context prompt's fixed wording via a hash, so an
+    edit to it fails a test instead of shipping silently.
+
+    monkeygrab.application.index_fingerprint._RECIPE_VERSION exists
+    precisely because this prompt template is one of the things that can
+    change stored chunk text without moving a single AppConfig value (see
+    that module's docstring). This test can't stop someone from editing the
+    template, but it can force the edit through a test failure instead of
+    past it.
+
+    The hash covers only the fixed wording, not the per-call values
+    (chunk_text/texto_base/idioma_doc are held fixed here) that get
+    interpolated into it on a real call.
+
+    If this fails because you intentionally changed the prompt: update the
+    hash below AND bump index_fingerprint._RECIPE_VERSION in the same
+    change -- do not update just this hash.
+    """
+    contextual = FakeContextualModel()
+    use_case = IndexCorpus(
+        FakeExtractor([]), FakeEmbedder(), FakeVectorStore(), AppConfig(), contextual_model=contextual
+    )
+
+    use_case._generate_situational_context(
+        chunk_text="a fixed chunk of text", texto_base="a fixed document sample", idioma_doc="English",
+    )
+
+    system_prompt, user_prompt = contextual.calls[0]["system"], contextual.calls[0]["prompt"]
+    digest = hashlib.sha256((system_prompt + "\x00" + user_prompt).encode("utf-8")).hexdigest()[:16]
+    assert digest == "9c4a5743523304fe"
 
 
 def _no_text_config(**overrides):

--- a/tests/unit/application/test_index_fingerprint.py
+++ b/tests/unit/application/test_index_fingerprint.py
@@ -2,6 +2,7 @@
 
 import dataclasses
 
+from monkeygrab.application import index_fingerprint
 from monkeygrab.application.index_fingerprint import (
     compute_index_fingerprint,
     index_recipe,
@@ -101,10 +102,12 @@ def test_recipe_version_is_omitted_at_v1_and_matches_pre_change_main():
     contextual_num_ctx addition tested above (issue #37 item 2): that
     addition legitimately changes the fingerprint of a *contextual-on*
     config -- including the all-defaults AppConfig, since
-    usar_contextual_retrieval defaults to True -- and that is a real,
-    justified one-time reindex for anyone running with the stage on,
-    explained in the commit that introduced it. This test is only about
-    recipe_version, which must move nothing on its own.
+    usar_contextual_retrieval defaults to True. No product code reads or
+    writes fingerprint.txt today (only tests/eval/run_eval.py does --
+    wiring it into rag/engine/indexing.py and the CLI/web is #36, still
+    open), so that particular invalidation costs nothing right now; it will
+    once #36 lands. This test is only about recipe_version, which must move
+    nothing on its own, ever.
 
     Value computed on main @ 8b4f16d (before recipe_version or
     contextual_num_ctx existed in the recipe) via:
@@ -115,6 +118,48 @@ def test_recipe_version_is_omitted_at_v1_and_matches_pre_change_main():
     config = AppConfig().with_overrides(**{"flags.usar_contextual_retrieval": False})
     assert compute_index_fingerprint(config) == "3802ef9e11d5e813"
     assert "recipe_version" not in index_recipe(config)
+
+
+def test_recipe_version_bump_actually_changes_the_recipe_and_the_fingerprint(monkeypatch):
+    """Exercises the mechanism itself, not just its at-rest state at v1.
+
+    test_recipe_version_is_omitted_at_v1_and_matches_pre_change_main above
+    only proves the key is absent while _RECIPE_VERSION == 1 -- equally true
+    of a tree where the two lines
+        if _RECIPE_VERSION != 1:
+            recipe["recipe_version"] = _RECIPE_VERSION
+    were deleted entirely, or never written. Deleting them leaves the full
+    suite green, since nothing else in this module bumps the constant. This
+    test bumps it and checks the key actually appears and the fingerprint
+    actually moves, so a later refactor that "simplifies" those two lines
+    away fails here instead of shipping silently.
+    """
+    config = AppConfig()
+    v1_fingerprint = compute_index_fingerprint(config)
+
+    monkeypatch.setattr(index_fingerprint, "_RECIPE_VERSION", 2)
+
+    assert index_recipe(config)["recipe_version"] == 2
+    assert compute_index_fingerprint(config) != v1_fingerprint
+
+
+def test_default_app_config_fingerprint_is_pinned():
+    """Pins the branch every product user actually takes -- contextual ON.
+
+    The pin above (test_recipe_version_is_omitted_at_v1_and_matches_pre_change_main)
+    only exercises the contextual-OFF path, which is the eval gate's own
+    config, not the product default: usar_contextual_retrieval defaults to
+    True, so a stray field added inside
+    `if config.flags.usar_contextual_retrieval:` would move every real
+    user's fingerprint while that other test stayed green. This PR's own
+    contextual_num_ctx addition is exactly such a change -- it is the reason
+    this value differs from main's 70b88d55bb078bf9 -- and only a pin on the
+    default config, not the contextual-off one, would have caught it.
+
+    Value computed on this branch, after recipe_version + contextual_num_ctx:
+        compute_index_fingerprint(AppConfig()) == "b4bc32189fbd3efe"
+    """
+    assert compute_index_fingerprint(AppConfig()) == "b4bc32189fbd3efe"
 
 
 def test_fingerprint_is_short_hex():

--- a/tests/unit/application/test_index_fingerprint.py
+++ b/tests/unit/application/test_index_fingerprint.py
@@ -1,10 +1,21 @@
 """Tests for the index fingerprint: what must and must not invalidate an index."""
 
+import dataclasses
+
 from monkeygrab.application.index_fingerprint import (
     compute_index_fingerprint,
     index_recipe,
 )
 from monkeygrab.config.app_config import AppConfig
+
+
+def _with_contextual_num_ctx(config: AppConfig, value: int) -> AppConfig:
+    # models.ollama.* is not part of with_overrides's runtime-mutable surface
+    # (see app_config.py's _SECTION_NAMES comment), so this bypasses it and
+    # rebuilds the nested dataclass directly.
+    ollama = dataclasses.replace(config.models.ollama, contextual_num_ctx=value)
+    models = dataclasses.replace(config.models, ollama=ollama)
+    return dataclasses.replace(config, models=models)
 
 
 def test_same_config_gives_same_fingerprint():
@@ -15,6 +26,18 @@ def test_same_config_gives_same_fingerprint():
 def test_chunk_size_change_invalidates():
     base = AppConfig()
     changed = base.with_overrides(**{"chunking.chunk_size": 1000})
+    assert compute_index_fingerprint(base) != compute_index_fingerprint(changed)
+
+
+def test_chunk_overlap_change_invalidates():
+    base = AppConfig()
+    changed = base.with_overrides(**{"chunking.chunk_overlap": 100})
+    assert compute_index_fingerprint(base) != compute_index_fingerprint(changed)
+
+
+def test_min_chunk_length_change_invalidates():
+    base = AppConfig()
+    changed = base.with_overrides(**{"chunking.min_chunk_length": 50})
     assert compute_index_fingerprint(base) != compute_index_fingerprint(changed)
 
 
@@ -48,6 +71,50 @@ def test_contextual_model_only_counts_when_the_stage_runs():
     on = AppConfig().with_overrides(**{"flags.usar_contextual_retrieval": True})
     on_other_model = on.with_overrides(**{"models.contextual": "some-other-model"})
     assert compute_index_fingerprint(on) != compute_index_fingerprint(on_other_model)
+
+
+def test_contextual_doc_chars_only_counts_when_the_stage_runs():
+    off = AppConfig().with_overrides(**{"flags.usar_contextual_retrieval": False})
+    off_other_chars = off.with_overrides(**{"chunking.contextual_doc_chars": 500})
+    assert compute_index_fingerprint(off) == compute_index_fingerprint(off_other_chars)
+
+    on = AppConfig().with_overrides(**{"flags.usar_contextual_retrieval": True})
+    on_other_chars = on.with_overrides(**{"chunking.contextual_doc_chars": 500})
+    assert compute_index_fingerprint(on) != compute_index_fingerprint(on_other_chars)
+
+
+def test_contextual_num_ctx_only_counts_when_the_stage_runs():
+    off = AppConfig().with_overrides(**{"flags.usar_contextual_retrieval": False})
+    off_other_ctx = _with_contextual_num_ctx(off, 9999)
+    assert compute_index_fingerprint(off) == compute_index_fingerprint(off_other_ctx)
+
+    on = AppConfig().with_overrides(**{"flags.usar_contextual_retrieval": True})
+    on_other_ctx = _with_contextual_num_ctx(on, 9999)
+    assert compute_index_fingerprint(on) != compute_index_fingerprint(on_other_ctx)
+
+
+def test_recipe_version_is_omitted_at_v1_and_matches_pre_change_main():
+    """recipe_version must not move a single existing fingerprint at v1.
+
+    Uses a contextual-off config specifically so this test isolates
+    recipe_version's own effect from the deliberate, unrelated
+    contextual_num_ctx addition tested above (issue #37 item 2): that
+    addition legitimately changes the fingerprint of a *contextual-on*
+    config -- including the all-defaults AppConfig, since
+    usar_contextual_retrieval defaults to True -- and that is a real,
+    justified one-time reindex for anyone running with the stage on,
+    explained in the commit that introduced it. This test is only about
+    recipe_version, which must move nothing on its own.
+
+    Value computed on main @ 8b4f16d (before recipe_version or
+    contextual_num_ctx existed in the recipe) via:
+        compute_index_fingerprint(
+            AppConfig().with_overrides(**{"flags.usar_contextual_retrieval": False})
+        )
+    """
+    config = AppConfig().with_overrides(**{"flags.usar_contextual_retrieval": False})
+    assert compute_index_fingerprint(config) == "3802ef9e11d5e813"
+    assert "recipe_version" not in index_recipe(config)
 
 
 def test_fingerprint_is_short_hex():

--- a/tests/unit/test_embedding_id_binding.py
+++ b/tests/unit/test_embedding_id_binding.py
@@ -1,0 +1,21 @@
+"""Binds index_fingerprint's _EMBEDDING_ID to the model the adapter loads.
+
+Nothing in either monkeygrab.application or monkeygrab.adapters can make this
+comparison itself: the dependency rule (see test_architecture_boundaries.py)
+forbids application from importing adapters, so index_fingerprint cannot read
+jina_clip_worker's constants directly. A plain test module has no such
+restriction and can import both, which is what turns "remember to bump both
+strings together" into something a green suite actually checks.
+"""
+
+from monkeygrab.adapters.embedding.jina_clip_worker import _MODEL_NAME, _TRUNCATE_DIM
+from monkeygrab.application.index_fingerprint import _EMBEDDING_ID
+
+
+def test_embedding_id_names_the_model_and_dimension_the_worker_actually_loads():
+    # jina_clip_worker.py is the process that calls
+    # SentenceTransformer(_MODEL_NAME, ...) and encodes with
+    # truncate_dim=_TRUNCATE_DIM. Bumping either without a matching bump to
+    # _EMBEDDING_ID would silently leave the recipe fingerprint claiming an
+    # embedding no index was actually built with.
+    assert _EMBEDDING_ID == f"{_MODEL_NAME}@{_TRUNCATE_DIM}"


### PR DESCRIPTION
## Summary

Triaged leftovers from the #23 measurement-integrity review, all under `src/monkeygrab/application/index_fingerprint.py`, `src/monkeygrab/adapters/vectorstore/faiss_store.py` and `tests/eval/compare_runs.py`.

- **`recipe_version`** (the headline, time-sensitive): `index_recipe()` covers configuration but not the *code* that turns a recipe into stored content -- a chunking-algorithm or contextual-prompt change alters stored chunks without moving a single config value. `_RECIPE_VERSION` is a hand-maintained constant a human bumps when that code changes; the module docstring names what counts (chunking algorithm, contextual prompt, image extraction) and what does not (a config value -- those already invalidate on their own).
  - **Reindex cost of `recipe_version` itself: zero.** Version 1 = "the recipe exactly as it existed before `recipe_version` existed," serialized **by omission** while `_RECIPE_VERSION == 1` -- the key never appears in the JSON or the hash. Pinned two ways: `test_recipe_version_is_omitted_at_v1_and_matches_pre_change_main` hardcodes the fingerprint of a contextual-off `AppConfig` computed on `main@8b4f16d` and asserts it hasn't moved; `test_recipe_version_bump_actually_changes_the_recipe_and_the_fingerprint` monkeypatches the constant to 2 and asserts the key actually appears and the fingerprint actually moves -- added after review caught that the first test alone would stay green even if the two `if _RECIPE_VERSION != 1: ...` lines were deleted outright.
- **`contextual_num_ctx`**: added inside the existing `if config.flags.usar_contextual_retrieval:` branch, same rationale as `contextual_model`/`contextual_doc_chars`.
  - **Reindex cost, corrected after review: currently zero, for everyone.** `usar_contextual_retrieval` defaults to `True`, so this field does move the fingerprint of a default `AppConfig` (`70b88d55bb078bf9` on main -> `b4bc32189fbd3efe` here, now pinned by `test_default_app_config_fingerprint_is_pinned`). But no product code path reads or writes `fingerprint.txt` today -- only `tests/eval/run_eval.py` does; wiring it into `rag/engine/indexing.py` and the CLI/web is #36, still open. So nothing gets reindexed by this change right now, in the product or in the eval gate (the eval forces the contextual stage off, so its fingerprint is untouched either way). The move only matters, and becomes a real one-time reindex for anyone running the contextual stage on, once #36 lands.
- **`write_fingerprint`**: now writes to a temp path + `os.replace()`, and wraps `OSError` into the same `RuntimeError`-naming-the-store-directory shape `_save`/`_rewrite` use. Rebased on #52 (merged) -- `_save`/`_rewrite` there now stage all three files before replacing any of them; `write_fingerprint` is a single file, so it already matches that convention's spirit without needing the multi-file staging. `test_write_fingerprint_failure_does_not_destroy_the_previous_value` pins the actual reason for the change: a failed write on a second call must not clobber the fingerprint a prior successful call recorded.
- **`_EMBEDDING_ID` binding**: `tests/unit/test_embedding_id_binding.py` lives outside both `monkeygrab.application` and `monkeygrab.adapters` and imports both `index_fingerprint._EMBEDDING_ID` and `jina_clip_worker`'s `_MODEL_NAME`/`_TRUNCATE_DIM` (the constants the worker actually passes to `SentenceTransformer`/`encode(truncate_dim=...)`), asserting they agree. Neither layer may import the other, so a plain test module does the comparison instead.
- **Test coverage**: invalidation tests for `chunk_overlap`, `min_chunk_length`, `contextual_doc_chars`; a pin that deleting a store's last source drops its fingerprint and that `write_fingerprint` overwrites rather than appends; an exhaustiveness test that `build_summary`'s `retrieval_only`/`answer` split still sums to `overall` for an unseen `case_type`; the untested side of both `compare_runs` guards. Also added, after review: `test_contextual_prompt_template_is_pinned` (`tests/unit/application/test_index_corpus.py`) hashes the situational-context prompt's fixed wording, so an edit to it -- one of the three things `_RECIPE_VERSION`'s own comment names -- fails a test instead of shipping unnoticed.
- **Cosmetic**: removed `compare_runs`' `if total else 0.0` -- unreachable, since `_reject_unusable` already guarantees a non-empty report before that line runs. `compare()` now takes `label_a`/`label_b` (default `"report_a"`/`"report_b"` for existing callers) and `main()` passes the real file paths, so a rejection names the file instead of the parameter name.

`grade.py`, `gold_cases.jsonl` and `baseline_min_pass_rate.txt` are byte-identical to `main` -- only tests were added to `tests/eval/`.

## Review round

An independent Opus review confirmed all four fingerprint values, the recipe-version omission, that the default moves *exclusively* because of `contextual_num_ctx`, that the eval corpus fingerprint doesn't move, that the removed `compare_runs` branch was genuinely unreachable, that `write_fingerprint` matches #52's convention with a clean trial merge, and that the gate files are untouched. It flagged two must-fix gaps (both closed, see `test_recipe_version_bump_actually_changes_the_recipe_and_the_fingerprint` and `test_default_app_config_fingerprint_is_pinned` above) and one overstated claim (the reindex-cost correction above). All addressed in the second commit.

## Test plan

- [x] `pytest -q -p no:randomly`: **352 passed, 1 skipped**, rebased on current `origin/main` (334/1, after #51/#52/#53/#61) -- the +18 across both commits is exactly the tests added here, nothing dropped.
- [x] `ruff check .` clean.
- [x] No `tests/characterization/` test touched or failed.
- [x] Manually verified the new `recipe_version` test actually catches the regression it targets: deleting the two `if _RECIPE_VERSION != 1: ...` lines makes it fail (`KeyError`) while the rest of the suite stays green; restored before committing.
- [x] Fingerprint of a default `AppConfig`: `70b88d55bb078bf9` (before) -> `b4bc32189fbd3efe` (after), now pinned -- costs nothing today per the corrected reindex-cost note above.
- [x] Fingerprint of a contextual-off `AppConfig` (isolates `recipe_version`'s own effect): `3802ef9e11d5e813` -> `3802ef9e11d5e813`, unchanged, pinned both at rest and under a version bump.

Closes #37.

🤖 Generated with [Claude Code](https://claude.com/claude-code)