### PR TITLE
Document MINERU_BIN/MINERU_CACHE_DIR and fix non-Windows MinerU resolution

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,7 @@
 # `rag/chat_pdfs.py`. The process environment ALWAYS wins over this file, so a
 # value exported in your shell overrides the same key here.
 #
-# Every value below is the built-in DEFAULT baked into `rag/chat_pdfs.py`.
+# Every value below is the built-in DEFAULT baked into the code.
 # All lines are commented out: uncomment only what you want to change.
 # ─────────────────────────────────────────────────────────────────────────────
 
@@ -36,7 +36,8 @@
 
 
 # ── Ollama connection ───────────────────────────────────────────────────────
-#OLLAMA_BASE_URL=http://localhost:11434
+#OLLAMA_HOST=http://127.0.0.1:11434             # read natively by the `ollama` client and by the web control panel's Ollama probes (/api/ollama, /api/models)
+#OLLAMA_BASE_URL=http://localhost:11434         # only read by the CLI's own startup reachability check; generation/embedding calls do not use it (tracked in #62)
 
 
 # ── Ollama context windows (tokens) ─────────────────────────────────────────

--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,12 @@
 #RERANKER_DEVICE=                               # force cuda|cpu; empty selects cuda when available
 
 
+# ── MinerU (PDF/table extraction, external CLI, not a Python dependency) ────
+#MINERU_BIN=                                    # path to the mineru executable; defaults to .venv-mineru/Scripts/mineru.exe (Windows) or .venv-mineru/bin/mineru (Linux/Mac), whichever exists
+#MINERU_CACHE_DIR=                              # extraction cache directory; defaults to <repo_root>/.mineru_cache
+#MINERU_MODEL_SOURCE=local                      # forwarded to the MinerU CLI; "local" reuses the already-downloaded HuggingFace cache without attempting a download
+
+
 # ── Ollama connection ───────────────────────────────────────────────────────
 #OLLAMA_BASE_URL=http://localhost:11434
 

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ The rest of the stack is not an Ollama model:
 
 > [!NOTE]
 > MinerU is an external CLI, and `jina_clip` runs in an isolated interpreter
-> because its dependencies
+> that requires a CUDA GPU, because its dependencies
 > conflict with the product's — see [`src/monkeygrab/README.md`](src/monkeygrab/README.md).
 
 ---

--- a/README.md
+++ b/README.md
@@ -169,9 +169,9 @@ The rest of the stack is not an Ollama model:
 | **PDF extraction** | [MinerU](https://github.com/opendatalab/MinerU), structured text, tables and figures | fixed |
 
 > [!NOTE]
-> MinerU is an external CLI, and `jina_clip` runs in an isolated interpreter
-> that requires a CUDA GPU, because its dependencies
-> conflict with the product's — see [`src/monkeygrab/README.md`](src/monkeygrab/README.md).
+> MinerU is an external CLI, and `jina_clip` runs in an isolated interpreter,
+> which needs a CUDA GPU, because its dependencies conflict with the
+> product's — see [`src/monkeygrab/README.md`](src/monkeygrab/README.md).
 
 ---
 

--- a/src/monkeygrab/adapters/extraction/mineru_extractor.py
+++ b/src/monkeygrab/adapters/extraction/mineru_extractor.py
@@ -82,11 +82,31 @@ _DISCARDED_BLOCK_TYPES = frozenset({"page_number", "footer", "page_footnote", "a
 
 def _default_mineru_bin() -> str:
     """Resolve the configured MinerU binary: ``MINERU_BIN`` env var, else the
-    project's isolated venv."""
+    project's isolated venv, probing both layouts the same way
+    ``composition._isolated_python`` probes both ``python.exe`` and
+    ``python`` -- whichever of the two conventional paths actually exists
+    wins, so ``MINERU_BIN`` is only needed as an override, not as a
+    non-Windows requirement.
+
+    Raises:
+        RuntimeError: Neither conventional path exists and ``MINERU_BIN`` is
+            unset.
+    """
     configured = os.getenv("MINERU_BIN", "").strip()
     if configured:
         return configured
-    return os.path.join(_PROJECT_ROOT, ".venv-mineru", "Scripts", "mineru.exe")
+
+    windows_path = os.path.join(_PROJECT_ROOT, ".venv-mineru", "Scripts", "mineru.exe")
+    posix_path = os.path.join(_PROJECT_ROOT, ".venv-mineru", "bin", "mineru")
+    for candidate in (windows_path, posix_path):
+        if os.path.isfile(candidate):
+            return candidate
+
+    raise RuntimeError(
+        f"MinerU binary not found at {windows_path!r} or {posix_path!r}. "
+        "Install MinerU in the isolated venv (.venv-mineru) or set MINERU_BIN "
+        "to its executable."
+    )
 
 
 def _default_cache_dir() -> Path:
@@ -391,7 +411,9 @@ class MineruExtractor:
         """Args:
             mineru_bin: Path to the MinerU executable, or a bare command to
                 resolve on PATH. Defaults to the ``MINERU_BIN`` env var, then
-                the project's isolated venv (``.venv-mineru``).
+                the project's isolated venv (``.venv-mineru``), probing both
+                the Windows (``Scripts\\mineru.exe``) and POSIX
+                (``bin/mineru``) layouts.
             cache_dir: Directory cached extractions are stored under.
                 Defaults to the ``MINERU_CACHE_DIR`` env var, then
                 ``<repo_root>/.mineru_cache``.

--- a/src/monkeygrab/adapters/extraction/mineru_extractor.py
+++ b/src/monkeygrab/adapters/extraction/mineru_extractor.py
@@ -459,13 +459,17 @@ class MineruImageExtractor:
     the CLI only once.
 
     Per the ``ImageExtractor`` port's documented carve-out from this
-    project's hard-fail default, CLI-level failures (binary missing, exit
-    code != 0, empty output) are logged and swallowed here, returning ``{}``
-    -- exactly like the image port's "cannot open the file"
-    case. This does not reopen the hard-fail question SECTION 3 exists to
-    close: ``IndexCorpus`` always calls the ``PdfExtractor`` first, so a
-    broken MinerU installation already aborts the whole PDF via
-    ``MineruExtractor`` before this adapter would ever run in production.
+    project's hard-fail default, CLI-level failures during ``extract`` (a
+    configured binary that turns out to be missing at run time, exit code
+    != 0, empty output) are logged and swallowed here, returning ``{}`` --
+    exactly like the image port's "cannot open the file" case. Resolving the
+    *default* binary (``mineru_bin=None``) happens eagerly at construction,
+    via ``_default_mineru_bin``, and raises there instead -- before this
+    carve-out ever applies. This does not reopen the hard-fail question
+    SECTION 3 exists to close: ``IndexCorpus`` always calls the
+    ``PdfExtractor`` first, so a broken MinerU installation already aborts
+    the whole PDF via ``MineruExtractor`` before this adapter would ever run
+    in production.
     """
 
     def __init__(

--- a/src/monkeygrab/composition.py
+++ b/src/monkeygrab/composition.py
@@ -23,7 +23,7 @@ def _isolated_python() -> str:
             return str(candidate)
     raise FileNotFoundError(
         "The multimodal pipeline needs the isolated MinerU environment at "
-        f"{candidates[0]}"
+        f"{candidates[0]} or {candidates[1]}"
     )
 
 

--- a/tests/unit/adapters/test_mineru_extractor.py
+++ b/tests/unit/adapters/test_mineru_extractor.py
@@ -15,7 +15,6 @@ partial output.
 
 import base64
 import json
-import os
 import sys
 from pathlib import Path
 
@@ -164,12 +163,40 @@ def test_default_mineru_bin_reads_the_mineru_bin_env_var(monkeypatch, tmp_path):
     assert module._default_mineru_bin() == str(bin_path)
 
 
-def test_default_mineru_bin_falls_back_to_the_project_venv(monkeypatch):
+def test_default_mineru_bin_falls_back_to_the_windows_venv_layout(monkeypatch, tmp_path):
+    """Windows layout is probed first, mirroring composition._isolated_python."""
     monkeypatch.delenv("MINERU_BIN", raising=False)
+    monkeypatch.setattr(module, "_PROJECT_ROOT", str(tmp_path))
+    windows_bin = tmp_path / ".venv-mineru" / "Scripts" / "mineru.exe"
+    windows_bin.parent.mkdir(parents=True)
+    windows_bin.write_text("fake binary", encoding="utf-8")
 
-    resolved = module._default_mineru_bin()
+    assert module._default_mineru_bin() == str(windows_bin)
 
-    assert resolved.endswith(os.path.join(".venv-mineru", "Scripts", "mineru.exe"))
+
+def test_default_mineru_bin_falls_back_to_the_posix_venv_layout(monkeypatch, tmp_path):
+    """Non-Windows layout: only ``.venv-mineru/bin/mineru`` exists.
+
+    Driven by creating (or not creating) files under a monkeypatched
+    ``_PROJECT_ROOT`` rather than the host OS, since this suite runs on
+    Windows -- the Windows candidate is deliberately absent so the function
+    must fall through to the POSIX one.
+    """
+    monkeypatch.delenv("MINERU_BIN", raising=False)
+    monkeypatch.setattr(module, "_PROJECT_ROOT", str(tmp_path))
+    posix_bin = tmp_path / ".venv-mineru" / "bin" / "mineru"
+    posix_bin.parent.mkdir(parents=True)
+    posix_bin.write_text("fake binary", encoding="utf-8")
+
+    assert module._default_mineru_bin() == str(posix_bin)
+
+
+def test_default_mineru_bin_raises_when_neither_venv_layout_exists(monkeypatch, tmp_path):
+    monkeypatch.delenv("MINERU_BIN", raising=False)
+    monkeypatch.setattr(module, "_PROJECT_ROOT", str(tmp_path))
+
+    with pytest.raises(RuntimeError, match="MinerU binary not found"):
+        module._default_mineru_bin()
 
 
 def test_missing_binary_raises_an_actionable_error(tmp_path):


### PR DESCRIPTION
## Summary

Two pre-existing documentation gaps from issue #41.

**1. `.env.example` was incomplete despite the README's completeness claim.**
`MINERU_BIN` and `MINERU_CACHE_DIR` are read by
`src/monkeygrab/adapters/extraction/mineru_extractor.py` and were undocumented.
Also added `MINERU_MODEL_SOURCE`, which the adapter forwards to the MinerU CLI
subprocess (honored via `env.setdefault` if already present in the ambient
environment, e.g. loaded from `.env`) even though it isn't read via a plain
`os.getenv`/`AppConfig` field. Verified completeness with a full-codebase grep
of `os.getenv`/`os.environ`/`monkeygrab.config.env`'s `read_env_*` against
every variable already in `.env.example` -- no other gaps found.

**2. `_default_mineru_bin()` had no POSIX branch.** It returned the Windows
`.venv-mineru\Scripts\mineru.exe` path unconditionally, so a Linux/macOS user
was rescued only by an active venv on `PATH` or by already knowing
`MINERU_BIN` existed. It now probes both the Windows and POSIX venv layouts,
mirroring the existing precedent in `composition._isolated_python`, and
raises a `RuntimeError` naming both paths tried plus the `MINERU_BIN`
override when neither exists -- this is path resolution, not the silent
degradation the repo's hard-fail policy (CLAUDE.md §1 rule 8) forbids.

**3. README's "What it runs on" section never mentioned the CUDA
requirement**, even though it's the section named for exactly that question.
Added one clause to the existing MinerU/Jina CLIP isolation note.

## Test plan

- [x] `tests/unit/adapters/test_mineru_extractor.py` -- rewrote the stale
      Windows-only default test into three: Windows layout, POSIX layout
      (pinned by creating the file under a monkeypatched `_PROJECT_ROOT`,
      not by relying on the host OS), and the raise when neither exists.
- [x] `pytest -q -p no:randomly` -- full suite green (331 passed, 1 skipped
      vs. 329 passed, 1 skipped on `main` at this branch's base; net +2 new
      tests after retiring the one stale test).
- [x] `ruff check .` -- clean.

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)