### PR TITLE
Add block-C configuration search harness (#31)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -78,6 +78,7 @@ tests/
   unit/                      domain/ports/config/application + adapters, doubled infrastructure
   characterization/          pins current pipeline behavior — do not edit (§1 rule 9)
   eval/                      gold-case evaluation gate (§5) — do not touch without agreement
+harness/                  Configuration search harness (issue #31); not product — see harness/README.md
 packaging/                PyInstaller desktop app build (see §3)
 docs/design/               Architecture design docs; current: 2026-07-26-monkeygrab-v2.md
 docs/README.md             Documentation standard
@@ -138,13 +139,14 @@ Two gates, deliberately not one — a job that doubles infrastructure is never
 presented as pipeline coverage, and vice versa:
 
 - **Fast gate** (`.github/workflows/ci.yml`, every PR, hosted runner, no GPU/Ollama/model
-  downloads): lint (`ruff`), `tests/unit` + `tests/eval`'s grader against
-  test doubles (`architecture` job — must import nothing but the standard
-  library, since it exercises `domain`/`ports`/`config`/`application`),
-  frontend build (`pnpm install --frozen-lockfile` + `pnpm run lint` +
-  `pnpm run build`), and the full `pytest` suite with real dependencies but a
-  doubled/absent Ollama server (`engine` job — Ollama-dependent tests skip
-  themselves when no server answers).
+  downloads): lint (`ruff`), `tests/unit` + `tests/eval`'s grader + `harness/tests`
+  against test doubles (`architecture` job — must import nothing but the
+  standard library, since it exercises `domain`/`ports`/`config`/`application`
+  and the harness's own fake-evaluator tests), frontend build
+  (`pnpm install --frozen-lockfile` + `pnpm run lint` + `pnpm run build`), and
+  the full `pytest` suite with real dependencies but a doubled/absent Ollama
+  server (`engine` job — Ollama-dependent tests skip themselves when no
+  server answers).
 - **Full gate** (`.github/workflows/full-eval.yml`, `workflow_dispatch` only,
   self-hosted GPU runner with Ollama installed): runs the real pipeline —
   Ollama generation, Jina CLIP embeddings, hybrid BM25+semantic retrieval,
@@ -205,9 +207,12 @@ python rag/web/app.py                          # http://localhost:5000 (ES/EN/VA
 cd rag/web/frontend && pnpm install && pnpm run build
 
 # Tests / CI gates
-pytest                                          # full suite (unit + characterization + eval grader + loose tests)
-pytest tests/unit tests/eval --ignore=tests/unit/adapters   # what the fast "architecture" CI job runs
+pytest                                          # full suite (unit + characterization + eval grader + harness + loose tests)
+pytest tests/unit tests/eval harness/tests --ignore=tests/unit/adapters   # what the fast "architecture" CI job runs
 python tests/eval/run_eval.py --models <model...>           # full gate locally; needs Ollama + GPU
+
+# Configuration search harness (issue #31) — not product, see harness/README.md
+python -m harness.cli --dry-run --max-iterations 3          # smoke-test the loop, no GPU/Ollama needed
 
 # Misc
 git check-ignore -v <path>

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,11 @@ jobs:
     # tests that compare against the original implementation) are skipped by
     # tests/conftest.py, which detects that the stack is absent. No path list
     # lives here: it would go stale the moment a test is added.
+    #
+    # harness/tests belongs here, not in the "engine" job below: the block-C
+    # search harness (issue #31) is tested entirely against fake evaluators
+    # and AppConfig (pure stdlib), so it needs nothing this job does not
+    # already have.
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -58,7 +63,7 @@ jobs:
       - name: Install test runner
         run: pip install pytest
       - name: Run
-        run: pytest tests/unit tests/eval -q --no-header
+        run: pytest tests/unit tests/eval harness/tests -q --no-header
 
   frontend:
     name: Frontend build

--- a/harness/README.md
+++ b/harness/README.md
@@ -12,6 +12,12 @@ candidate so a run can be reconstructed. Implements
 > `gold_cases.jsonl` and `baseline_min_pass_rate.txt` stay byte-identical —
 > enforced by `harness/tests/test_harness_boundaries.py`, which parses every
 > harness module's imports and write calls with `ast`, not by convention.
+> Proven, not assumed: `test_adversarial_bypass_module_is_caught_by_every_check`
+> parses a module doing everything a #65 PR review found the first version
+> of these checks missed (`importlib.import_module("grade")`, a dotted
+> `import tests.eval.grade`, `shutil.copyfile`/`os.replace`/`os.remove`
+> against the three protected files, a `"grade" + ".py"` string built to
+> dodge a literal match) and asserts each attack is caught.
 
 ## Why this is not product
 
@@ -46,19 +52,33 @@ tests/                  Unit tests — no GPU, no Ollama, no model downloads (se
 ## The declared search space
 
 Written by hand as data in `search_space.py`, never inferred by
-introspecting `AppConfig` — each parameter multiplies the space against a
-budget of three or four full-search-set candidates per night (~2.8 h each).
-Validated at import time: every declared value is applied via
+introspecting `AppConfig` — each parameter is a visible decision about what
+the loop is allowed to search, independent of how expensive an evaluation
+is. Validated at import time: every declared value is applied via
 `AppConfig().with_overrides(**{key: value})`, which raises `ValueError` on
 an unknown section or field — confirmed in this PR that it really does raise
 on every unknown field, so the space cannot drift from the config it
 searches without a red test.
 
+> [!NOTE]
+> **The design's original evaluation-time estimate was wrong by a factor of
+> ~6.** Section 4 assumed ~2.8 h/candidate (three or four candidates a
+> night); issue #27's keep-alive fix removed a per-case cold model load
+> that estimate baked in. A full search-set evaluation (32 cases) now costs
+> ~13 min, measured 2026-08-12 against
+> `tests/eval/runs/20260812T194812Z_mineru-jina_clip-faiss.json` (local,
+> gitignored) — a night now fits dozens of candidates, not three or four.
+> This does not change anything about how the space is declared (see
+> above); it does change the case for the LLM proposer, see "Proposers"
+> below.
+
 **Index-time keys are excluded and the exclusion is enforced,** not
 remembered: `chunking.*` and `flags.usar_contextual_retrieval`/
 `usar_embeddings_imagen` change what gets stored, forcing a full MinerU +
-jina-clip reindex on top of the 2.8 h a candidate already costs. Declaring
-one is a red test (`INDEX_TIME_KEYS`, checked by `_validate_declared_space`).
+jina-clip reindex per candidate — far more expensive than the ~13 min a
+retrieval/generation-only evaluation now costs, whatever the exact multiple
+turns out to be once block B (#30) measures it. Declaring one is a red test
+(`INDEX_TIME_KEYS`, checked by `_validate_declared_space`).
 
 **`weight_semantic_rrf`/`weight_bm25_rrf` are one knob, not two.**
 `src/monkeygrab/application/rrf_fusion.py::fuse_semantic_and_keyword` computes
@@ -145,11 +165,14 @@ fake evaluator that raises on a declared key makes startup fail loudly
   `harness/tests/test_evaluator.py` asserts the blind set is disjoint from
   both the search set and the fast tier.
 - **Fast tier** (13 fixed ids, `fast_tier.txt`) — regression filter only, it
-  **never declares an improvement**. 8 answered cases (~200 s each) + 5
-  retrieval-only cases (~4.5 s each) ≈ 27 min, matching the design's ~32 min
-  budget. Includes all 5 of today's known search-set failures (three
-  figure-retrieval failures cost ~4 s each, nearly free to include, and give
-  the regression filter real signal on the retrieval side).
+  **never declares an improvement**. Costs ~4 min at current measured rates
+  (8 answered cases × ~28.5 s + 5 retrieval-only × ~4.1 s), against a ~13 min
+  full search set — a real but much smaller saving than the design's ~32 min
+  estimate assumed (see the search-space note above); its job is rejecting a
+  bad candidate before it can contaminate the ratchet, not the minutes it
+  happens to save. Includes all 5 of today's known search-set failures
+  (three figure-retrieval failures cost ~4 s each, nearly free to include,
+  and give the regression filter real signal on the retrieval side).
 
 ## Objective, constraint, noise floor
 
@@ -169,13 +192,43 @@ tracked alongside so the exclusion mechanism is auditable before it is ever
 needed — today `raw == adjusted`.
 
 **Constraint, per bucket, not blended.** Answered cases (`factual_number`/
-`factual_concept`) cost ~200 s; retrieval-only cases (`figure_retrieval`/
-`table_retrieval`) cost ~4 s — a ~50x gap. A single blended median is
-dominated by whichever bucket is larger and would let a candidate trade
-retrieval quality for fewer generator calls without the constraint
-noticing. `loop.py` checks each bucket's median against
-`1.20 ×` its own reference median independently; a breach in either bucket
-is `rejected_latency`, even if the candidate scored higher.
+`factual_concept`) cost ~28.5 s; retrieval-only cases (`figure_retrieval`/
+`table_retrieval`) cost ~4.1 s (both measured 2026-08-12, same run cited
+above; the gap was ~50x before issue #27's keep-alive fix and is ~7x now —
+narrower, not gone). A single blended median is dominated by whichever
+bucket is larger and would let a candidate trade retrieval quality for
+fewer/cheaper generator calls without the constraint noticing. `loop.py`
+checks each bucket's median against `1.20 ×` its own reference median
+independently; a breach in either bucket is `rejected_latency`, even if the
+candidate scored higher.
+
+**A candidate cannot buy the objective with the retrieval-only bucket.**
+The blended objective by itself has the same blind spot as a blended
+latency median: a candidate that flips several `figure_retrieval`/
+`table_retrieval` cases to FAIL while flipping more answered cases to PASS
+would otherwise read as a plain improvement — exactly the trade design doc
+§2's "Consecuencia para el arnés" warns a blended score would hide. Found
+in a #65 PR review; `loop.py` now also rejects (`rejected_regression`, at
+the search-set stage) any candidate whose retrieval-only bucket loses cases
+net against the reference, paired by id, regardless of the blended
+objective. `LedgerEntry.summary` also carries a `by_case_type` breakdown
+(mirroring `run_eval.py`'s own `build_summary`) so the trade is visible in
+the ledger even for an iteration this check does not reject.
+
+**An `inconclusive` verdict, never a false "improvement" or "regression".**
+`tests/eval/run_eval.py` marks a case `infrastructure_error` when it could
+not be evaluated at all (dead/overloaded Ollama, a retrieval exception) and
+refuses to compare such a run against the baseline. Reading those records
+as ordinary failures would let a dead Ollama masquerade as a retrieval
+collapse (fast tier: a good candidate wrongly `rejected_regression`) or
+silently deflate the reference and inflate every later candidate into a
+false `accepted` — found in the same review, and precisely the "loop sobre
+una medida que miente produce basura reproducible" failure the design doc
+opens with. `loop.py` gives any iteration with such a record the
+`inconclusive` verdict (no ratchet move, still written to the ledger, still
+counts toward `--patience`) and raises `evaluator.InconclusiveEvaluationError`
+before the loop even starts if the **reference** measurement itself carries
+one — no ratchet baseline can be trusted in that case.
 
 **Noise floor: 0 cases.** Measured 2026-07-29 (design doc, criterion 1
 note): two runs of the same configuration and code, same index, zero flips
@@ -199,10 +252,15 @@ the quantitative case for block B (#30, corpus expansion) — sharper than the
 design doc's own estimate — not a reason to withhold the harness.
 
 > [!NOTE]
-> All of the numbers above come from three local, gitignored artifacts
+> All of the numbers above come from four local, gitignored artifacts
 > (`tests/eval/runs/20260729T020233Z_...json`, `...040824Z...`,
-> `...081129Z...json`) — `tests/eval/runs/` is in `.gitignore`, so they are
-> not reproducible from a fresh clone. They are cited, not shipped.
+> `...081129Z...json`, `...20260812T194812Z...json`) — `tests/eval/runs/` is
+> in `.gitignore`, so they are not reproducible from a fresh clone. They are
+> cited, not shipped. The three 2026-07-29 runs predate issue #27's
+> keep-alive fix and are cited for their PASS/FAIL evidence (noise floor,
+> sabotage flips, resolution limit), which the fix did not touch
+> (`compare_runs.py` against the healthy 2026-07-29 run reports 51 cases
+> unchanged); the 2026-08-12 run is cited for current timing.
 
 ## Proposers
 
@@ -210,6 +268,37 @@ design doc's own estimate — not a reason to withhold the harness.
 reference configuration, one field at a time, in `proposal_order()`,
 skipping infeasible points and points already in the ledger. Reproducible
 from the ledger alone.
+
+> [!NOTE]
+> **Why keep an LLM proposer at all, now that evaluation is cheap.** Design
+> doc §4 originally argued: ~2.8 h/evaluation, three or four candidates a
+> night, blind/grid search is useless at that budget, therefore an LLM
+> reading actual failures is the natural fit. That argument no longer holds
+> at ~13 min/evaluation (a night fits dozens of candidates, see "The
+> declared search space" above) — corrected in the design doc, PR #68. This
+> is **not** evidence the deterministic proposer is sufficient on its own,
+> and it is not a reason to drop `LlmProposer`: it means criterion 5's
+> controlled comparison between the two (design doc §2) is now cheap enough
+> to settle with evidence instead of an argument from budget. Keeping both
+> was the right call before this correction and is better justified after
+> it, not worse.
+
+> [!IMPORTANT]
+> **Scope, stated plainly (a #65 PR review asked for this explicitly):
+> stage 1 is a single-field sweep from a fixed reference, not a compounding
+> hill climb.** `reference` never changes during a `run_loop` call, even
+> after an acceptance — matching `GridProposer`'s own spec-given definition
+> ("coordinate descent from **the reference configuration**", issue #31 spec
+> §5.4). Two accepted single-field changes cannot combine into one
+> two-field configuration within a run, and after the first acceptance the
+> ratchet has already risen, so a further single-field change measured from
+> the *original* reference is unlikely to clear it — `--patience` typically
+> fires not long after the first success. This matches criterion 5 (recover
+> from one deliberately worsened point) and the design doc's framing of
+> block C as proving the search mechanism works, not as shipping a
+> multi-step optimizer. Rebinding the reference to an accepted candidate
+> (a real hill climb) is future work, not something "ratchet" already
+> implies.
 
 `LlmProposer` prompts a local Ollama model (default `gemma4:e4b`,
 `http://localhost:11434`) with the declared space, the ledger history and
@@ -241,18 +330,51 @@ python -m harness.cli --proposer llm --max-iterations 8 --patience 3
 in-process synthetic landscape. It exercises the wiring, not the pipeline —
 it has no opinion about which real configuration is better.
 
+> [!NOTE]
+> **The default `--ledger-dir` (`harness/ledger/`) is meant to be the same
+> directory across many invocations over time** — a #65 PR review asked
+> this explicitly. "Append-only, versioned, one entry per iteration" (design
+> doc §4) spans the whole history a team accumulates, not one run:
+> `GridProposer`'s "already tried" check and `next_iteration_number` both
+> read the directory back via `ledger.read_history` to continue where the
+> last invocation left off. `--dry-run` deliberately does NOT default to
+> this directory (a fresh temp dir instead), precisely so demo runs never
+> mix into that history. A second real invocation against a non-empty
+> `--ledger-dir` — including the default, after one real run — used to
+> crash (`ledger.read_history` fed `cli.py`'s own `report.json` to
+> `LedgerEntry(**data)`); fixed, see `harness/tests/test_ledger.py`'s
+> `test_read_history_ignores_a_report_json_in_the_same_directory`.
+
+`evaluator.real_evaluate` maps `run_eval.evaluate()`'s actual return shape
+(`{"records": [...], "config": {"dev": ..., "blind": ...}}`, confirmed
+against the sibling PR's contract) — an earlier draft of this adapter
+assumed `{"results": [...], "effective_config": ...}` and would have raised
+`KeyError` on the very first real call, found in the same review before
+`evaluate()` had even landed. `harness/tests/test_evaluator.py` exercises
+the mapping against a stub `run_eval` module carrying the real contract, so
+this stays checked rather than only checked once #56 merges.
+
 ## Testing
 
 All 13 required behaviors from the implementation spec are covered under
 `harness/tests/`, entirely against fake/deterministic evaluators — no GPU,
 no Ollama, no model downloads, matching this repo's fast CI gate (`tests/
 conftest.py`'s pattern of skipping engine-dependent tests where the stack is
-absent; `harness/tests` needs nothing from that stack at all).
+absent; `harness/tests` needs nothing from that stack at all). A #65 PR
+review added coverage the original 13 did not require but a real multi-hour
+run depends on: `LlmProposer._real_call`'s bounded timeout and its fallback
+on a connection failure/non-2xx status/non-JSON body/missing `requests`
+install (all against a fake `requests` module, never a real Ollama server),
+`real_evaluate`'s mapping of the sibling PR's actual return shape (against a
+stub `run_eval` module), the `inconclusive` verdict, the retrieval-only
+net-loss rejection, and the adversarial-module regression test for the
+boundary checks.
 
 > [!IMPORTANT]
 > `harness/tests/test_criterion5_simulated.py` proves the **search logic**
 > recovers from a deliberately worsened point in a synthetic, fully
 > controlled landscape — for both proposers. It does **not** prove the real
-> pipeline improves. The real criterion-5 run (design doc §2) needs the GPU
-> and ~2.8 h/candidate and is pending measurement; nothing in this PR claims
-> it ran.
+> pipeline improves. The real criterion-5 run (design doc §2) still needs
+> the GPU and Ollama — now at ~13 min/full-search-set-evaluation rather than
+> the ~2.8 h originally assumed (see "The declared search space" above) —
+> and is pending measurement; nothing in this PR claims it ran.

--- a/harness/README.md
+++ b/harness/README.md
@@ -1,0 +1,258 @@
+# `harness/` — block-C configuration search (issue #31)
+
+An optimiser that searches for a pipeline configuration with a higher
+gold-case pass rate, subject to a hard latency ceiling, recording every
+candidate so a run can be reconstructed. Implements
+[`docs/design/2026-07-28-loop-automejorable.md`](../docs/design/2026-07-28-loop-automejorable.md)
+§4 ("Arquitectura del arnés").
+
+> [!CAUTION]
+> The harness may **read and run** the evaluation gate under `tests/eval/`.
+> It never redefines how the evaluation scores. `tests/eval/grade.py`,
+> `gold_cases.jsonl` and `baseline_min_pass_rate.txt` stay byte-identical —
+> enforced by `harness/tests/test_harness_boundaries.py`, which parses every
+> harness module's imports and write calls with `ast`, not by convention.
+
+## Why this is not product
+
+It lives at the repo root, outside the hexagonal core (`src/monkeygrab/`)
+and the interface layer (`rag/`), and consumes the evaluation gate as a
+library the same way `tests/eval/run_eval.py` does. It has no product
+runtime dependents: nothing under `rag/` or `src/monkeygrab/` imports it.
+
+**Repo rule 6** ("do not flip pipeline flags without agreement") governs the
+**product's** defaults — `rag/chat_pdfs.py`'s module-level flags, what ships.
+The harness flips flags only inside its own candidate evaluations, run
+through the gate's own config plumbing, and never writes a winner back into
+the product. The loop proposes; a human integrates (design doc §5). Rule 6
+is about unreviewed changes reaching users, not about an optimiser measuring
+what a flag does — this is exactly the loop's job.
+
+## Layout
+
+```
+search_space.py      Declared tunables, index-time exclusions, feasibility, reachability gate metadata
+fast_tier.txt         Fixed 13-case regression filter (never declares an improvement)
+unreachable_cases.txt Cases excluded from the maximised scalar — starts empty, evidence-backed
+ledger.py              Append-only evidence ledger (JSON per iteration + index.jsonl)
+proposers.py            GridProposer (deterministic control) + LlmProposer (Ollama-backed)
+evaluator.py            Case-set selection, objective/latency math, the real-evaluator adapter
+loop.py                The ratchet, the latency constraint, termination
+cli.py                  Entry point (python -m harness.cli)
+ledger/                 Written evidence (empty until the harness actually runs; not auto-committed)
+tests/                  Unit tests — no GPU, no Ollama, no model downloads (see below)
+```
+
+## The declared search space
+
+Written by hand as data in `search_space.py`, never inferred by
+introspecting `AppConfig` — each parameter multiplies the space against a
+budget of three or four full-search-set candidates per night (~2.8 h each).
+Validated at import time: every declared value is applied via
+`AppConfig().with_overrides(**{key: value})`, which raises `ValueError` on
+an unknown section or field — confirmed in this PR that it really does raise
+on every unknown field, so the space cannot drift from the config it
+searches without a red test.
+
+**Index-time keys are excluded and the exclusion is enforced,** not
+remembered: `chunking.*` and `flags.usar_contextual_retrieval`/
+`usar_embeddings_imagen` change what gets stored, forcing a full MinerU +
+jina-clip reindex on top of the 2.8 h a candidate already costs. Declaring
+one is a red test (`INDEX_TIME_KEYS`, checked by `_validate_declared_space`).
+
+**`weight_semantic_rrf`/`weight_bm25_rrf` are one knob, not two.**
+`src/monkeygrab/application/rrf_fusion.py::fuse_semantic_and_keyword` computes
+`score_final = score_semantic * weight_semantic + score_keyword * weight_keyword`
+and sorts by it — confirmed in this PR by reading the function: it is a
+linear combination used only for ordering, so scaling both weights by any
+positive constant cannot change the sort order; only their ratio matters.
+Only `weight_semantic_rrf` is declared; `weight_bm25_rrf` is always derived
+as `1 - weight_semantic_rrf` (`search_space.expand_overrides`).
+
+`usar_busqueda_hibrida` and `usar_reranker` are deliberately **not**
+tunable: the design doc names turning the reranker off as the known-bad
+sabotage used to prove criterion 2. A knob whose "off" position is the
+control the gate was validated against does not belong in the space the
+same gate searches.
+
+> [!IMPORTANT]
+> This space is not "every field `AppConfig` has" — it is "every field the
+> measurement can actually move", and those two sets differ today by more
+> than one entry. `retrieval.min_question_length` exists on `AppConfig` but
+> is absent here: nothing under `src/monkeygrab/` reads it, the real
+> minimum-length check lives in the legacy `rag.chat_pdfs` globals, so
+> tuning it through `evaluate()` would move nothing. See "Reachability
+> gate" below for the other two ways a declared field can turn out inert.
+
+## Reachability gate
+
+Found 2026-08-12 while building the sibling PR (#56, the
+`tests/eval/run_eval.evaluate()` library API this harness's `evaluator.py`
+wraps): `evaluate()` threads its `AppConfig` into retrieval and indexing,
+but generation went through `rag/engine/generation.py`'s
+`generar_respuesta_silenciosa`, which did not always receive that config.
+**Resolved by #56**, which audited all 48 dotted `AppConfig` fields end to
+end: `context.max_context_chars` and `flags.expandir_contexto` were already
+reaching generation (both are read inside `Answer.select_evidence`, which
+runs under the threaded config — the original finding was overcautious
+about these two); `flags.usar_recomp_synthesis` and
+`flags.usar_optimizacion_contexto` were genuinely dropped (read only in
+`build_user_message`, which phase 2 re-executes under a *fresh* config from
+`wiring.app_config_from_runtime()`) and are now applied through the
+sanctioned `rag.set_pipeline_flags(...)` runtime setter for the duration of
+an evaluation, restored in a `finally` (with a test that an exception
+mid-run still restores the previous globals). All four keys are honoured
+today; `search_space.PENDING_REACHABILITY_KEYS` is empty.
+
+The same audit found a *second*, different way for a declared key to be
+inert: `flags.usar_llm_query_decomposition` is on `AppConfig`, but
+`tests/eval/run_eval.py` builds `Retrieve(..., query_decomposer=None)`
+unconditionally while the product wires it whenever the flag is on and
+defaults to on — the gate measures a retrieval pipeline no user runs, so
+flipping the flag inside an evaluation cannot change anything.
+`evaluate()` would not raise for it either (unlike the first four, this
+isn't a hard-fail case), so it is simply **removed from `SEARCH_SPACE`**
+rather than relied on the gate to catch — filed as issue #64, needs
+sign-off to fix because it will move the pass rate.
+
+The gate itself stays for exactly this reason — two different failure
+classes turned up in one audit, and a future added key gets the same
+protection for free instead of needing someone to remember either lesson:
+
+- `evaluator.verify_reachable` probes the injected evaluator once, at loop
+  startup, with every declared key set simultaneously — before the
+  reference is even measured. If `evaluate()` raises, the loop fails loudly
+  with `ReachabilityError` naming what it can, instead of running a full
+  night on top of a silently inert knob.
+- `GridProposer` walks `search_space.proposal_order()` (currently identical
+  to declaration order, since `PENDING_REACHABILITY_KEYS` is empty — but it
+  would reorder known-reachable keys first the moment a future key needs
+  flagging again), not necessarily `SEARCH_SPACE`'s raw order.
+
+This is structural, the same class of protection as the boundary test: a
+fake evaluator that raises on a declared key makes startup fail loudly
+(`harness/tests/test_reachability_gate.py`), not silently disable the knob.
+
+## Sets
+
+- **Search set** (32 `source: corpus` cases) — the loop's objective.
+- **Blind set** (19 `source: arxiv` cases) — never requested. Structurally
+  unreachable: `evaluator.search_set_case_ids()`/`blind_set_case_ids()` both
+  filter `gold_cases.jsonl` by `source`, and every case-id list `loop.py`
+  ever hands an evaluator comes from one of those two functions or
+  `load_fast_tier()` (itself validated as a search-set subset) — never from
+  a proposer, which can only emit config overrides. Proven, not assumed:
+  `harness/tests/test_evaluator.py` asserts the blind set is disjoint from
+  both the search set and the fast tier.
+- **Fast tier** (13 fixed ids, `fast_tier.txt`) — regression filter only, it
+  **never declares an improvement**. 8 answered cases (~200 s each) + 5
+  retrieval-only cases (~4.5 s each) ≈ 27 min, matching the design's ~32 min
+  budget. Includes all 5 of today's known search-set failures (three
+  figure-retrieval failures cost ~4 s each, nearly free to include, and give
+  the regression filter real signal on the retrieval side).
+
+## Objective, constraint, noise floor
+
+**Objective:** `objective_adjusted` = passing cases on the search set, minus
+cases listed in `unreachable_cases.txt` (excluded from both numerator and
+denominator, not just discounted). `unreachable_cases.txt` starts **empty**
+and stays that way as of 2026-08-12: the `reason` field of all five of
+today's search-set failures was read against the reference gate run and
+none is the generator failing to answer over a figure it saw — three are
+`figure_retrieval` cases (never call the generator) that fail because
+retrieval surfaced text where an image chunk was wanted, exactly what fusion
+weights/`top_k_final`/the reranker threshold move; the other two are a
+number present in the abstract that did not survive into the generated
+answer. All five are inside stage 1's action space. See the file's header
+for the full citation. `objective_raw` (unreachable cases included) is
+tracked alongside so the exclusion mechanism is auditable before it is ever
+needed — today `raw == adjusted`.
+
+**Constraint, per bucket, not blended.** Answered cases (`factual_number`/
+`factual_concept`) cost ~200 s; retrieval-only cases (`figure_retrieval`/
+`table_retrieval`) cost ~4 s — a ~50x gap. A single blended median is
+dominated by whichever bucket is larger and would let a candidate trade
+retrieval quality for fewer generator calls without the constraint
+noticing. `loop.py` checks each bucket's median against
+`1.20 ×` its own reference median independently; a breach in either bucket
+is `rejected_latency`, even if the candidate scored higher.
+
+**Noise floor: 0 cases.** Measured 2026-07-29 (design doc, criterion 1
+note): two runs of the same configuration and code, same index, zero flips
+across 51 gold cases. Independently re-verified in this PR restricted to
+the 32-case search set: still 0 flips. A delta of 0 is not an improvement
+(`loop.NOISE_FLOOR_CASES`).
+
+## Resolution warning
+
+The search set can win at most **5** cases today (27/32 pass on the
+reference run) — below the **~6 net flips** the design doc sets as the
+threshold for a paired difference not attributable to chance. Restricting
+the same paired comparison to the known-catastrophic sabotage used for
+criterion 2 (`RAG_TOP_K_FINAL=1`) gives only **3 net flips** on the search
+set, versus 7 on the full 51-case gate — the loop's own objective set is
+under-powered against the most destructive single-field change anyone has
+measured, not merely against subtle ones. Every `run_loop` report carries
+this as `resolution_warning`, so an accepted improvement on today's corpus
+reads as a candidate for confirmation, not a demonstrated result. This is
+the quantitative case for block B (#30, corpus expansion) — sharper than the
+design doc's own estimate — not a reason to withhold the harness.
+
+> [!NOTE]
+> All of the numbers above come from three local, gitignored artifacts
+> (`tests/eval/runs/20260729T020233Z_...json`, `...040824Z...`,
+> `...081129Z...json`) — `tests/eval/runs/` is in `.gitignore`, so they are
+> not reproducible from a fresh clone. They are cited, not shipped.
+
+## Proposers
+
+`GridProposer` is the deterministic control: coordinate descent from the
+reference configuration, one field at a time, in `proposal_order()`,
+skipping infeasible points and points already in the ledger. Reproducible
+from the ledger alone.
+
+`LlmProposer` prompts a local Ollama model (default `gemma4:e4b`,
+`http://localhost:11434`) with the declared space, the ledger history and
+the currently failing search-set cases' questions, and requires strict JSON
+back. **Validation is the security boundary, not the prompt:** every
+returned override is checked against the declared keys, their declared
+values and the feasibility predicate before it is trusted; anything else —
+malformed JSON, an undeclared key, an infeasible combination, or Ollama
+being unreachable — falls back to `GridProposer` after up to 3 attempts,
+recorded in the ledger (`proposer_fallback`/`proposer_fallback_reason`).
+Because the only thing `propose()` can return is a dict of declared dotted
+keys, there is no path by which the LLM reaches `grade.py`, the gold-case
+file or the baseline.
+
+## Running it
+
+```bash
+# Smoke-test the whole loop -- proposer, feasibility, ledger, latency
+# constraint, termination -- with no GPU, no Ollama, no PDFs. Writes to a
+# fresh temp directory unless --ledger-dir is given.
+python -m harness.cli --dry-run --max-iterations 3
+
+# Real run (needs the sibling PR's tests/eval/run_eval.evaluate() on main,
+# Ollama, and a GPU -- fails with an actionable message otherwise):
+python -m harness.cli --proposer llm --max-iterations 8 --patience 3
+```
+
+`--dry-run` uses `evaluator.build_demo_evaluator()`: a tiny, deterministic,
+in-process synthetic landscape. It exercises the wiring, not the pipeline —
+it has no opinion about which real configuration is better.
+
+## Testing
+
+All 13 required behaviors from the implementation spec are covered under
+`harness/tests/`, entirely against fake/deterministic evaluators — no GPU,
+no Ollama, no model downloads, matching this repo's fast CI gate (`tests/
+conftest.py`'s pattern of skipping engine-dependent tests where the stack is
+absent; `harness/tests` needs nothing from that stack at all).
+
+> [!IMPORTANT]
+> `harness/tests/test_criterion5_simulated.py` proves the **search logic**
+> recovers from a deliberately worsened point in a synthetic, fully
+> controlled landscape — for both proposers. It does **not** prove the real
+> pipeline improves. The real criterion-5 run (design doc §2) needs the GPU
+> and ~2.8 h/candidate and is pending measurement; nothing in this PR claims
+> it ran.

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -1,0 +1,6 @@
+"""harness -- the block-C configuration search harness (issue #31).
+
+Not product: it lives outside the hexagonal core (src/monkeygrab/) and the
+interface layer (rag/), and only ever reads and runs the evaluation gate
+under tests/eval/ -- never redefines how it scores. See harness/README.md.
+"""

--- a/harness/cli.py
+++ b/harness/cli.py
@@ -1,0 +1,117 @@
+"""cli -- entry point for the block-C configuration search harness.
+
+Usage:
+    python -m harness.cli --dry-run --max-iterations 3
+    python -m harness.cli --proposer llm --max-iterations 8 --patience 3
+
+``--dry-run`` always works: it wires in a small deterministic in-process
+evaluator (``evaluator.build_demo_evaluator``) so the whole loop -- proposer,
+feasibility, ledger, latency constraint, termination -- can be exercised
+with no GPU, no Ollama and no PDFs, writing its ledger to a fresh temporary
+directory unless ``--ledger-dir`` is given (so a demo run never litters
+``harness/ledger/``). Without it, the CLI uses the real evaluator
+(``evaluator.real_evaluate``), which depends on the sibling PR (issue #31
+spec section 5.2, #56) landing ``tests/eval/run_eval.evaluate()`` -- it
+fails with an actionable message, not a stack trace, until that lands.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import tempfile
+from pathlib import Path
+from typing import Optional, Sequence
+
+from harness import evaluator as evaluator_mod
+from harness import ledger as ledger_mod
+from harness import loop as loop_mod
+from harness import proposers as proposers_mod
+
+
+def _build_reference():
+    """The ``AppConfig`` the loop's ratchet, feasibility and latency ceiling measure against."""
+    import sys as _sys
+    from pathlib import Path as _Path
+
+    src = _Path(__file__).resolve().parents[1] / "src"
+    if str(src) not in _sys.path:
+        _sys.path.insert(0, str(src))
+    from monkeygrab.config.app_config import AppConfig
+
+    return AppConfig.from_env()
+
+
+def _build_proposer(name: str, reference, *, model: str):
+    if name == "grid":
+        return proposers_mod.GridProposer(reference)
+    if name == "llm":
+        return proposers_mod.LlmProposer(reference, model=model)
+    raise ValueError(f"unknown proposer {name!r}")
+
+
+def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Block-C configuration search harness (issue #31).")
+    parser.add_argument("--proposer", choices=("grid", "llm"), default="grid",
+                         help="grid (deterministic control) or llm (Ollama-backed). Default: grid.")
+    parser.add_argument("--max-iterations", type=int, default=None,
+                         help="Hard iteration budget. Default: none (patience alone decides).")
+    parser.add_argument("--patience", type=int, default=3,
+                         help="Stop after this many consecutive non-accepted iterations. Default: 3.")
+    parser.add_argument("--ledger-dir", type=Path, default=None,
+                         help="Default: harness/ledger/, or a fresh temp dir under --dry-run.")
+    parser.add_argument("--dry-run", action="store_true",
+                         help="Use the deterministic in-process demo evaluator instead of the real gate.")
+    parser.add_argument("--llm-model", default=proposers_mod.LlmProposer.DEFAULT_MODEL,
+                         help=f"Ollama model for --proposer llm. Default: {proposers_mod.LlmProposer.DEFAULT_MODEL}.")
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = parse_args(argv)
+
+    reference = _build_reference()
+    proposer = _build_proposer(args.proposer, reference, model=args.llm_model)
+
+    if args.dry_run:
+        evaluate = evaluator_mod.build_demo_evaluator()
+        ledger_dir = args.ledger_dir or Path(tempfile.mkdtemp(prefix="harness_dry_run_"))
+    else:
+        evaluate = evaluator_mod.real_evaluate
+        ledger_dir = args.ledger_dir or ledger_mod.LEDGER_DIR
+
+    search_set_ids = evaluator_mod.search_set_case_ids()
+    fast_tier_ids = evaluator_mod.load_fast_tier()
+    unreachable_ids = evaluator_mod.load_unreachable_ids()
+
+    try:
+        report = loop_mod.run_loop(
+            reference=reference, evaluate=evaluate, proposer=proposer,
+            search_set_ids=search_set_ids, fast_tier_ids=fast_tier_ids,
+            unreachable_ids=unreachable_ids,
+            max_iterations=args.max_iterations, patience=args.patience,
+            ledger_dir=ledger_dir,
+        )
+    except evaluator_mod.ReachabilityError as exc:
+        print(f"REACHABILITY GATE FAILED: {exc}", file=sys.stderr)
+        return 1
+    except NotImplementedError as exc:
+        print(f"NOT AVAILABLE: {exc}", file=sys.stderr)
+        return 1
+
+    ledger_dir.mkdir(parents=True, exist_ok=True)
+    report_path = ledger_dir / "report.json"
+    report_path.write_text(json.dumps(report, indent=2, ensure_ascii=False), encoding="utf-8")
+
+    print(f"iterations run: {report['iterations_run']} (stopped: {report['termination_reason']})")
+    print(f"reference objective_adjusted: {report['reference']['objective_adjusted']}")
+    print(f"ratchet: {report['ratchet']} (best iteration: {report['best_iteration']})")
+    print(f"ledger: {ledger_dir}")
+    print(f"report: {report_path}")
+    print(f"resolution warning: {report['resolution_warning']['message']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/harness/evaluator.py
+++ b/harness/evaluator.py
@@ -1,0 +1,395 @@
+"""evaluator -- adapts tests/eval/run_eval's evaluation to the harness loop.
+
+Owns everything about "what gets asked of the evaluation": which case ids
+belong to the search set, the blind set and the fast tier; the objective
+(raw and unreachable-adjusted pass count) and the per-bucket latency medians
+computed from an evaluation's records; the reachability gate that fails
+startup instead of the loop silently running on top of an inert knob; and
+the ``EvaluatorFn`` adapter to the real ``tests/eval/run_eval.evaluate()``.
+
+The harness may read and run the evaluation, never redefine how it scores
+(issue #31 spec section 0). Nothing here imports ``grade`` -- run_eval.py
+does, for its own purposes, and this module imports *run_eval*, not grade,
+exactly as harness/tests/test_harness_boundaries.py checks. ``grade.py``,
+``gold_cases.jsonl`` and ``baseline_min_pass_rate.txt`` are only ever read.
+
+Two run-record facts drove this module's shape, both confirmed against a
+real gate run (``tests/eval/runs/20260729T020233Z_mineru-jina_clip-faiss.json``,
+a local, gitignored artifact -- see harness/README.md):
+
+- A record has no ``source`` field (``case_type``, ``elapsed_seconds``,
+  ``id``, ``lang``, ``model``, ``paper``, ``passed``, ``reason`` only). Search
+  vs. blind membership is never read off a record -- it is decided entirely
+  by which case ids the caller asks ``evaluate()`` for, sourced from
+  ``search_set_case_ids()``/``load_fast_tier()`` (both filtered from
+  ``gold_cases.jsonl`` by ``source``) and never from anything a proposer or
+  an evaluation result controls. That is what makes the blind set
+  structurally unreachable (spec section 4, test 5).
+- Per-case-type latency differs by roughly a factor of fifty (answered
+  ~200 s vs. retrieval-only ~4 s), so a single blended median is dominated by
+  which bucket happened to be larger and would mask a retrieval-quality
+  collapse a candidate paid for with fewer generator calls. The latency
+  constraint (``loop.py``) is therefore per-bucket, not blended --
+  ``median_latency_by_bucket`` is what makes that possible.
+"""
+
+from __future__ import annotations
+
+import json
+import statistics
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+from harness import search_space
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+EVAL_DIR = REPO_ROOT / "tests" / "eval"
+GOLD_FILE = EVAL_DIR / "gold_cases.jsonl"
+FAST_TIER_FILE = Path(__file__).resolve().parent / "fast_tier.txt"
+UNREACHABLE_FILE = Path(__file__).resolve().parent / "unreachable_cases.txt"
+
+# Mirrors tests/eval/run_eval.py's private _RETRIEVAL_ONLY_CASE_TYPES: these
+# case types skip generation entirely (a pass means retrieval surfaced the
+# right content kind, not that any answer used it), which is exactly why
+# their latency belongs in its own bucket. Duplicated rather than imported
+# because it is a leading-underscore name in a module this one only imports
+# lazily (see _run_eval_module) -- harness/tests/test_evaluator.py asserts
+# this tuple stays equal to run_eval's, so the two cannot silently drift.
+RETRIEVAL_ONLY_CASE_TYPES: Tuple[str, ...] = ("figure_retrieval", "table_retrieval")
+
+
+@dataclass(frozen=True)
+class CaseRecord:
+    """One graded case, the fields every ledger entry and latency bucket needs.
+
+    Attributes:
+        id: Gold-case id (``gold_cases.jsonl``'s ``"id"``).
+        case_type: One of ``factual_number``, ``factual_concept``,
+            ``figure_retrieval``, ``table_retrieval``.
+        passed: Grading verdict.
+        elapsed_seconds: Wall time for this case (retrieval, and generation
+            when the case type calls the generator).
+    """
+
+    id: str
+    case_type: str
+    passed: bool
+    elapsed_seconds: float
+
+
+@dataclass(frozen=True)
+class EvaluationResult:
+    """What one ``EvaluatorFn`` call returns.
+
+    Attributes:
+        records: One ``CaseRecord`` per requested case id.
+        effective_config: ``dataclasses.asdict`` of the ``AppConfig`` this
+            evaluation actually ran with (reference config plus the expanded
+            overrides) -- kept alongside the raw ``config_overrides`` deltas
+            in the ledger so a default changing later cannot silently change
+            what an old entry meant (issue #31 spec section 5.3).
+    """
+
+    records: Tuple[CaseRecord, ...]
+    effective_config: Dict[str, Any]
+
+
+EvaluatorFn = Callable[[Mapping[str, Any], Sequence[str]], EvaluationResult]
+
+
+def median_latency_by_bucket(records: Sequence[CaseRecord]) -> Dict[str, Optional[float]]:
+    """Median wall time, split into the answered and retrieval-only buckets.
+
+    Per-bucket, not blended -- see this module's docstring for why a single
+    median over case types that differ by ~50x in cost is not a meaningful
+    latency signal.
+
+    Args:
+        records: Case records from one evaluation.
+
+    Returns:
+        ``{"answered": median_or_None, "retrieval_only": median_or_None}``.
+        ``None`` for a bucket with zero records in ``records`` (e.g. a
+        fast-tier probe evaluated with only retrieval-only ids).
+    """
+    answered = [r.elapsed_seconds for r in records if r.case_type not in RETRIEVAL_ONLY_CASE_TYPES]
+    retrieval_only = [r.elapsed_seconds for r in records if r.case_type in RETRIEVAL_ONLY_CASE_TYPES]
+    return {
+        "answered": statistics.median(answered) if answered else None,
+        "retrieval_only": statistics.median(retrieval_only) if retrieval_only else None,
+    }
+
+
+def compute_objective(records: Sequence[CaseRecord], unreachable_ids: Iterable[str] = ()) -> Tuple[int, int]:
+    """Raw and unreachable-adjusted passing-case counts (issue #31 spec section 3).
+
+    A case in ``unreachable_ids`` is dropped from consideration entirely for
+    the adjusted count -- neither a pass nor a fail counts against it -- so
+    the loop never spends iterations chasing a case no stage-1 configuration
+    can fix (design doc section 3, "Margen inalcanzable"). Today
+    ``unreachable_cases.txt`` is empty (evidence-backed, see that file's
+    header), so ``raw == adjusted`` for every real evaluation; the two are
+    kept distinct here so that stays true by construction rather than by
+    coincidence once a case earns a place there.
+
+    Args:
+        records: Case records to score.
+        unreachable_ids: Ids to exclude from the adjusted count.
+
+    Returns:
+        ``(raw, adjusted)``, both plain counts, not rates.
+    """
+    unreachable = set(unreachable_ids)
+    raw = sum(1 for r in records if r.passed)
+    adjusted = sum(1 for r in records if r.passed and r.id not in unreachable)
+    return raw, adjusted
+
+
+# GOLD CASES / CASE SETS
+
+_gold_cases_cache: Optional[List[Dict[str, Any]]] = None
+
+
+def _gold_cases() -> List[Dict[str, Any]]:
+    """Parse gold_cases.jsonl once and cache it (read-only, never written)."""
+    global _gold_cases_cache
+    if _gold_cases_cache is None:
+        cases = []
+        for line in GOLD_FILE.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if line:
+                cases.append(json.loads(line))
+        _gold_cases_cache = cases
+    return _gold_cases_cache
+
+
+def search_set_case_ids() -> Tuple[str, ...]:
+    """Case ids with ``source == "corpus"`` -- the loop's objective (spec section 4)."""
+    return tuple(c["id"] for c in _gold_cases() if c["source"] == "corpus")
+
+
+def blind_set_case_ids() -> Tuple[str, ...]:
+    """Case ids with ``source == "arxiv"`` -- never requested by the harness."""
+    return tuple(c["id"] for c in _gold_cases() if c["source"] == "arxiv")
+
+
+def _read_id_list(path: Path) -> List[str]:
+    """Parse a harness case-id file: one id per non-comment, non-blank line.
+
+    A trailing justification/comment after the id (space- or ``#``-separated)
+    is accepted and ignored -- ``unreachable_cases.txt`` uses it, ``fast_tier.txt``
+    does not need to.
+    """
+    ids = []
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        ids.append(line.split()[0])
+    return ids
+
+
+def load_fast_tier(path: Path = FAST_TIER_FILE) -> Tuple[str, ...]:
+    """Fixed regression-filter case ids (spec section 4); validated as a search-set subset.
+
+    Raises:
+        ValueError: ``path`` names an id outside ``search_set_case_ids()``.
+    """
+    ids = tuple(_read_id_list(path))
+    search_ids = set(search_set_case_ids())
+    unknown = [i for i in ids if i not in search_ids]
+    if unknown:
+        raise ValueError(f"{path}: case id(s) outside the search set: {unknown}")
+    return ids
+
+
+def load_unreachable_ids(path: Path = UNREACHABLE_FILE) -> Tuple[str, ...]:
+    """Case ids excluded from the maximised scalar (spec section 3); validated as a search-set subset.
+
+    Raises:
+        ValueError: ``path`` names an id outside ``search_set_case_ids()``.
+    """
+    ids = tuple(_read_id_list(path))
+    search_ids = set(search_set_case_ids())
+    unknown = [i for i in ids if i not in search_ids]
+    if unknown:
+        raise ValueError(f"{path}: case id(s) outside the search set: {unknown}")
+    return ids
+
+
+# REACHABILITY GATE
+
+
+class ReachabilityError(RuntimeError):
+    """Raised when ``evaluate()`` rejects a declared search-space key at startup.
+
+    Not a bug in the harness: it means ``evaluate()`` is doing exactly what
+    the hard-fail policy (rule 8) asks of it -- refusing to silently ignore
+    an override it cannot honour end to end. The harness's job is to surface
+    that loudly, before the loop's first iteration, rather than let a
+    candidate "improve" on a knob that never reached the pipeline.
+    """
+
+
+def verify_reachable(evaluate: EvaluatorFn, probe_case_ids: Sequence[str] = ()) -> None:
+    """Fail loudly if ``evaluate`` cannot honour a declared search-space key.
+
+    Calls ``evaluate`` exactly once, with every declared key set to its
+    first allowed value simultaneously, and lets whatever ``evaluate`` raises
+    propagate wrapped in ``ReachabilityError``. One call, not one per key: a
+    per-key probe against the real evaluator would cost up to
+    ``len(search_space.DECLARED_KEYS)`` full evaluations before the loop even
+    starts, which defeats the point of a startup gate. ``probe_case_ids``
+    defaults to empty, on the assumption that a hard-fail check belongs at
+    config-construction time (this codebase's own pattern -- see
+    ``AppConfig.with_overrides``) rather than requiring a case to actually
+    run; this is documented as an assumption, not a guarantee, because this
+    harness does not control ``evaluate()``'s implementation (issue #31,
+    sibling PR #56). If ``evaluate()`` only detects an unreachable override
+    while processing a case, a caller must pass at least one id here for the
+    gate to be meaningful.
+
+    ``search_space.PENDING_REACHABILITY_KEYS`` is empty today -- #56 audited
+    and closed the reachability gap it used to name -- but this gate stays:
+    the same audit also found ``flags.usar_llm_query_decomposition`` silently
+    inert for a different reason (the gate hardcodes its collaborator to
+    ``None``, issue #64) and simply removed that key from
+    ``search_space.SEARCH_SPACE`` instead, since ``evaluate()`` would not
+    raise for it either. This gate is what turns a *future* key like either
+    of those into a loud startup failure the moment ``evaluate()`` starts
+    enforcing it, instead of a silent no-op discovered by reading a
+    suspiciously flat ledger.
+
+    Args:
+        evaluate: The evaluator the loop is about to run with.
+        probe_case_ids: Case ids to pass on the probe call (default: none).
+
+    Raises:
+        ReachabilityError: ``evaluate`` raised for the combined probe
+            overrides; the original exception is chained and its message
+            (expected to name the offending key(s), per #56) is included.
+    """
+    probe_overrides = {key: search_space.ALLOWED_VALUES[key][0] for key in search_space.DECLARED_KEYS}
+    try:
+        evaluate(probe_overrides, tuple(probe_case_ids))
+    except Exception as exc:  # noqa: BLE001 -- any failure here must name the key, never be swallowed
+        raise ReachabilityError(
+            "evaluate() rejected one or more declared search-space keys at startup "
+            f"(see search_space.PENDING_REACHABILITY_KEYS): {exc}"
+        ) from exc
+
+
+# REAL EVALUATOR (depends on sibling PR #56)
+
+
+def _run_eval_module():
+    """Import tests/eval/run_eval.py as a top-level ``run_eval`` module.
+
+    Mirrors tests/eval/test_index_reuse.py's own ``sys.path.insert`` +
+    ``import run_eval`` convention, so this is the one place harness/ reaches
+    into tests/eval/ from, and every caller resolves to the same module
+    object.
+    """
+    if str(EVAL_DIR) not in sys.path:
+        sys.path.insert(0, str(EVAL_DIR))
+    import run_eval  # noqa: E402
+
+    return run_eval
+
+
+def real_evaluate(config_overrides: Mapping[str, Any], case_ids: Sequence[str]) -> EvaluationResult:
+    """Adapt ``tests/eval/run_eval.evaluate()`` (issue #31 spec section 5.2) to ``EvaluatorFn``.
+
+    TODO: depends on the sibling PR (#56) landing ``run_eval.evaluate()`` on
+    main. Guarded rather than imported at module level so importing
+    ``harness.evaluator`` (which ``harness/tests/`` does, in CI, with no
+    engine dependencies installed) never fails on this function's account --
+    only *calling* it before #56 lands does, with a message that says why.
+
+    Args:
+        config_overrides: Dotted-key overrides, as a proposer emits them
+            (``retrieval.weight_bm25_rrf`` is derived here via
+            ``search_space.expand_overrides``, not required from the caller).
+        case_ids: Case ids to evaluate.
+
+    Returns:
+        The adapted ``EvaluationResult``.
+
+    Raises:
+        NotImplementedError: ``run_eval.py`` has no ``evaluate()`` yet.
+    """
+    run_eval = _run_eval_module()
+    if not hasattr(run_eval, "evaluate"):
+        raise NotImplementedError(
+            "tests/eval/run_eval.py has no evaluate() yet -- the real evaluator "
+            "depends on the sibling PR (issue #31 spec section 5.2, #56). Use "
+            "evaluator.build_demo_evaluator() to exercise the harness without it."
+        )
+    raw = run_eval.evaluate(
+        models=run_eval.DEFAULT_MODELS,
+        case_ids=tuple(case_ids),
+        config_overrides=search_space.expand_overrides(config_overrides),
+        update_baseline=False,
+        write_report=True,
+    )
+    records = tuple(
+        CaseRecord(
+            id=r["id"],
+            case_type=r["case_type"],
+            passed=bool(r["passed"]),
+            elapsed_seconds=float(r["elapsed_seconds"]),
+        )
+        for r in raw["results"]
+    )
+    return EvaluationResult(records=records, effective_config=raw.get("effective_config", {}))
+
+
+# DEMO EVALUATOR (no GPU, no Ollama -- harness/cli.py --dry-run)
+
+
+def build_demo_evaluator(seed_overrides: Optional[Mapping[str, Any]] = None) -> EvaluatorFn:
+    """A tiny deterministic in-process evaluator, for smoke-testing the CLI/loop wiring.
+
+    Not a substitute for the real pipeline and never claims to be: it scores
+    a candidate purely by how many of a handful of declared keys match a
+    fixed synthetic optimum, with fixed per-case-type latencies. It exists so
+    ``harness/cli.py --dry-run`` can exercise the whole loop -- proposer,
+    feasibility, ledger, the latency constraint, termination -- with no GPU,
+    no Ollama and no PDFs. See ``harness/tests/`` for the same idea used with
+    landscapes shaped to test specific loop behaviors (regression, latency
+    rejection, recovery); this one is only for the CLI demo.
+
+    Args:
+        seed_overrides: Dotted-key values the synthetic landscape treats as
+            optimal. Defaults to a fixed point so repeated ``--dry-run``
+            invocations are comparable.
+
+    Returns:
+        An ``EvaluatorFn`` closed over the synthetic scoring function.
+    """
+    optimum = dict(seed_overrides or {"retrieval.top_k_final": 8, "retrieval.weight_semantic_rrf": 0.55})
+    all_ids = search_set_case_ids()
+    case_types = {c["id"]: c["case_type"] for c in _gold_cases()}
+
+    def _evaluate(config_overrides: Mapping[str, Any], case_ids: Sequence[str]) -> EvaluationResult:
+        effective = search_space.expand_overrides(config_overrides)
+        distance = sum(0 if effective.get(key) == value else 1 for key, value in optimum.items())
+        ids = tuple(case_ids) or all_ids
+        records = []
+        for index, case_id in enumerate(ids):
+            case_type = case_types.get(case_id, "factual_number")
+            is_retrieval_only = case_type in RETRIEVAL_ONLY_CASE_TYPES
+            # Deterministic, not random: farther from the synthetic optimum
+            # fails a larger fraction of cases (smaller modulus -> more
+            # failures), and index 0 always fails once distance > 0 so a
+            # perturbation is guaranteed to show up in a 1-case probe too.
+            passed = distance == 0 or (index % (distance + 1)) != 0
+            records.append(CaseRecord(
+                id=case_id, case_type=case_type, passed=passed,
+                elapsed_seconds=4.0 if is_retrieval_only else 200.0,
+            ))
+        return EvaluationResult(records=tuple(records), effective_config=effective)
+
+    return _evaluate

--- a/harness/evaluator.py
+++ b/harness/evaluator.py
@@ -25,11 +25,14 @@ a local, gitignored artifact -- see harness/README.md):
   ``gold_cases.jsonl`` by ``source``) and never from anything a proposer or
   an evaluation result controls. That is what makes the blind set
   structurally unreachable (spec section 4, test 5).
-- Per-case-type latency differs by roughly a factor of fifty (answered
-  ~200 s vs. retrieval-only ~4 s), so a single blended median is dominated by
+- Per-case-type latency differs enough (answered ~28.5 s vs. retrieval-only
+  ~4.1 s as of the latest measurement, 2026-08-12,
+  ``tests/eval/runs/20260812T194812Z_mineru-jina_clip-faiss.json``, local/
+  gitignored -- issue #27's keep-alive fix narrowed this gap from ~50x to
+  ~7x, but did not close it) that a single blended median is dominated by
   which bucket happened to be larger and would mask a retrieval-quality
-  collapse a candidate paid for with fewer generator calls. The latency
-  constraint (``loop.py``) is therefore per-bucket, not blended --
+  collapse a candidate paid for with fewer/cheaper generator calls. The
+  latency constraint (``loop.py``) is therefore per-bucket, not blended --
   ``median_latency_by_bucket`` is what makes that possible.
 """
 
@@ -71,12 +74,21 @@ class CaseRecord:
         passed: Grading verdict.
         elapsed_seconds: Wall time for this case (retrieval, and generation
             when the case type calls the generator).
+        infrastructure_error: True when ``run_eval.py`` could not evaluate
+            this case at all (dead/overloaded Ollama, retrieval exception --
+            see ``run_eval.run_factual_case``/``run_all_cases``), as opposed
+            to a real grading failure. ``run_eval.main`` itself refuses to
+            compare such a run against the baseline ("this run measured
+            nothing"); ``loop.py`` applies the same refusal per iteration
+            (verdict ``inconclusive``) rather than silently reading a dead
+            Ollama as "every case failed."
     """
 
     id: str
     case_type: str
     passed: bool
     elapsed_seconds: float
+    infrastructure_error: bool = False
 
 
 @dataclass(frozen=True)
@@ -103,8 +115,8 @@ def median_latency_by_bucket(records: Sequence[CaseRecord]) -> Dict[str, Optiona
     """Median wall time, split into the answered and retrieval-only buckets.
 
     Per-bucket, not blended -- see this module's docstring for why a single
-    median over case types that differ by ~50x in cost is not a meaningful
-    latency signal.
+    median over case types that differ enough in cost (~7x as of the latest
+    measurement) is not a meaningful latency signal.
 
     Args:
         records: Case records from one evaluation.
@@ -233,6 +245,19 @@ class ReachabilityError(RuntimeError):
     """
 
 
+class InconclusiveEvaluationError(RuntimeError):
+    """Raised when the REFERENCE evaluation itself carries an ``infrastructure_error`` record.
+
+    ``tests/eval/run_eval.py``'s own gate refuses to compare an inconclusive
+    run against the baseline ("this run measured nothing" -- see
+    ``run_eval.main``). A candidate iteration gets the softer ``inconclusive``
+    ledger verdict (``loop.run_loop`` handles it per iteration and keeps
+    going), but the reference measurement has no verdict to fall back on: if
+    it is unreliable, no ratchet baseline exists at all, so the loop must not
+    start.
+    """
+
+
 def verify_reachable(evaluate: EvaluatorFn, probe_case_ids: Sequence[str] = ()) -> None:
     """Fail loudly if ``evaluate`` cannot honour a declared search-space key.
 
@@ -274,7 +299,16 @@ def verify_reachable(evaluate: EvaluatorFn, probe_case_ids: Sequence[str] = ()) 
     probe_overrides = {key: search_space.ALLOWED_VALUES[key][0] for key in search_space.DECLARED_KEYS}
     try:
         evaluate(probe_overrides, tuple(probe_case_ids))
-    except Exception as exc:  # noqa: BLE001 -- any failure here must name the key, never be swallowed
+    except ValueError as exc:
+        # ValueError is what AppConfig.with_overrides raises for an unknown
+        # field, and the shape a hard-fail "override not honoured end to
+        # end" check would plausibly take too -- that is what this gate
+        # exists to catch. Anything else (EvalSetupError for a missing
+        # Ollama/model/index, a bare RuntimeError, ...) is a setup or
+        # infrastructure problem, not a reachability problem, and propagates
+        # as itself: wrapping it here would send an operator chasing "which
+        # search-space key is broken" for a problem that has nothing to do
+        # with the declared space.
         raise ReachabilityError(
             "evaluate() rejected one or more declared search-space keys at startup "
             f"(see search_space.PENDING_REACHABILITY_KEYS): {exc}"
@@ -301,6 +335,15 @@ def _run_eval_module():
 
 def real_evaluate(config_overrides: Mapping[str, Any], case_ids: Sequence[str]) -> EvaluationResult:
     """Adapt ``tests/eval/run_eval.evaluate()`` (issue #31 spec section 5.2) to ``EvaluatorFn``.
+
+    Return shape confirmed against #56's actual contract (not the spec
+    sketch): ``{"records": [...], "config": {"dev": <AppConfig-as-dict>,
+    "blind": <...>}, ...}`` -- ``"results"``/``"effective_config"`` from an
+    earlier draft of this function do not exist on that dict and would raise
+    ``KeyError`` on the first real call. This harness only ever requests
+    ``source: corpus`` (dev-corpus) case ids -- see ``search_set_case_ids``/
+    ``load_fast_tier`` -- so ``config["dev"]`` is always the config this
+    evaluation actually ran with; ``config["blind"]`` is never read here.
 
     TODO: depends on the sibling PR (#56) landing ``run_eval.evaluate()`` on
     main. Guarded rather than imported at module level so importing
@@ -340,10 +383,11 @@ def real_evaluate(config_overrides: Mapping[str, Any], case_ids: Sequence[str]) 
             case_type=r["case_type"],
             passed=bool(r["passed"]),
             elapsed_seconds=float(r["elapsed_seconds"]),
+            infrastructure_error=bool(r.get("infrastructure_error", False)),
         )
-        for r in raw["results"]
+        for r in raw["records"]
     )
-    return EvaluationResult(records=records, effective_config=raw.get("effective_config", {}))
+    return EvaluationResult(records=records, effective_config=raw["config"]["dev"])
 
 
 # DEMO EVALUATOR (no GPU, no Ollama -- harness/cli.py --dry-run)

--- a/harness/fast_tier.txt
+++ b/harness/fast_tier.txt
@@ -1,11 +1,27 @@
 # Fast tier -- regression filter only (never declares an improvement).
 # Fixed, versioned subset of the search set: 13 cases spanning every
-# case_type and every paper. Sizing arithmetic (issue #31 spec section 4,
-# corrected against measured per-case-type cost from the reference gate run,
-# tests/eval/runs/20260729T020233Z_mineru-jina_clip-faiss.json, local/gitignored):
-#   8 answered cases  x ~200s (factual_number/factual_concept median 201.1s/198.4s) = ~1600s
-#   5 retrieval-only  x ~4.5s (figure_retrieval/table_retrieval median 3.9s/4.5s)   =   ~23s
-#   total ~1623s ~= 27 min, matching the design doc's ~32 min budget.
+# case_type and every paper.
+#
+# Its job is not to save minutes -- it is to reject a bad candidate without
+# contaminating the ratchet, before paying for the full search set. Earlier
+# revisions of this file justified the tier by an evaluation-time budget
+# (the design's original ~2.8 h/candidate estimate); that budget was wrong
+# by a factor of ~6 (issue #27's keep-alive fix removed a per-case cold
+# model load the original figure baked in -- measured 2026-08-12,
+# tests/eval/runs/20260812T194812Z_mineru-jina_clip-faiss.json, local and
+# gitignored) and the saving this tier buys is correspondingly smaller than
+# assumed. The tier stays regardless: its function (a regression filter the
+# ratchet needs) does not depend on how many minutes it happens to save.
+#
+# Sizing arithmetic, recomputed against the 2026-08-12 measurement's bucket
+# medians (answered 28.5 s, retrieval-only 4.1 s -- both down from the
+# 2026-07-29 reference's 201.1 s/198.4 s and 3.9 s/4.5 s respectively; only
+# the answered bucket moved, since retrieval-only cases never call the
+# generator the keep-alive fix affects):
+#   8 answered cases  x ~28.5s = ~228s
+#   5 retrieval-only  x ~4.1s  =  ~21s
+#   total ~249s ~= 4 min, against a ~13 min full search set (32 cases) --
+#   still worth running first, just not for the reason originally assumed.
 #
 # Includes all 5 of today's known search-set failures (dpo-pipeline-figure-es,
 # higgs-diphoton-figure, planck-contours-figure, planck-sigma8-es,

--- a/harness/fast_tier.txt
+++ b/harness/fast_tier.txt
@@ -1,0 +1,32 @@
+# Fast tier -- regression filter only (never declares an improvement).
+# Fixed, versioned subset of the search set: 13 cases spanning every
+# case_type and every paper. Sizing arithmetic (issue #31 spec section 4,
+# corrected against measured per-case-type cost from the reference gate run,
+# tests/eval/runs/20260729T020233Z_mineru-jina_clip-faiss.json, local/gitignored):
+#   8 answered cases  x ~200s (factual_number/factual_concept median 201.1s/198.4s) = ~1600s
+#   5 retrieval-only  x ~4.5s (figure_retrieval/table_retrieval median 3.9s/4.5s)   =   ~23s
+#   total ~1623s ~= 27 min, matching the design doc's ~32 min budget.
+#
+# Includes all 5 of today's known search-set failures (dpo-pipeline-figure-es,
+# higgs-diphoton-figure, planck-contours-figure, planck-sigma8-es,
+# planck-h0-tension) -- the three figure failures cost ~4s each, so including
+# them is nearly free and gives the regression filter real signal on the
+# retrieval side; the two answered failures satisfy "at least two of five"
+# before the figures are even counted.
+
+# -- answered (8): factual_number / factual_concept --
+planck-sigma8-es
+planck-h0-tension
+att-n-layers
+dpo-acronym
+gw-snr
+gw-site
+higgs-significance
+ricci-hamilton-intro
+
+# -- retrieval-only (5): figure_retrieval / table_retrieval --
+att-bleu-table
+dpo-pipeline-figure-es
+higgs-diphoton-figure
+planck-contours-figure
+gw-strain-figure

--- a/harness/ledger.py
+++ b/harness/ledger.py
@@ -1,0 +1,276 @@
+"""ledger -- append-only evidence ledger for block-C iterations.
+
+One JSON file per iteration under ``harness/ledger/`` plus a summary line in
+``harness/ledger/index.jsonl``, carrying enough to satisfy criterion 7
+(docs/design/2026-07-28-loop-automejorable.md section 2): reconstruct the
+configuration an iteration ran with, and get the same result within the
+noise floor.
+
+Writing is the whole extent of this module's git awareness: it never adds,
+commits or pushes anything. Design section 5 -- "el loop propone, el humano
+integra" -- and issue #31 spec section 1 make that a hard prohibition, not a
+default; ``harness/tests/test_harness_boundaries.py`` asserts no module under
+``harness/`` imports ``subprocess`` (or any git-shelling mechanism) at all,
+which is why ``_read_git_commit`` below reads ``.git`` metadata directly
+instead of shelling out to ``git rev-parse HEAD``.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+SCHEMA_VERSION = 1
+
+LEDGER_DIR = Path(__file__).resolve().parent / "ledger"
+INDEX_FILE_NAME = "index.jsonl"
+
+VERDICTS = ("accepted", "rejected_regression", "rejected_latency", "rejected_no_gain")
+
+
+@dataclasses.dataclass(frozen=True)
+class LedgerEntry:
+    """One iteration's full evidence record (issue #31 spec section 5.3).
+
+    Attributes:
+        schema_version: Bumped whenever a field is added, renamed or removed,
+            so an old entry can be told apart from a new one by a reader that
+            has not been updated yet.
+        iteration: 1-based sequence number.
+        parent_iteration: Which entry this candidate was proposed from, or
+            ``None`` for the first iteration (proposed from the reference).
+        git_commit: SHA the evaluation ran at, or ``None`` if it could not be
+            determined (see ``read_git_commit``).
+        config_overrides: The raw proposer deltas -- NOT expanded (e.g.
+            ``retrieval.weight_bm25_rrf`` stays implicit if the proposer only
+            set ``weight_semantic_rrf``). Reconstructing the same effective
+            config from this requires ``search_space.expand_overrides``.
+        effective_config: ``dataclasses.asdict`` of the full ``AppConfig``
+            this iteration actually ran with -- kept alongside the deltas so
+            a later default change cannot silently change what this entry
+            meant.
+        proposer: ``"grid"`` or ``"llm"``.
+        proposer_rationale: The LLM's verbatim rationale, or ``None`` for grid
+            (or for an LLM call that fell back to grid).
+        proposer_model: Ollama model id that produced the rationale, or
+            ``None``.
+        proposer_fallback: Whether an ``LlmProposer`` fell back to
+            ``GridProposer`` this iteration.
+        proposer_fallback_reason: Why, if ``proposer_fallback`` is True.
+        evaluated_case_set: ``"fast_tier"`` if this iteration was rejected at
+            the regression-filter stage (no full search-set evaluation ran),
+            else ``"search_set"``.
+        case_records: Per-case ``{id, case_type, passed, elapsed_seconds}``
+            from whichever set ``evaluated_case_set`` names.
+        summary: ``{total, passed, pass_rate}`` over ``case_records``.
+        objective_raw: Passing-case count, unreachable cases included.
+        objective_adjusted: Passing-case count, unreachable cases excluded
+            (``evaluator.compute_objective``). What the ratchet tracks.
+        median_latency_answered_s: This iteration's answered-case median, or
+            ``None`` if ``case_records`` has no answered case.
+        median_latency_retrieval_only_s: This iteration's retrieval-only
+            median, or ``None``.
+        reference_median_latency_answered_s: The reference configuration's
+            answered-case median, frozen at loop start -- what
+            ``median_latency_answered_s`` is checked against.
+        reference_median_latency_retrieval_only_s: Same, retrieval-only.
+        latency_ceiling_multiplier: The constraint's multiplier (1.20, design
+            doc section 5) -- recorded per entry rather than assumed constant,
+            so a later change to the ceiling does not retroactively change
+            what an old entry's ``rejected_latency`` verdict meant.
+        verdict: One of ``VERDICTS``.
+        reason: Human-readable explanation (which cases regressed, which
+            bucket breached the ceiling and by how much, or the gain over the
+            ratchet).
+    """
+
+    schema_version: int
+    iteration: int
+    parent_iteration: Optional[int]
+    git_commit: Optional[str]
+    config_overrides: Dict[str, Any]
+    effective_config: Dict[str, Any]
+    proposer: str
+    proposer_rationale: Optional[str]
+    proposer_model: Optional[str]
+    proposer_fallback: bool
+    proposer_fallback_reason: Optional[str]
+    evaluated_case_set: str
+    case_records: List[Dict[str, Any]]
+    summary: Dict[str, Any]
+    objective_raw: int
+    objective_adjusted: int
+    median_latency_answered_s: Optional[float]
+    median_latency_retrieval_only_s: Optional[float]
+    reference_median_latency_answered_s: Optional[float]
+    reference_median_latency_retrieval_only_s: Optional[float]
+    latency_ceiling_multiplier: float
+    verdict: str
+    reason: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return dataclasses.asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "LedgerEntry":
+        return cls(**data)
+
+
+def _find_git_dir(start: Path) -> Optional[Path]:
+    """Walk upward from ``start`` looking for a ``.git`` file or directory."""
+    current = start
+    for _ in range(20):
+        candidate = current / ".git"
+        if candidate.exists():
+            return candidate
+        if current.parent == current:
+            return None
+        current = current.parent
+    return None
+
+
+def _resolve_ref(common_dir: Path, ref_path: str) -> Optional[str]:
+    """Resolve ``ref_path`` (e.g. "refs/heads/main") to a commit sha.
+
+    Tries the loose ref file first, then ``packed-refs`` -- a repository with
+    many branches (this one included) periodically packs old refs there.
+    """
+    direct = common_dir / ref_path
+    if direct.exists():
+        return direct.read_text(encoding="utf-8").strip() or None
+    packed = common_dir / "packed-refs"
+    if packed.exists():
+        for line in packed.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or line.startswith("^"):
+                continue
+            parts = line.split(" ", 1)
+            if len(parts) == 2 and parts[1] == ref_path:
+                return parts[0]
+    return None
+
+
+def read_git_commit(start: Optional[Path] = None) -> Optional[str]:
+    """Best-effort current commit sha, read from ``.git`` metadata directly.
+
+    Deliberately avoids ``subprocess``/GitPython: this is what lets
+    ``harness/tests/test_harness_boundaries.py`` assert no module under
+    ``harness/`` imports ``subprocess`` at all, closing off any git-write
+    code path structurally (issue #31 spec section 1, item 5) rather than by
+    convention.
+
+    Handles both a plain ``.git`` directory and a worktree's ``.git`` file
+    (``gitdir: <path>``, as ``git worktree add`` produces, and what this
+    harness is developed under), including the worktree's separate
+    per-worktree ``HEAD`` and its ``commondir`` pointer back to the shared
+    refs. Never raises: a missing or unexpected ``.git`` layout returns
+    ``None`` rather than crashing the loop over a nice-to-have field.
+
+    Args:
+        start: Where to start walking upward for ``.git``. Defaults to this
+            file's own directory.
+
+    Returns:
+        The commit sha HEAD points at, or ``None``.
+    """
+    try:
+        git_path = _find_git_dir(start or Path(__file__).resolve().parent)
+        if git_path is None:
+            return None
+
+        if git_path.is_dir():
+            git_dir = git_path
+            common_dir = git_dir
+        else:
+            content = git_path.read_text(encoding="utf-8").strip()
+            if not content.startswith("gitdir:"):
+                return None
+            gitdir_value = content.split(":", 1)[1].strip()
+            git_dir = Path(gitdir_value)
+            if not git_dir.is_absolute():
+                git_dir = (git_path.parent / git_dir).resolve()
+            commondir_file = git_dir / "commondir"
+            if commondir_file.exists():
+                common_rel = commondir_file.read_text(encoding="utf-8").strip()
+                common_dir = (git_dir / common_rel).resolve()
+            else:
+                common_dir = git_dir
+
+        head_file = git_dir / "HEAD"
+        if not head_file.exists():
+            return None
+        head = head_file.read_text(encoding="utf-8").strip()
+        if head.startswith("ref:"):
+            return _resolve_ref(common_dir, head.split(":", 1)[1].strip())
+        return head or None
+    except OSError:
+        return None
+
+
+def next_iteration_number(ledger_dir: Path = LEDGER_DIR) -> int:
+    """1 for an empty/missing ledger dir, else one past the highest recorded iteration."""
+    if not ledger_dir.exists():
+        return 1
+    highest = 0
+    for path in ledger_dir.glob("*.json"):
+        try:
+            highest = max(highest, int(path.name.split("_", 1)[0]))
+        except ValueError:
+            continue
+    return highest + 1
+
+
+def write_entry(entry: LedgerEntry, ledger_dir: Path = LEDGER_DIR) -> Path:
+    """Write ``entry``'s full JSON and append its summary line to the index.
+
+    Append-only: never overwrites a previous iteration's file, and the index
+    is opened in append mode. Writing is local-filesystem only -- see this
+    module's docstring for why nothing here ever touches git.
+
+    Args:
+        entry: The iteration to record.
+        ledger_dir: Defaults to ``harness/ledger/``; overridden by tests and
+            by ``harness/cli.py --dry-run`` (see that module) so a demo run
+            never writes into the real ledger.
+
+    Returns:
+        Path to the entry's own JSON file.
+    """
+    ledger_dir.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    entry_path = ledger_dir / f"{entry.iteration:04d}_{timestamp}.json"
+    entry_path.write_text(json.dumps(entry.to_dict(), indent=2, ensure_ascii=False), encoding="utf-8")
+
+    index_line = json.dumps({
+        "iteration": entry.iteration,
+        "parent_iteration": entry.parent_iteration,
+        "proposer": entry.proposer,
+        "verdict": entry.verdict,
+        "objective_adjusted": entry.objective_adjusted,
+        "entry_file": entry_path.name,
+    }, ensure_ascii=False)
+    with (ledger_dir / INDEX_FILE_NAME).open("a", encoding="utf-8") as fh:
+        fh.write(index_line + "\n")
+
+    return entry_path
+
+
+def read_entry(path: Path) -> LedgerEntry:
+    """Load one ledger entry JSON file back into a ``LedgerEntry``."""
+    return LedgerEntry.from_dict(json.loads(path.read_text(encoding="utf-8")))
+
+
+def read_history(ledger_dir: Path = LEDGER_DIR) -> List[LedgerEntry]:
+    """Every entry under ``ledger_dir``, oldest iteration first.
+
+    Reads the full per-entry JSON files (not just the index summary), since
+    proposers need each entry's ``config_overrides`` to avoid repeating a
+    point already tried (criterion-adjacent to spec test 7).
+    """
+    if not ledger_dir.exists():
+        return []
+    entries = [read_entry(p) for p in ledger_dir.glob("*.json")]
+    return sorted(entries, key=lambda e: e.iteration)

--- a/harness/ledger.py
+++ b/harness/ledger.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import dataclasses
 import json
+import re
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -28,7 +29,17 @@ SCHEMA_VERSION = 1
 LEDGER_DIR = Path(__file__).resolve().parent / "ledger"
 INDEX_FILE_NAME = "index.jsonl"
 
-VERDICTS = ("accepted", "rejected_regression", "rejected_latency", "rejected_no_gain")
+# Matches exactly what write_entry names an entry file (f"{iteration:04d}_{timestamp}.json"),
+# so next_iteration_number/read_history never pick up another *.json file a
+# caller happens to drop in the same directory -- cli.py's own report.json
+# lives right next to these (issue #65 PR review, HIGH 3): a naive `*.json`
+# glob fed report.json into LedgerEntry.from_dict and crashed with
+# "unexpected keyword argument 'generated_at'" on the very next invocation
+# against a non-empty ledger_dir, which the default harness/ledger/ becomes
+# after one real run.
+_ENTRY_FILENAME_RE = re.compile(r"^\d{4}_.*\.json$")
+
+VERDICTS = ("accepted", "rejected_regression", "rejected_latency", "rejected_no_gain", "inconclusive")
 
 
 @dataclasses.dataclass(frozen=True)
@@ -210,16 +221,24 @@ def read_git_commit(start: Optional[Path] = None) -> Optional[str]:
         return None
 
 
+def _entry_files(ledger_dir: Path) -> List[Path]:
+    """Every ``NNNN_<timestamp>.json`` file directly under ``ledger_dir``.
+
+    Deliberately NOT a bare ``*.json`` glob: ``harness/cli.py`` writes
+    ``report.json`` into the same directory as a normal part of a run, and a
+    naive glob would feed it (and anything else dropped in later) to
+    ``LedgerEntry.from_dict`` -- see ``_ENTRY_FILENAME_RE``'s comment.
+    """
+    if not ledger_dir.exists():
+        return []
+    return [p for p in ledger_dir.glob("*.json") if _ENTRY_FILENAME_RE.match(p.name)]
+
+
 def next_iteration_number(ledger_dir: Path = LEDGER_DIR) -> int:
     """1 for an empty/missing ledger dir, else one past the highest recorded iteration."""
-    if not ledger_dir.exists():
-        return 1
     highest = 0
-    for path in ledger_dir.glob("*.json"):
-        try:
-            highest = max(highest, int(path.name.split("_", 1)[0]))
-        except ValueError:
-            continue
+    for path in _entry_files(ledger_dir):
+        highest = max(highest, int(path.name.split("_", 1)[0]))
     return highest + 1
 
 
@@ -268,9 +287,8 @@ def read_history(ledger_dir: Path = LEDGER_DIR) -> List[LedgerEntry]:
 
     Reads the full per-entry JSON files (not just the index summary), since
     proposers need each entry's ``config_overrides`` to avoid repeating a
-    point already tried (criterion-adjacent to spec test 7).
+    point already tried (criterion-adjacent to spec test 7). Only files
+    matching the entry naming pattern are read -- see ``_entry_files``.
     """
-    if not ledger_dir.exists():
-        return []
-    entries = [read_entry(p) for p in ledger_dir.glob("*.json")]
+    entries = [read_entry(p) for p in _entry_files(ledger_dir)]
     return sorted(entries, key=lambda e: e.iteration)

--- a/harness/loop.py
+++ b/harness/loop.py
@@ -1,0 +1,318 @@
+"""loop -- the ratchet, the latency constraint and termination for block C.
+
+Implements issue #31 spec section 5.5, with two corrections applied after
+measuring against the real reference gate runs (local, gitignored --
+tests/eval/runs/{20260729T020233Z,20260729T040824Z,20260729T081129Z}_
+mineru-jina_clip-faiss.json; see harness/README.md for the full numbers and
+why they cannot be re-derived from a fresh clone):
+
+1. **Per-bucket latency, not one blended median.** Answered cases (call the
+   generator) cost ~200s; retrieval-only cases (figure_retrieval,
+   table_retrieval) cost ~4s -- a ~50x gap. A single median over both is
+   dominated by which bucket happens to be larger and would let a candidate
+   trade retrieval quality for fewer generator calls without the constraint
+   noticing. ``_latency_breach`` checks each bucket against its own
+   reference median independently.
+2. **``resolution_warning`` in the final report.** The search set (32
+   ``source: corpus`` cases) can win at most 5 cases today, and moved only 3
+   net flips under the most destructive single-field change anyone has
+   measured (``RAG_TOP_K_FINAL=1``) -- both below the ~6-flip threshold
+   design doc section 3 sets for a paired difference not attributable to
+   chance. Every report says so, so an accepted improvement reads as a
+   candidate for confirmation, not a demonstrated result.
+
+The evaluator is always a callable injected by the caller (``cli.py`` for a
+real or demo run, a test double in ``harness/tests/``) -- this module never
+imports ``tests.eval.run_eval`` or anything that would let it, which is the
+decision that makes the whole harness testable with no GPU and no Ollama
+(issue #31 spec section 5.1).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Sequence
+
+from harness import evaluator as evaluator_mod
+from harness import ledger as ledger_mod
+from harness import proposers as proposers_mod
+from harness import search_space
+
+# NOISE FLOOR
+
+# Measured 2026-07-29 (docs/design/2026-07-28-loop-automejorable.md,
+# criterion 1 note): two runs of the same configuration and code, same index
+# (both recorded a cache hit), zero flips across all 51 gold cases --
+# tests/eval/runs/20260729T020233Z_mineru-jina_clip-faiss.json and
+# tests/eval/runs/20260729T040824Z_mineru-jina_clip-faiss.json (both local,
+# gitignored, so not reproducible from a fresh clone -- see harness/README.md).
+# Independently re-verified in this PR restricted to just the 32-case search
+# set this harness actually uses: still 0 flips. A delta of zero cases is not
+# an improvement. If tests/eval/grade.py's scoring rules ever change, this
+# floor must be remeasured -- it is specific to that grader, not a law of the
+# pipeline.
+NOISE_FLOOR_CASES = 0
+
+# The latency constraint's multiplier (design doc section 5).
+LATENCY_CEILING_MULTIPLIER = 1.20
+
+# RESOLUTION LIMIT (see module docstring point 2)
+
+SEARCH_SET_AVAILABLE_FAILURES = 5
+DEMONSTRABILITY_FLIP_THRESHOLD = 6
+SEARCH_SET_NET_FLIPS_UNDER_KNOWN_SABOTAGE = 3
+SEARCH_SET_SABOTAGE_DESCRIPTION = "RAG_TOP_K_FINAL=1 (single fragment retrieved; criterion 2, 2026-07-29)"
+
+RESOLUTION_WARNING: Dict[str, Any] = {
+    "available_search_set_failures": SEARCH_SET_AVAILABLE_FAILURES,
+    "demonstrability_flip_threshold": DEMONSTRABILITY_FLIP_THRESHOLD,
+    "net_flips_under_known_sabotage": SEARCH_SET_NET_FLIPS_UNDER_KNOWN_SABOTAGE,
+    "sabotage_description": SEARCH_SET_SABOTAGE_DESCRIPTION,
+    "message": (
+        "The search set can win at most 5 cases and moved only 3 net flips under "
+        "a known-catastrophic single-field sabotage, below the ~6-flip threshold "
+        "design doc section 3 sets for a demonstrable paired difference. An "
+        "accepted improvement on today's corpus is a candidate for confirmation, "
+        "not a demonstrated result -- see "
+        "docs/design/2026-07-28-loop-automejorable.md section 3 and issue #30 "
+        "(block B, the corpus expansion this harness is sized against)."
+    ),
+}
+
+
+def _summary(records: Sequence[evaluator_mod.CaseRecord]) -> Dict[str, Any]:
+    total = len(records)
+    passed = sum(1 for r in records if r.passed)
+    return {"total": total, "passed": passed, "pass_rate": round(passed / total, 4) if total else 0.0}
+
+
+def _regressed_ids(
+    reference_records: Sequence[evaluator_mod.CaseRecord],
+    candidate_records: Sequence[evaluator_mod.CaseRecord],
+) -> List[str]:
+    """Case ids that passed for the reference and failed for the candidate (paired)."""
+    reference_passed = {r.id: r.passed for r in reference_records}
+    return [r.id for r in candidate_records if reference_passed.get(r.id) and not r.passed]
+
+
+def _latency_breach(
+    candidate: Dict[str, Optional[float]], reference: Dict[str, Optional[float]]
+) -> Optional[str]:
+    """``None`` if both buckets are within ``LATENCY_CEILING_MULTIPLIER`` of reference, else why not."""
+    for bucket in ("answered", "retrieval_only"):
+        ref_value = reference.get(bucket)
+        cand_value = candidate.get(bucket)
+        if ref_value is None or cand_value is None:
+            continue
+        ceiling = ref_value * LATENCY_CEILING_MULTIPLIER
+        if cand_value > ceiling:
+            return (
+                f"{bucket} median {cand_value:.1f}s exceeds ceiling {ceiling:.1f}s "
+                f"({LATENCY_CEILING_MULTIPLIER}x reference {ref_value:.1f}s)"
+            )
+    return None
+
+
+def _build_entry(
+    *,
+    iteration: int,
+    parent_iteration: Optional[int],
+    git_commit: Optional[str],
+    overrides: Dict[str, Any],
+    meta: Dict[str, Any],
+    evaluated_case_set: str,
+    result: evaluator_mod.EvaluationResult,
+    unreachable_ids: Sequence[str],
+    reference_latency: Dict[str, Optional[float]],
+    verdict: str,
+    reason: str,
+    candidate_latency: Optional[Dict[str, Optional[float]]] = None,
+) -> ledger_mod.LedgerEntry:
+    objective_raw, objective_adjusted = evaluator_mod.compute_objective(result.records, unreachable_ids)
+    if candidate_latency is None:
+        candidate_latency = evaluator_mod.median_latency_by_bucket(result.records)
+    return ledger_mod.LedgerEntry(
+        schema_version=ledger_mod.SCHEMA_VERSION,
+        iteration=iteration,
+        parent_iteration=parent_iteration,
+        git_commit=git_commit,
+        config_overrides=dict(overrides),
+        effective_config=dict(result.effective_config),
+        proposer=meta.get("proposer", "unknown"),
+        proposer_rationale=meta.get("rationale"),
+        proposer_model=meta.get("model"),
+        proposer_fallback=bool(meta.get("fallback", False)),
+        proposer_fallback_reason=meta.get("fallback_reason"),
+        evaluated_case_set=evaluated_case_set,
+        case_records=[dataclasses.asdict(r) for r in result.records],
+        summary=_summary(result.records),
+        objective_raw=objective_raw,
+        objective_adjusted=objective_adjusted,
+        median_latency_answered_s=candidate_latency.get("answered"),
+        median_latency_retrieval_only_s=candidate_latency.get("retrieval_only"),
+        reference_median_latency_answered_s=reference_latency.get("answered"),
+        reference_median_latency_retrieval_only_s=reference_latency.get("retrieval_only"),
+        latency_ceiling_multiplier=LATENCY_CEILING_MULTIPLIER,
+        verdict=verdict,
+        reason=reason,
+    )
+
+
+def run_loop(
+    *,
+    reference: Any,
+    evaluate: evaluator_mod.EvaluatorFn,
+    proposer: Any,
+    search_set_ids: Sequence[str],
+    fast_tier_ids: Sequence[str],
+    unreachable_ids: Sequence[str] = (),
+    max_iterations: Optional[int] = None,
+    patience: Optional[int] = 3,
+    ledger_dir=ledger_mod.LEDGER_DIR,
+    verify_reachability: bool = True,
+    reachability_probe_case_ids: Sequence[str] = (),
+) -> Dict[str, Any]:
+    """Run the search until termination, writing one ledger entry per iteration.
+
+    Args:
+        reference: The ``AppConfig`` the loop's ratchet, feasibility checks
+            and latency ceiling are all measured against (typically
+            ``AppConfig.from_env()``).
+        evaluate: Injected ``EvaluatorFn`` -- never imported here (spec
+            section 5.1).
+        proposer: A ``GridProposer`` or ``LlmProposer`` instance.
+        search_set_ids: Case ids the objective is computed over.
+        fast_tier_ids: Case ids the cheap regression filter runs over.
+        unreachable_ids: Case ids excluded from the adjusted objective.
+        max_iterations: Hard iteration budget, or ``None`` for no cap.
+        patience: Consecutive non-accepted iterations before stopping, or
+            ``None`` for no cap. At least one of ``max_iterations``/
+            ``patience`` must be set, so the loop is guaranteed to terminate.
+        ledger_dir: Where to write ledger entries (default: ``harness/ledger/``).
+        verify_reachability: Run ``evaluator.verify_reachable`` before
+            measuring the reference. Disabling this is only for tests that
+            intentionally use an evaluator too narrow to answer the probe
+            (e.g. one that only ever sees a fixed, tiny case set).
+        reachability_probe_case_ids: Forwarded to ``evaluator.verify_reachable``.
+
+    Returns:
+        The final report: reference stats, ratchet, best iteration, iteration
+        count, termination reason, ``resolution_warning``, and every entry
+        written this run. Always returned, on every termination path
+        (criterion 8) -- including when the search space is exhausted.
+
+    Raises:
+        ValueError: Neither ``max_iterations`` nor ``patience`` is set.
+        evaluator.ReachabilityError: ``evaluate`` rejects a declared key at
+            startup (only when ``verify_reachability`` is True).
+    """
+    if max_iterations is None and patience is None:
+        raise ValueError("run_loop needs max_iterations and/or patience to guarantee termination")
+
+    if verify_reachability:
+        evaluator_mod.verify_reachable(evaluate, reachability_probe_case_ids)
+
+    reference_full = evaluate({}, tuple(search_set_ids))
+    reference_fast = evaluate({}, tuple(fast_tier_ids))
+    reference_objective_raw, reference_objective_adjusted = evaluator_mod.compute_objective(
+        reference_full.records, unreachable_ids
+    )
+    reference_latency = evaluator_mod.median_latency_by_bucket(reference_full.records)
+
+    ratchet = reference_objective_adjusted
+    best_iteration: Optional[int] = None
+
+    entries_so_far: List[ledger_mod.LedgerEntry] = list(ledger_mod.read_history(ledger_dir))
+    iteration = ledger_mod.next_iteration_number(ledger_dir)
+    parent_iteration: Optional[int] = entries_so_far[-1].iteration if entries_so_far else None
+
+    consecutive_non_accepted = 0
+    iterations_run = 0
+    last_result = reference_full
+    new_entries: List[ledger_mod.LedgerEntry] = []
+    termination_reason = "unknown"
+
+    while True:
+        if max_iterations is not None and iterations_run >= max_iterations:
+            termination_reason = "max_iterations"
+            break
+        if patience is not None and consecutive_non_accepted >= patience:
+            termination_reason = "patience"
+            break
+
+        try:
+            overrides = proposer.propose(search_space, entries_so_far, last_result)
+        except proposers_mod.SearchSpaceExhausted:
+            termination_reason = "search_space_exhausted"
+            break
+
+        meta = dict(getattr(proposer, "last_meta", {}))
+        git_commit = ledger_mod.read_git_commit()
+
+        fast_result = evaluate(overrides, tuple(fast_tier_ids))
+        regressed = _regressed_ids(reference_fast.records, fast_result.records)
+
+        if regressed:
+            entry = _build_entry(
+                iteration=iteration, parent_iteration=parent_iteration, git_commit=git_commit,
+                overrides=overrides, meta=meta, evaluated_case_set="fast_tier",
+                result=fast_result, unreachable_ids=unreachable_ids,
+                reference_latency=reference_latency, verdict="rejected_regression",
+                reason=f"fast-tier regression on {regressed}",
+            )
+        else:
+            full_result = evaluate(overrides, tuple(search_set_ids))
+            candidate_latency = evaluator_mod.median_latency_by_bucket(full_result.records)
+            breach = _latency_breach(candidate_latency, reference_latency)
+            _objective_raw, objective_adjusted = evaluator_mod.compute_objective(
+                full_result.records, unreachable_ids
+            )
+
+            if breach:
+                verdict, reason = "rejected_latency", breach
+            elif objective_adjusted - ratchet <= NOISE_FLOOR_CASES:
+                verdict = "rejected_no_gain"
+                reason = (
+                    f"objective_adjusted {objective_adjusted} did not exceed ratchet "
+                    f"{ratchet} beyond the noise floor ({NOISE_FLOOR_CASES})"
+                )
+            else:
+                verdict = "accepted"
+                reason = f"objective_adjusted {objective_adjusted} exceeds ratchet {ratchet}"
+                ratchet = objective_adjusted
+                best_iteration = iteration
+
+            entry = _build_entry(
+                iteration=iteration, parent_iteration=parent_iteration, git_commit=git_commit,
+                overrides=overrides, meta=meta, evaluated_case_set="search_set",
+                result=full_result, unreachable_ids=unreachable_ids,
+                reference_latency=reference_latency, verdict=verdict, reason=reason,
+                candidate_latency=candidate_latency,
+            )
+            last_result = full_result
+
+        ledger_mod.write_entry(entry, ledger_dir)
+        entries_so_far.append(entry)
+        new_entries.append(entry)
+
+        consecutive_non_accepted = 0 if entry.verdict == "accepted" else consecutive_non_accepted + 1
+        parent_iteration = entry.iteration
+        iteration += 1
+        iterations_run += 1
+
+    return {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "reference": {
+            "objective_raw": reference_objective_raw,
+            "objective_adjusted": reference_objective_adjusted,
+            "median_latency_answered_s": reference_latency.get("answered"),
+            "median_latency_retrieval_only_s": reference_latency.get("retrieval_only"),
+        },
+        "ratchet": ratchet,
+        "best_iteration": best_iteration,
+        "iterations_run": iterations_run,
+        "termination_reason": termination_reason,
+        "resolution_warning": RESOLUTION_WARNING,
+        "iterations": [e.to_dict() for e in new_entries],
+    }

--- a/harness/loop.py
+++ b/harness/loop.py
@@ -1,18 +1,22 @@
 """loop -- the ratchet, the latency constraint and termination for block C.
 
-Implements issue #31 spec section 5.5, with two corrections applied after
+Implements issue #31 spec section 5.5, with corrections applied after
 measuring against the real reference gate runs (local, gitignored --
-tests/eval/runs/{20260729T020233Z,20260729T040824Z,20260729T081129Z}_
-mineru-jina_clip-faiss.json; see harness/README.md for the full numbers and
-why they cannot be re-derived from a fresh clone):
+tests/eval/runs/{20260729T020233Z,20260729T040824Z,20260729T081129Z,
+20260812T194812Z}_mineru-jina_clip-faiss.json; see harness/README.md for the
+full numbers and why they cannot be re-derived from a fresh clone):
 
 1. **Per-bucket latency, not one blended median.** Answered cases (call the
-   generator) cost ~200s; retrieval-only cases (figure_retrieval,
-   table_retrieval) cost ~4s -- a ~50x gap. A single median over both is
-   dominated by which bucket happens to be larger and would let a candidate
-   trade retrieval quality for fewer generator calls without the constraint
-   noticing. ``_latency_breach`` checks each bucket against its own
-   reference median independently.
+   generator) and retrieval-only cases (figure_retrieval, table_retrieval)
+   differ enough in cost -- ~28.5s vs. ~4.1s as of the latest measurement
+   (2026-08-12, tests/eval/runs/20260812T194812Z_mineru-jina_clip-faiss.json,
+   local/gitignored; this gap was ~50x before issue #27's keep-alive fix and
+   is ~7x now, but the fix only ever changed the *magnitude*, not whether it
+   exists) -- that a single median over both is dominated by which bucket
+   happens to be larger and would let a candidate trade retrieval quality
+   for fewer/cheaper generator calls without the constraint noticing.
+   ``_latency_breach`` checks each bucket against its own reference median
+   independently.
 2. **``resolution_warning`` in the final report.** The search set (32
    ``source: corpus`` cases) can win at most 5 cases today, and moved only 3
    net flips under the most destructive single-field change anyone has
@@ -20,6 +24,47 @@ why they cannot be re-derived from a fresh clone):
    design doc section 3 sets for a paired difference not attributable to
    chance. Every report says so, so an accepted improvement reads as a
    candidate for confirmation, not a demonstrated result.
+3. **A ``rejected_regression`` verdict also fires at the search-set stage**
+   when the retrieval-only bucket loses cases net against the reference
+   (paired by id), even if the blended ``objective_adjusted`` still went up.
+   Blended acceptance alone is exactly the trade design doc section 2's
+   "Consecuencia para el arnés" warns about: a candidate that swaps
+   retrieval quality for factual-answer luck would otherwise read as a plain
+   improvement. The fast tier's own regression check only weakly guards
+   this (of its 5 retrieval-only ids, 3 already fail today, leaving 2 to
+   catch a regression) -- this check runs over all ~9 retrieval-only ids in
+   the full search set instead.
+4. **A ``inconclusive`` verdict when any record carries
+   ``infrastructure_error``.** ``tests/eval/run_eval.py`` marks a case this
+   way when it could not be evaluated at all (dead/overloaded Ollama, a
+   retrieval exception) and refuses to compare such a run against the
+   baseline ("this run measured nothing" -- see ``run_eval.main``). Reading
+   those records as ordinary failures would let a dead Ollama read as a
+   quality collapse (fast tier: a good candidate wrongly
+   ``rejected_regression``) or an artificially low reference silently
+   inflate every later candidate into a false ``accepted`` -- exactly the
+   "loop sobre una medida que miente produce basura reproducible" failure
+   the design doc opens with. The reference measurement itself gets no
+   verdict to fall back on: if it carries an infrastructure error,
+   ``run_loop`` raises before entering the loop at all, since no ratchet
+   baseline can be trusted.
+
+**Scope, stated plainly (not fixed by this PR): stage 1 is a single-field
+sweep from a fixed reference, not a compounding hill climb.**
+``GridProposer`` always perturbs ``reference`` (per its own docstring,
+"coordinate descent from the reference configuration" -- issue #31 spec
+section 5.4's own wording), and ``run_loop`` never rebinds ``reference`` or
+the reference latency medians to an accepted candidate. Two accepted
+single-field changes cannot compound into one two-field configuration
+within a single run, and after the first acceptance the ratchet has already
+risen, so a further single-field change measured from the *original*
+reference is unlikely to clear it -- in practice this makes `patience`
+likely to fire not long after the first acceptance. This matches criterion
+5 (search recovers from one deliberately worsened point) and the design
+doc's own framing of block C as proving the search mechanism works, not as
+delivering a multi-step optimizer; widening it to rebind the reference (a
+real hill climb) or to search combinations is future work, not silently
+implied by "ratchet".
 
 The evaluator is always a callable injected by the caller (``cli.py`` for a
 real or demo run, a test double in ``harness/tests/``) -- this module never
@@ -81,10 +126,39 @@ RESOLUTION_WARNING: Dict[str, Any] = {
 }
 
 
+def _bucket_stats(records: Sequence[evaluator_mod.CaseRecord], key_fn) -> Dict[str, Dict[str, Any]]:
+    buckets: Dict[str, Dict[str, int]] = {}
+    for r in records:
+        key = key_fn(r)
+        b = buckets.setdefault(key, {"total": 0, "passed": 0})
+        b["total"] += 1
+        b["passed"] += int(r.passed)
+    return {
+        key: {**b, "pass_rate": round(b["passed"] / b["total"], 4) if b["total"] else 0.0}
+        for key, b in buckets.items()
+    }
+
+
 def _summary(records: Sequence[evaluator_mod.CaseRecord]) -> Dict[str, Any]:
+    """Overall pass/total/rate, plus a per-case-type breakdown.
+
+    The per-case-type split (MEDIUM 3 in the #65 review) is what makes a
+    retrieval-quality-for-factual-luck trade visible in the ledger even when
+    the blended ``objective_adjusted`` does not show it -- mirrors
+    ``run_eval.py``'s own ``build_summary``/``_bucket_stats`` shape.
+    """
     total = len(records)
     passed = sum(1 for r in records if r.passed)
-    return {"total": total, "passed": passed, "pass_rate": round(passed / total, 4) if total else 0.0}
+    return {
+        "total": total,
+        "passed": passed,
+        "pass_rate": round(passed / total, 4) if total else 0.0,
+        "by_case_type": _bucket_stats(records, lambda r: r.case_type),
+    }
+
+
+def _has_infrastructure_error(records: Sequence[evaluator_mod.CaseRecord]) -> bool:
+    return any(r.infrastructure_error for r in records)
 
 
 def _regressed_ids(
@@ -94,6 +168,31 @@ def _regressed_ids(
     """Case ids that passed for the reference and failed for the candidate (paired)."""
     reference_passed = {r.id: r.passed for r in reference_records}
     return [r.id for r in candidate_records if reference_passed.get(r.id) and not r.passed]
+
+
+def _retrieval_only_net_change(
+    reference_records: Sequence[evaluator_mod.CaseRecord],
+    candidate_records: Sequence[evaluator_mod.CaseRecord],
+) -> int:
+    """Net change (candidate minus reference) in retrieval-only passing count, paired by id.
+
+    Positive: more retrieval-only cases pass than in the reference. Negative:
+    fewer do -- what ``run_loop`` refuses to accept regardless of the
+    blended objective (see module docstring point 3).
+    """
+    reference_passed = {
+        r.id: r.passed for r in reference_records if r.case_type in evaluator_mod.RETRIEVAL_ONLY_CASE_TYPES
+    }
+    net = 0
+    for r in candidate_records:
+        if r.case_type not in evaluator_mod.RETRIEVAL_ONLY_CASE_TYPES:
+            continue
+        was_passing = reference_passed.get(r.id, False)
+        if r.passed and not was_passing:
+            net += 1
+        elif not r.passed and was_passing:
+            net -= 1
+    return net
 
 
 def _latency_breach(
@@ -178,7 +277,8 @@ def run_loop(
     Args:
         reference: The ``AppConfig`` the loop's ratchet, feasibility checks
             and latency ceiling are all measured against (typically
-            ``AppConfig.from_env()``).
+            ``AppConfig.from_env()``). Fixed for the whole run -- see the
+            module docstring's "Scope" note.
         evaluate: Injected ``EvaluatorFn`` -- never imported here (spec
             section 5.1).
         proposer: A ``GridProposer`` or ``LlmProposer`` instance.
@@ -189,7 +289,14 @@ def run_loop(
         patience: Consecutive non-accepted iterations before stopping, or
             ``None`` for no cap. At least one of ``max_iterations``/
             ``patience`` must be set, so the loop is guaranteed to terminate.
+            An ``inconclusive`` verdict counts toward patience like any other
+            non-accepted outcome.
         ledger_dir: Where to write ledger entries (default: ``harness/ledger/``).
+            Meant to be the SAME directory across many invocations over time
+            (design doc section 4: "append-only, versioned" spans the whole
+            history, not one run) -- ``GridProposer``'s "already tried"
+            check and ``next_iteration_number`` both depend on reading it
+            back via ``ledger.read_history``.
         verify_reachability: Run ``evaluator.verify_reachable`` before
             measuring the reference. Disabling this is only for tests that
             intentionally use an evaluator too narrow to answer the probe
@@ -206,6 +313,9 @@ def run_loop(
         ValueError: Neither ``max_iterations`` nor ``patience`` is set.
         evaluator.ReachabilityError: ``evaluate`` rejects a declared key at
             startup (only when ``verify_reachability`` is True).
+        evaluator.InconclusiveEvaluationError: The reference measurement
+            itself carries an ``infrastructure_error`` record -- no ratchet
+            baseline can be trusted, so the loop never starts.
     """
     if max_iterations is None and patience is None:
         raise ValueError("run_loop needs max_iterations and/or patience to guarantee termination")
@@ -215,6 +325,11 @@ def run_loop(
 
     reference_full = evaluate({}, tuple(search_set_ids))
     reference_fast = evaluate({}, tuple(fast_tier_ids))
+    if _has_infrastructure_error(reference_full.records) or _has_infrastructure_error(reference_fast.records):
+        raise evaluator_mod.InconclusiveEvaluationError(
+            "reference evaluation carries at least one infrastructure_error record -- "
+            "no ratchet baseline can be trusted; fix Ollama/the index and retry"
+        )
     reference_objective_raw, reference_objective_adjusted = evaluator_mod.compute_objective(
         reference_full.records, unreachable_ids
     )
@@ -251,46 +366,70 @@ def run_loop(
         git_commit = ledger_mod.read_git_commit()
 
         fast_result = evaluate(overrides, tuple(fast_tier_ids))
-        regressed = _regressed_ids(reference_fast.records, fast_result.records)
 
-        if regressed:
+        if _has_infrastructure_error(fast_result.records):
             entry = _build_entry(
                 iteration=iteration, parent_iteration=parent_iteration, git_commit=git_commit,
                 overrides=overrides, meta=meta, evaluated_case_set="fast_tier",
                 result=fast_result, unreachable_ids=unreachable_ids,
-                reference_latency=reference_latency, verdict="rejected_regression",
-                reason=f"fast-tier regression on {regressed}",
+                reference_latency=reference_latency, verdict="inconclusive",
+                reason="fast-tier evaluation carries infrastructure_error record(s) -- not scored",
             )
         else:
-            full_result = evaluate(overrides, tuple(search_set_ids))
-            candidate_latency = evaluator_mod.median_latency_by_bucket(full_result.records)
-            breach = _latency_breach(candidate_latency, reference_latency)
-            _objective_raw, objective_adjusted = evaluator_mod.compute_objective(
-                full_result.records, unreachable_ids
-            )
+            regressed = _regressed_ids(reference_fast.records, fast_result.records)
 
-            if breach:
-                verdict, reason = "rejected_latency", breach
-            elif objective_adjusted - ratchet <= NOISE_FLOOR_CASES:
-                verdict = "rejected_no_gain"
-                reason = (
-                    f"objective_adjusted {objective_adjusted} did not exceed ratchet "
-                    f"{ratchet} beyond the noise floor ({NOISE_FLOOR_CASES})"
+            if regressed:
+                entry = _build_entry(
+                    iteration=iteration, parent_iteration=parent_iteration, git_commit=git_commit,
+                    overrides=overrides, meta=meta, evaluated_case_set="fast_tier",
+                    result=fast_result, unreachable_ids=unreachable_ids,
+                    reference_latency=reference_latency, verdict="rejected_regression",
+                    reason=f"fast-tier regression on {regressed}",
                 )
             else:
-                verdict = "accepted"
-                reason = f"objective_adjusted {objective_adjusted} exceeds ratchet {ratchet}"
-                ratchet = objective_adjusted
-                best_iteration = iteration
+                full_result = evaluate(overrides, tuple(search_set_ids))
+                last_result = full_result
 
-            entry = _build_entry(
-                iteration=iteration, parent_iteration=parent_iteration, git_commit=git_commit,
-                overrides=overrides, meta=meta, evaluated_case_set="search_set",
-                result=full_result, unreachable_ids=unreachable_ids,
-                reference_latency=reference_latency, verdict=verdict, reason=reason,
-                candidate_latency=candidate_latency,
-            )
-            last_result = full_result
+                if _has_infrastructure_error(full_result.records):
+                    entry = _build_entry(
+                        iteration=iteration, parent_iteration=parent_iteration, git_commit=git_commit,
+                        overrides=overrides, meta=meta, evaluated_case_set="search_set",
+                        result=full_result, unreachable_ids=unreachable_ids,
+                        reference_latency=reference_latency, verdict="inconclusive",
+                        reason="search-set evaluation carries infrastructure_error record(s) -- not scored",
+                    )
+                else:
+                    candidate_latency = evaluator_mod.median_latency_by_bucket(full_result.records)
+                    breach = _latency_breach(candidate_latency, reference_latency)
+                    retrieval_net = _retrieval_only_net_change(reference_full.records, full_result.records)
+                    _objective_raw, objective_adjusted = evaluator_mod.compute_objective(
+                        full_result.records, unreachable_ids
+                    )
+
+                    if breach:
+                        verdict, reason = "rejected_latency", breach
+                    elif retrieval_net < 0:
+                        verdict = "rejected_regression"
+                        reason = f"retrieval-only bucket lost cases net vs reference ({retrieval_net:+d})"
+                    elif objective_adjusted - ratchet <= NOISE_FLOOR_CASES:
+                        verdict = "rejected_no_gain"
+                        reason = (
+                            f"objective_adjusted {objective_adjusted} did not exceed ratchet "
+                            f"{ratchet} beyond the noise floor ({NOISE_FLOOR_CASES})"
+                        )
+                    else:
+                        verdict = "accepted"
+                        reason = f"objective_adjusted {objective_adjusted} exceeds ratchet {ratchet}"
+                        ratchet = objective_adjusted
+                        best_iteration = iteration
+
+                    entry = _build_entry(
+                        iteration=iteration, parent_iteration=parent_iteration, git_commit=git_commit,
+                        overrides=overrides, meta=meta, evaluated_case_set="search_set",
+                        result=full_result, unreachable_ids=unreachable_ids,
+                        reference_latency=reference_latency, verdict=verdict, reason=reason,
+                        candidate_latency=candidate_latency,
+                    )
 
         ledger_mod.write_entry(entry, ledger_dir)
         entries_so_far.append(entry)

--- a/harness/proposers.py
+++ b/harness/proposers.py
@@ -1,0 +1,286 @@
+"""proposers -- GridProposer (deterministic control) and LlmProposer.
+
+Both implement ``propose(space, ledger_history, last_result) -> dict[str, Any]``
+(issue #31 spec section 5.4): a dotted-key overrides dict, already checked
+against the declared space and the feasibility predicate. ``space`` is the
+``search_space`` module itself, so a proposer never hardcodes anything the
+space could change.
+
+After ``propose()`` returns, a proposer's ``last_meta`` attribute carries
+what the return value alone cannot: which proposer actually produced it
+(relevant when ``LlmProposer`` falls back), the LLM's rationale and model id,
+and whether a fallback fired. ``loop.py`` reads it to build the ledger entry.
+
+Criterion 5 (docs/design/2026-07-28-loop-automejorable.md section 2) runs the
+loop with both proposers so the LLM's reasoning can be shown to be worth its
+cost, or shown not to be, against this deterministic control.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
+
+
+class SearchSpaceExhausted(RuntimeError):
+    """Raised when a proposer has no untried, feasible point left to offer.
+
+    Not an error in the everyday sense -- a finite declared space run long
+    enough eventually runs out of single-field perturbations. ``loop.py``
+    catches this as an additional termination condition, on top of
+    ``--max-iterations``/``--patience``.
+    """
+
+
+class OllamaUnreachableError(RuntimeError):
+    """The real Ollama call could not reach the server, or timed out."""
+
+
+def _field_value(config: Any, dotted_key: str) -> Any:
+    """``_field_value(config, "retrieval.top_k_final")`` -> ``config.retrieval.top_k_final``."""
+    section_name, field_name = dotted_key.split(".", 1)
+    return getattr(getattr(config, section_name), field_name)
+
+
+class GridProposer:
+    """Deterministic coordinate descent from the reference configuration.
+
+    Walks ``space.proposal_order()`` (known-reachable keys first -- see
+    ``search_space.proposal_order``'s docstring), and for each key, its
+    declared values in the order given, proposing a *single*-field change
+    away from ``reference`` at a time (skipping the value that already
+    equals the reference's own, since that is not a change). Skips any point
+    already present in ``ledger_history`` (by its raw ``config_overrides``)
+    and any point ``space.is_feasible`` rejects. Reproducible from the
+    ledger alone: no randomness, no internal counter surviving between
+    ``propose()`` calls -- the walk position is entirely a function of
+    ``ledger_history``.
+    """
+
+    def __init__(self, reference: Any):
+        """Args:
+            reference: The ``AppConfig`` every single-field perturbation is
+                measured against (typically ``AppConfig.from_env()``, fixed
+                for the whole loop run).
+        """
+        self._reference = reference
+        self.last_meta: Dict[str, Any] = {"proposer": "grid", "rationale": None, "model": None,
+                                           "fallback": False, "fallback_reason": None}
+
+    def propose(self, space, ledger_history: Sequence[Any], last_result: Any) -> Dict[str, Any]:
+        """Args:
+            space: The ``search_space`` module.
+            ledger_history: Every ``LedgerEntry`` written so far, oldest first.
+            last_result: Unused by ``GridProposer`` (it only ever looks at
+                ``reference`` and the ledger) -- present for interface
+                parity with ``LlmProposer``.
+
+        Returns:
+            A single-key overrides dict.
+
+        Raises:
+            SearchSpaceExhausted: Every declared, feasible, untried point has
+                already been proposed.
+        """
+        del last_result  # deterministic control: only reference + ledger matter
+        tried = {frozenset(entry.config_overrides.items()) for entry in ledger_history}
+        for key in space.proposal_order():
+            default = _field_value(self._reference, key)
+            for value in space.ALLOWED_VALUES[key]:
+                if value == default:
+                    continue
+                overrides = {key: value}
+                if frozenset(overrides.items()) in tried:
+                    continue
+                if not space.is_feasible(overrides, self._reference):
+                    continue
+                return overrides
+        raise SearchSpaceExhausted("GridProposer has walked every declared, feasible point")
+
+
+class LlmProposer:
+    """Ollama-backed proposer, validated against the declared space before use.
+
+    Prompted with the declared space, the ledger history as
+    ``(overrides -> objective)`` pairs, and the currently failing search-set
+    cases' questions (joined from ``gold_cases.jsonl`` by id -- ``last_result``
+    itself carries no question text, only id/case_type/pass/elapsed, see
+    ``evaluator.CaseRecord``). Must return strict JSON
+    ``{"overrides": {...}, "rationale": "..."}``.
+
+    Validation is the security boundary, not the prompt (issue #31 spec
+    section 5.4): every returned overrides dict is checked against
+    ``space.DECLARED_KEYS``/``space.ALLOWED_VALUES``/``space.is_feasible``
+    before it is trusted. A key outside the space, a value outside the
+    declared set, an infeasible combination, or JSON that does not parse to
+    the required shape all count as a failed attempt and are retried, up to
+    ``max_retries`` times; past that, or the moment Ollama is unreachable,
+    this proposer falls back to an internal ``GridProposer`` and records the
+    fallback in ``last_meta`` rather than blocking the loop. Because the
+    only thing ``propose()`` can ever return is a dict of declared dotted
+    keys with declared values, there is no path by which the LLM's output
+    reaches ``grade.py``, the gold-case file or the baseline -- the harness
+    never evaluates a key or value it did not itself declare.
+    """
+
+    DEFAULT_MODEL = "gemma4:e4b"
+    DEFAULT_BASE_URL = "http://localhost:11434"
+    DEFAULT_TIMEOUT_SECONDS = 60.0
+    DEFAULT_MAX_RETRIES = 3
+
+    def __init__(
+        self,
+        reference: Any,
+        *,
+        model: str = DEFAULT_MODEL,
+        base_url: str = DEFAULT_BASE_URL,
+        timeout: float = DEFAULT_TIMEOUT_SECONDS,
+        max_retries: int = DEFAULT_MAX_RETRIES,
+        call: Optional[Callable[[str], str]] = None,
+    ):
+        """Args:
+            reference: Passed through to the internal fallback ``GridProposer``.
+            model: Ollama model id (default matches repo convention, see
+                harness/README.md).
+            base_url: Ollama server base URL.
+            timeout: Bounded HTTP timeout in seconds for the real call --
+                this is what stops an unresponsive Ollama from hanging the
+                loop.
+            max_retries: Attempts before falling back to grid.
+            call: Injected ``prompt -> raw_text`` callable, for tests. When
+                ``None``, uses the real Ollama HTTP call (lazy ``requests``
+                import, so importing this module never requires it).
+        """
+        self._reference = reference
+        self._model = model
+        self._base_url = base_url
+        self._timeout = timeout
+        self._max_retries = max_retries
+        self._call = call
+        self._grid_fallback = GridProposer(reference)
+        self.last_meta: Dict[str, Any] = {}
+
+    def propose(self, space, ledger_history: Sequence[Any], last_result: Any) -> Dict[str, Any]:
+        prompt = self._build_prompt(space, ledger_history, last_result)
+        for _attempt in range(self._max_retries):
+            try:
+                raw_text = self._call_llm(prompt)
+            except OllamaUnreachableError as exc:
+                return self._fallback(space, ledger_history, last_result, f"Ollama unreachable: {exc}")
+            parsed = self._parse(raw_text)
+            if parsed is None:
+                continue
+            overrides, rationale = parsed
+            if not self._validate(overrides, space):
+                continue
+            self.last_meta = {
+                "proposer": "llm", "rationale": rationale, "model": self._model,
+                "fallback": False, "fallback_reason": None,
+            }
+            return overrides
+        return self._fallback(
+            space, ledger_history, last_result,
+            f"no valid proposal in {self._max_retries} attempt(s) (malformed JSON or rejected by the space)",
+        )
+
+    def _fallback(self, space, ledger_history: Sequence[Any], last_result: Any, reason: str) -> Dict[str, Any]:
+        overrides = self._grid_fallback.propose(space, ledger_history, last_result)
+        self.last_meta = {
+            "proposer": "llm", "rationale": None, "model": self._model,
+            "fallback": True, "fallback_reason": reason,
+        }
+        return overrides
+
+    def _call_llm(self, prompt: str) -> str:
+        call = self._call or self._real_call
+        return call(prompt)
+
+    def _real_call(self, prompt: str) -> str:
+        """Real Ollama call: ``/api/generate``, non-streaming, JSON-formatted output."""
+        import requests  # lazy: keeps this module importable with no engine deps
+
+        try:
+            response = requests.post(
+                f"{self._base_url}/api/generate",
+                json={
+                    "model": self._model, "prompt": prompt, "stream": False,
+                    "format": "json", "think": False,
+                },
+                timeout=self._timeout,
+            )
+            response.raise_for_status()
+        except requests.RequestException as exc:
+            raise OllamaUnreachableError(str(exc)) from exc
+        return response.json().get("response", "")
+
+    @staticmethod
+    def _parse(raw_text: str) -> Optional[Tuple[Dict[str, Any], str]]:
+        try:
+            data = json.loads(raw_text)
+        except (json.JSONDecodeError, TypeError):
+            return None
+        if not isinstance(data, dict):
+            return None
+        overrides = data.get("overrides")
+        rationale = data.get("rationale")
+        if not isinstance(overrides, dict) or not isinstance(rationale, str):
+            return None
+        return overrides, rationale
+
+    def _validate(self, overrides: Dict[str, Any], space) -> bool:
+        for key, value in overrides.items():
+            if key not in space.DECLARED_KEYS:
+                return False
+            if value not in space.ALLOWED_VALUES[key]:
+                return False
+        return space.is_feasible(overrides, self._reference)
+
+    def _build_prompt(self, space, ledger_history: Sequence[Any], last_result: Any) -> str:
+        """Declared space + ledger history + currently failing questions.
+
+        Failing-case *questions* are joined from ``gold_cases.jsonl`` by id
+        (``evaluator._gold_cases``, kept as a lazy import here so this module
+        never needs ``evaluator`` at collection time either). What retrieval
+        actually surfaced is NOT included: ``evaluator.CaseRecord`` -- the
+        contract every ``EvaluatorFn`` (fake or real) returns -- carries only
+        id/case_type/passed/elapsed_seconds, not retrieved fragments. A
+        richer per-case diagnostic would need widening that contract, which
+        this PR does not do (see the PR report).
+        """
+        from harness import evaluator as evaluator_mod
+
+        lines: List[str] = [
+            "You are proposing one configuration change for a retrieval-augmented "
+            "generation pipeline, to improve gold-case pass rate without exceeding "
+            "a latency ceiling.",
+            "",
+            "Declared search space (dotted_key: allowed_values -- why):",
+        ]
+        for key, values, why, _stage in space.SEARCH_SPACE:
+            lines.append(f"  {key}: {list(values)} -- {why}")
+
+        lines.append("")
+        lines.append("Ledger history (overrides -> objective_adjusted, verdict):")
+        if ledger_history:
+            for entry in ledger_history:
+                lines.append(f"  {entry.config_overrides} -> {entry.objective_adjusted} ({entry.verdict})")
+        else:
+            lines.append("  (empty -- this is the first iteration)")
+
+        if last_result is not None:
+            questions_by_id = {c["id"]: c["question"] for c in evaluator_mod._gold_cases() if "question" in c}
+            failing = [r for r in last_result.records if not r.passed]
+            lines.append("")
+            lines.append("Currently failing search-set cases:")
+            for record in failing:
+                question = questions_by_id.get(record.id, "(question unavailable)")
+                lines.append(f"  {record.id} ({record.case_type}): {question}")
+
+        lines.append("")
+        lines.append(
+            "Propose ONE change: a dotted key from the declared space above, set to "
+            "one of its declared values. Respond with strict JSON only, no prose, "
+            'no markdown fences: {"overrides": {"<dotted_key>": <value>}, '
+            '"rationale": "<why this change should help>"}'
+        )
+        return "\n".join(lines)

--- a/harness/proposers.py
+++ b/harness/proposers.py
@@ -196,10 +196,22 @@ class LlmProposer:
         return call(prompt)
 
     def _real_call(self, prompt: str) -> str:
-        """Real Ollama call: ``/api/generate``, non-streaming, JSON-formatted output."""
-        import requests  # lazy: keeps this module importable with no engine deps
+        """Real Ollama call: ``/api/generate``, non-streaming, JSON-formatted output.
 
+        Everything that can go wrong here -- ``requests`` missing, the
+        connection failing, a non-2xx status, or a 200 whose body is not
+        JSON (a proxy error page, an empty response) -- becomes
+        ``OllamaUnreachableError`` and triggers the grid fallback (see
+        ``propose``), rather than crashing a run that might otherwise run
+        unattended for hours. Import and response-parsing both sit inside
+        the same ``try`` for exactly that reason (issue #65 PR review, LOW
+        2): the earlier version only wrapped the network call, so a missing
+        ``requests`` install or a malformed-but-200 response killed the loop
+        outright instead of falling back.
+        """
         try:
+            import requests  # lazy: keeps this module importable with no engine deps
+
             response = requests.post(
                 f"{self._base_url}/api/generate",
                 json={
@@ -209,9 +221,9 @@ class LlmProposer:
                 timeout=self._timeout,
             )
             response.raise_for_status()
-        except requests.RequestException as exc:
+            return response.json().get("response", "")
+        except Exception as exc:  # noqa: BLE001 -- any failure here must degrade to fallback, never crash the run
             raise OllamaUnreachableError(str(exc)) from exc
-        return response.json().get("response", "")
 
     @staticmethod
     def _parse(raw_text: str) -> Optional[Tuple[Dict[str, Any], str]]:

--- a/harness/search_space.py
+++ b/harness/search_space.py
@@ -1,9 +1,17 @@
 """search_space -- the declared configuration space block C searches over.
 
 Written by hand as data, never inferred by introspecting ``AppConfig``:
-adding a parameter is a visible decision here because each one multiplies the
-space against a budget of three or four full-search-set candidates per night
-(docs/design/2026-07-28-loop-automejorable.md section 4 -- 2.8 h/candidate).
+adding a parameter is a visible decision, not a budget-driven one. The
+design's original evaluation-time estimate (docs/design/2026-07-28-loop-
+automejorable.md section 4: ~2.8 h/candidate, three or four candidates a
+night) was wrong by a factor of ~6 -- issue #27's keep-alive fix removed a
+per-case cold model load the estimate baked in. A full search-set evaluation
+now costs ~13 min (measured 2026-08-12,
+tests/eval/runs/20260812T194812Z_mineru-jina_clip-faiss.json, local and
+gitignored -- a night now fits dozens of candidates). Declaring the space by
+hand stays the right call regardless of which budget is true: each
+parameter is still a visible decision about what the loop is allowed to
+search, independent of how many candidates fit in a night.
 
 Validated at import time against the real ``AppConfig``: every declared value
 is applied via ``AppConfig().with_overrides(**{key: value})``, which already
@@ -27,12 +35,13 @@ Four things live here besides the declared tunables:
 
 - ``INDEX_TIME_KEYS``: excluded from stage 1 (issue #31 spec section 2.1).
   Any of these changes what is stored, which moves the index fingerprint and
-  forces a full MinerU + jina-clip reindex -- a full evaluation already costs
-  ~2.8 h, and a reindex on top of that turns a night's three or four
-  candidates into one. They get their own slower tier once block B (#30)
-  lands and the timings are remeasured. ``_validate_declared_space`` raises
-  if any of them appears in ``SEARCH_SPACE``, so a future contributor who
-  adds one gets a red test instead of a silent overnight reindex.
+  forces a full MinerU + jina-clip reindex per candidate -- far more
+  expensive than the ~13 min a retrieval/generation-only evaluation now
+  costs (see above), whatever the exact multiple turns out to be once it is
+  measured. They get their own slower tier once block B (#30) lands and
+  reindex timing is measured. ``_validate_declared_space`` raises if any of
+  them appears in ``SEARCH_SPACE``, so a future contributor who adds one
+  gets a red test instead of a silent overnight reindex.
 - ``expand_overrides`` / ``is_feasible``: ``weight_semantic_rrf`` and
   ``weight_bm25_rrf`` are coupled (see the docstring on ``expand_overrides``),
   and three declared parameters interact (section 2.3). Neither coupling is

--- a/harness/search_space.py
+++ b/harness/search_space.py
@@ -1,0 +1,369 @@
+"""search_space -- the declared configuration space block C searches over.
+
+Written by hand as data, never inferred by introspecting ``AppConfig``:
+adding a parameter is a visible decision here because each one multiplies the
+space against a budget of three or four full-search-set candidates per night
+(docs/design/2026-07-28-loop-automejorable.md section 4 -- 2.8 h/candidate).
+
+Validated at import time against the real ``AppConfig``: every declared value
+is applied via ``AppConfig().with_overrides(**{key: value})``, which already
+raises ``ValueError`` on an unknown section or field (see
+``AppConfig.with_overrides``'s docstring), so this module cannot silently
+drift away from the config it searches. That validation call checks field
+*existence*, not value legality -- ``with_overrides`` does not type-check.
+
+This space is NOT "every field ``AppConfig`` has" -- it is "every field the
+measurement can actually move", and those two sets differ. Two examples
+found auditing this PR: ``flags.usar_llm_query_decomposition`` exists on
+``AppConfig`` but is absent from ``SEARCH_SPACE`` because the gate hardcodes
+its collaborator to ``None`` regardless of the flag (issue #64, see the
+comment where it would otherwise sit); ``retrieval.min_question_length``
+exists on ``AppConfig`` but is never declared here either -- nothing under
+``src/monkeygrab/`` reads it, the real check lives in the legacy
+``rag.chat_pdfs`` globals, so it is decorative on this config object and
+tuning it would move nothing.
+
+Four things live here besides the declared tunables:
+
+- ``INDEX_TIME_KEYS``: excluded from stage 1 (issue #31 spec section 2.1).
+  Any of these changes what is stored, which moves the index fingerprint and
+  forces a full MinerU + jina-clip reindex -- a full evaluation already costs
+  ~2.8 h, and a reindex on top of that turns a night's three or four
+  candidates into one. They get their own slower tier once block B (#30)
+  lands and the timings are remeasured. ``_validate_declared_space`` raises
+  if any of them appears in ``SEARCH_SPACE``, so a future contributor who
+  adds one gets a red test instead of a silent overnight reindex.
+- ``expand_overrides`` / ``is_feasible``: ``weight_semantic_rrf`` and
+  ``weight_bm25_rrf`` are coupled (see the docstring on ``expand_overrides``),
+  and three declared parameters interact (section 2.3). Neither coupling is
+  expressible as an independent row in ``SEARCH_SPACE``, so both live in code
+  next to the table they constrain.
+- ``PENDING_REACHABILITY_KEYS``: keys declared here but not yet proven to
+  reach the stage that consumes them through ``evaluate()``'s
+  ``config_overrides``. Currently empty -- the four keys it once named were
+  resolved by the sibling PR (#56), see its own docstring for the full
+  history -- but the set and the mechanism it drives
+  (``evaluator.verify_reachable``) stay, because this audit caught two
+  *different* ways a declared key can turn out inert (a config not reaching
+  a stage; a gate hardcoding a collaborator regardless of the flag, issue
+  #64) and a future addition gets the same check for free.
+- ``proposal_order``: the order ``GridProposer`` walks the space in, which is
+  NOT ``SEARCH_SPACE``'s declaration order -- known-reachable keys are walked
+  first so a run that starts before a future reachability gap closes still
+  spends its early iterations on knobs proven to do something.
+"""
+
+import sys
+from pathlib import Path
+from typing import Any, Mapping, Optional, Sequence, Tuple
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SRC = _REPO_ROOT / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from monkeygrab.config.app_config import AppConfig  # noqa: E402
+
+# INDEX-TIME EXCLUSION
+
+# Changing any of these invalidates the stored index (chunk boundaries,
+# contextual-retrieval summaries or embedded images all move), so they are
+# out of stage 1's action space entirely -- not just "not currently tuned".
+INDEX_TIME_KEYS: frozenset = frozenset({
+    "chunking.chunk_size",
+    "chunking.chunk_overlap",
+    "chunking.min_chunk_length",
+    "chunking.contextual_doc_chars",
+    "flags.usar_contextual_retrieval",
+    "flags.usar_embeddings_imagen",
+})
+
+# DECLARED TUNABLES
+
+# (dotted_key, allowed_values, why, stage) -- retrieval/generation-time only,
+# per issue #31 spec section 2.2. ``stage`` is documentation, naming which
+# pipeline phase reads the field ("retrieval", "reranking" or "generation");
+# it is NOT what drives the reachability gate below -- PENDING_REACHABILITY_KEYS
+# is the authoritative set for that, because "stage" alone does not predict
+# whether config_overrides actually reaches it (see that constant's docstring).
+#
+# ``usar_busqueda_hibrida`` and ``usar_reranker`` are deliberately absent: the
+# design doc names turning the reranker off as the *sabotage* used to prove
+# criterion 2 (measured 2026-07-29, see
+# docs/design/2026-07-28-loop-automejorable.md section 2). A knob whose "off"
+# position is the known-bad control used to validate the gate does not belong
+# in the same space the optimiser searches -- the loop could otherwise
+# "discover" the sabotage's opposite and get credit for reinventing the
+# default.
+SEARCH_SPACE: Tuple[Tuple[str, Tuple[Any, ...], str, str], ...] = (
+    (
+        "retrieval.top_k_final",
+        (4, 6, 8, 12, 16),
+        "Criterion 2 (2026-07-29): forcing this to 1 dropped retrieval pass "
+        "rate from 0.73 to 0.27 -- the single most load-bearing knob measured.",
+        "retrieval",
+    ),
+    (
+        "retrieval.top_k_rerank_candidates",
+        (100, 200, 300),
+        "How much the reranker gets to see.",
+        "reranking",
+    ),
+    (
+        "retrieval.n_semantic_results",
+        (40, 80, 120),
+        "Semantic branch fan-out.",
+        "retrieval",
+    ),
+    (
+        "retrieval.n_keyword_results",
+        (20, 40, 80),
+        "BM25 branch fan-out.",
+        "retrieval",
+    ),
+    (
+        "retrieval.rrf_k",
+        (30, 60, 100),
+        "Rank damping; low k trusts top ranks harder.",
+        "retrieval",
+    ),
+    (
+        "retrieval.weight_semantic_rrf",
+        (0.3, 0.45, 0.55, 0.7),
+        "Fusion weight; weight_bm25_rrf is derived, see expand_overrides().",
+        "retrieval",
+    ),
+    (
+        "retrieval.bm25_k1",
+        (1.2, 1.5, 2.0),
+        "Term-frequency saturation.",
+        "retrieval",
+    ),
+    (
+        "retrieval.bm25_b",
+        (0.5, 0.75, 0.9),
+        "Length normalisation.",
+        "retrieval",
+    ),
+    (
+        "retrieval.n_top_for_expansion",
+        (0, 3, 6),
+        "Neighbour-chunk expansion breadth; gated by flags.expandir_contexto, "
+        "see is_feasible().",
+        "retrieval",
+    ),
+    (
+        "reranking.score_threshold",
+        (0.4, 0.55, 0.65, 0.8),
+        "What the reranker is allowed to drop.",
+        "reranking",
+    ),
+    (
+        "context.max_context_chars",
+        (16000, 24000, 32000),
+        "Evidence budget handed to the generator.",
+        "generation",
+    ),
+    (
+        "flags.usar_recomp_synthesis",
+        (True, False),
+        "Synthesised briefing vs raw chunks.",
+        "generation",
+    ),
+    (
+        "flags.expandir_contexto",
+        (True, False),
+        "Neighbour-chunk expansion on/off.",
+        "generation",
+    ),
+    # flags.usar_llm_query_decomposition is deliberately ABSENT (issue #64,
+    # filed while auditing search-space reachability with the sibling PR,
+    # #56): tests/eval/run_eval.py:358 builds Retrieve(..., query_decomposer=None)
+    # unconditionally, while the product wires it whenever the flag is on
+    # (rag/engine/retrieval.py:50, default on). The gate therefore measures a
+    # retrieval pipeline no user runs, and flipping this flag inside an
+    # evaluation cannot change anything -- it would not raise (evaluate()
+    # accepts the override) and would not move a single case either. Fixing
+    # the gate needs sign-off because it will move the pass rate; until then,
+    # this key stays out of the declared space rather than spend iterations
+    # on a knob proven to do nothing. Put it back once #64 closes.
+    (
+        "flags.usar_optimizacion_contexto",
+        (True, False),
+        "Strip PDF extraction noise from fragment text before generation.",
+        "generation",
+    ),
+)
+
+DECLARED_KEYS: frozenset = frozenset(key for key, _values, _why, _stage in SEARCH_SPACE)
+ALLOWED_VALUES: dict = {key: values for key, values, _why, _stage in SEARCH_SPACE}
+_STAGE_OF: dict = {key: stage for key, _values, _why, stage in SEARCH_SPACE}
+
+# REACHABILITY GAP
+
+# History, not a live warning: found 2026-08-12 while building the sibling
+# PR (#56, the run_eval.evaluate() library API this harness's evaluator.py
+# wraps) that evaluate() threads its AppConfig into retrieval and indexing,
+# but generation goes through rag/engine/generation.py's
+# generar_respuesta_silenciosa, which never received that config directly.
+# #56 then audited all 48 dotted AppConfig fields end to end and closed the
+# gap for all four keys this set used to name:
+#   - context.max_context_chars / flags.expandir_contexto were ALREADY
+#     reaching generation -- both are read by Answer.select_evidence, which
+#     runs under the config evaluate() threads through; the original finding
+#     was overcautious about these two.
+#   - flags.usar_recomp_synthesis / flags.usar_optimizacion_contexto were
+#     genuinely dropped: they are read in build_user_message, which phase 2
+#     re-executes under a *fresh* config from wiring.app_config_from_runtime().
+#     #56 now applies them via the sanctioned rag.set_pipeline_flags(...)
+#     runtime setter for the duration of the evaluation, restored in a
+#     finally (with a test that an exception mid-run still restores the
+#     previous globals).
+#
+# Kept as a set (now empty) rather than deleted, because the mechanism it
+# drives -- evaluator.verify_reachable, proposal_order()'s reachable-first
+# walk -- caught two DIFFERENT failure classes during this same audit: this
+# one (a config silently not reaching a stage) and issue #64
+# (flags.usar_llm_query_decomposition, where the gate hardcodes
+# query_decomposer=None regardless of the flag -- see that key's removal
+# comment above). A future key added to SEARCH_SPACE gets the same startup
+# check for free; nobody has to remember to re-verify it by hand.
+PENDING_REACHABILITY_KEYS: frozenset = frozenset()
+
+
+def _validate_declared_space(entries: Sequence[Tuple[str, Tuple[Any, ...], str, str]]) -> None:
+    """Raise if ``entries`` names an index-time key, or a field ``AppConfig`` lacks.
+
+    Shared by the module-level self-check below and by
+    ``harness/tests/test_search_space.py``, which calls it directly with a
+    synthetic entry to prove an index-time addition is actually caught (spec
+    test 2) rather than trusting the module-level call never regresses.
+
+    Args:
+        entries: Same shape as ``SEARCH_SPACE``.
+
+    Raises:
+        ValueError: An entry's key is in ``INDEX_TIME_KEYS``, or
+            ``AppConfig.with_overrides`` rejects one of its declared values.
+    """
+    base = AppConfig()
+    for key, values, _why, _stage in entries:
+        if key in INDEX_TIME_KEYS:
+            raise ValueError(
+                f"{key!r} is an index-time parameter (see INDEX_TIME_KEYS) -- "
+                "it cannot be a stage-1 tunable without a reindex per candidate."
+            )
+        for value in values:
+            base.with_overrides(**{key: value})  # raises ValueError if key is unknown
+
+
+_validate_declared_space(SEARCH_SPACE)
+
+
+# COUPLED PARAMETERS
+
+
+def expand_overrides(overrides: Mapping[str, Any]) -> dict:
+    """Derive ``retrieval.weight_bm25_rrf`` from ``retrieval.weight_semantic_rrf``.
+
+    ``src/monkeygrab/application/rrf_fusion.py::fuse_semantic_and_keyword``
+    computes ``score_final = score_semantic * weight_semantic + score_keyword
+    * weight_keyword`` and sorts by it -- a linear combination used only for
+    ordering. Scaling both weights by any positive constant scales every
+    fragment's ``score_final`` by that same constant, which cannot change a
+    sort order; only the ratio between the two weights matters. Searching
+    both independently would spend budget on points that cannot differ, so
+    only ``weight_semantic_rrf`` is declared in ``SEARCH_SPACE`` and
+    ``weight_bm25_rrf`` is always derived as ``1 - weight_semantic_rrf``
+    (verified against the fusion code above, not assumed -- see the PR
+    report for confirmation).
+
+    Every override dict this module hands to ``AppConfig.with_overrides``
+    (directly, or via a caller applying overrides to build the config an
+    evaluation actually runs) must go through this function first, so a
+    ledger entry's raw ``config_overrides`` (just the one declared knob) and
+    its ``effective_config`` (both weights, summing to 1) stay reconstructible
+    from each other.
+
+    Args:
+        overrides: Dotted-key overrides, as a proposer emits them.
+
+    Returns:
+        A new dict; ``overrides`` is not mutated. Unchanged unless
+        ``"retrieval.weight_semantic_rrf"`` is present and
+        ``"retrieval.weight_bm25_rrf"`` is not already given explicitly.
+    """
+    expanded = dict(overrides)
+    if "retrieval.weight_semantic_rrf" in expanded and "retrieval.weight_bm25_rrf" not in expanded:
+        expanded["retrieval.weight_bm25_rrf"] = round(1.0 - expanded["retrieval.weight_semantic_rrf"], 10)
+    return expanded
+
+
+def is_feasible(overrides: Mapping[str, Any], reference: AppConfig) -> bool:
+    """Whether ``overrides`` applied to ``reference`` yields a runnable config.
+
+    Feasibility predicate from issue #31 spec section 2.3, checked against
+    the *effective* config (``reference`` with ``overrides`` applied), not
+    against the raw override dict -- a candidate that only touches one field
+    is feasible or not depending on what the other fields already are.
+
+    Three rules:
+
+    - ``top_k_final <= top_k_rerank_candidates``: the reranker cannot keep
+      more fragments than it was given.
+    - ``n_top_for_expansion <= top_k_final``: expansion cannot reach past the
+      fragments that survived reranking.
+    - ``n_top_for_expansion > 0`` only if ``flags.expandir_contexto`` is
+      True. Verified against ``src/monkeygrab/application/answer.py``'s
+      ``select_evidence``: ``_expand_with_neighbors(..., n_top_for_expansion)``
+      only runs ``if config.flags.expandir_contexto`` (see the PR report) --
+      the flag really does gate the parameter, so the spec's constraint holds
+      and was not dropped. (This coupling is unaffected by expandir_contexto's
+      reachability gap above: the gap is about whether an *override* to it
+      reaches generation, not about what the field means inside AppConfig.)
+
+    Args:
+        overrides: Dotted-key overrides to test.
+        reference: Base config the overrides would be applied to.
+
+    Returns:
+        False if ``overrides`` names an unknown field/section, or if the
+        resulting config would violate any of the three rules above.
+    """
+    try:
+        effective = reference.with_overrides(**expand_overrides(overrides))
+    except ValueError:
+        return False
+
+    r = effective.retrieval
+    if r.top_k_final > r.top_k_rerank_candidates:
+        return False
+    if r.n_top_for_expansion > r.top_k_final:
+        return False
+    if r.n_top_for_expansion > 0 and not effective.flags.expandir_contexto:
+        return False
+    return True
+
+
+def allowed_values(key: str) -> Optional[Tuple[Any, ...]]:
+    """Declared values for ``key``, or ``None`` if it is not in ``SEARCH_SPACE``."""
+    return ALLOWED_VALUES.get(key)
+
+
+def proposal_order() -> Tuple[str, ...]:
+    """Declared keys, known-reachable ones first, each group in declared order.
+
+    ``GridProposer`` walks the space in this order rather than
+    ``SEARCH_SPACE``'s declaration order, so a run started before the
+    reachability gap (``PENDING_REACHABILITY_KEYS``) is closed still spends
+    its early iterations on knobs proven to reach the pipeline, instead of
+    interleaving them with knobs that might currently be silent no-ops.
+
+    Returns:
+        Every key in ``DECLARED_KEYS``, reachable keys before pending ones,
+        stable within each group.
+    """
+    declared_order = [key for key, _values, _why, _stage in SEARCH_SPACE]
+    reachable = [k for k in declared_order if k not in PENDING_REACHABILITY_KEYS]
+    pending = [k for k in declared_order if k in PENDING_REACHABILITY_KEYS]
+    return tuple(reachable + pending)

--- a/harness/tests/test_criterion5_simulated.py
+++ b/harness/tests/test_criterion5_simulated.py
@@ -1,0 +1,89 @@
+"""Criterion-5 simulated test -- issue #31 spec section 6, test 12.
+
+Starting from a deliberately worsened configuration IN A SYNTHETIC LANDSCAPE,
+the loop recovers to at least a known target objective without intervention,
+run with BOTH proposers. This proves the SEARCH LOGIC recovers in a
+controlled, synthetic setting -- it does NOT prove the real pipeline
+improves. The real criterion 5 (design doc section 2) needs the GPU and
+hours (~2.8 h/candidate) and is documented in harness/README.md as pending
+measurement, never claimed here.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+if str(REPO_ROOT / "src") not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from monkeygrab.config.app_config import AppConfig
+from harness import evaluator as ev
+from harness import loop
+from harness.proposers import GridProposer, LlmProposer
+
+_KEY = "retrieval.top_k_final"
+# Deliberately not 4 (the first value GridProposer's coordinate descent
+# tries for this key) -- forces the grid run to actually search past a
+# couple of wrong guesses instead of stumbling onto the answer immediately.
+_GOOD_VALUE = 16
+_SEARCH_IDS = tuple("abcdefgh")
+_FAST_IDS = ("a",)
+_WORSENED_OBJECTIVE = 2  # what overrides={} (the reference) scores, out of 8
+_GOOD_TARGET = 7  # what {_KEY: _GOOD_VALUE} scores -- the recovery target
+
+
+def _synthetic_evaluate(overrides, case_ids):
+    """Pure, deterministic landscape: empty overrides (the reference) is a
+    deliberately worsened start; only the one declared point
+    {_KEY: _GOOD_VALUE} recovers. Every other point scores like the
+    worsened start, so a proposer cannot stumble into the good point by
+    coincidence -- it has to actually be the point proposed.
+    """
+    good = overrides.get(_KEY) == _GOOD_VALUE
+    n_pass = _GOOD_TARGET if good else _WORSENED_OBJECTIVE
+    passed_ids = set(_SEARCH_IDS[:n_pass])
+    records = tuple(
+        ev.CaseRecord(id=cid, case_type="factual_number", passed=cid in passed_ids, elapsed_seconds=200.0)
+        for cid in case_ids
+    )
+    return ev.EvaluationResult(records=records, effective_config=dict(overrides))
+
+
+def test_grid_proposer_recovers_from_a_worsened_start(tmp_path):
+    proposer = GridProposer(AppConfig())
+    report = loop.run_loop(
+        reference=AppConfig(), evaluate=_synthetic_evaluate, proposer=proposer,
+        search_set_ids=_SEARCH_IDS, fast_tier_ids=_FAST_IDS, unreachable_ids=(),
+        max_iterations=6, patience=None, ledger_dir=tmp_path, verify_reachability=False,
+    )
+
+    assert report["reference"]["objective_adjusted"] == _WORSENED_OBJECTIVE  # confirms the worsened premise
+    assert report["ratchet"] >= _GOOD_TARGET
+
+    accepted = [e for e in report["iterations"] if e["verdict"] == "accepted"]
+    assert accepted, "grid proposer never found the recovering point within its iteration budget"
+    assert accepted[0]["config_overrides"] == {_KEY: _GOOD_VALUE}
+    assert accepted[0]["proposer"] == "grid"
+
+
+def test_llm_proposer_recovers_from_a_worsened_start(tmp_path):
+    scripted_response = json.dumps({"overrides": {_KEY: _GOOD_VALUE}, "rationale": "widen top_k_final"})
+    proposer = LlmProposer(AppConfig(), call=lambda _prompt: scripted_response)
+    report = loop.run_loop(
+        reference=AppConfig(), evaluate=_synthetic_evaluate, proposer=proposer,
+        search_set_ids=_SEARCH_IDS, fast_tier_ids=_FAST_IDS, unreachable_ids=(),
+        max_iterations=3, patience=None, ledger_dir=tmp_path, verify_reachability=False,
+    )
+
+    assert report["reference"]["objective_adjusted"] == _WORSENED_OBJECTIVE
+    assert report["ratchet"] >= _GOOD_TARGET
+
+    accepted = [e for e in report["iterations"] if e["verdict"] == "accepted"]
+    assert accepted, "llm proposer never found the recovering point within its iteration budget"
+    assert accepted[0]["config_overrides"] == {_KEY: _GOOD_VALUE}
+    assert accepted[0]["proposer"] == "llm"
+    assert accepted[0]["proposer_fallback"] is False
+    assert accepted[0]["proposer_rationale"] == "widen top_k_final"

--- a/harness/tests/test_evaluator.py
+++ b/harness/tests/test_evaluator.py
@@ -1,0 +1,142 @@
+"""Tests for harness/evaluator.py -- issue #31 spec section 6, tests 5-6,
+plus the objective/latency helpers those tests and loop.py both rely on.
+"""
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+if str(REPO_ROOT / "src") not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT / "src"))
+
+import pytest
+
+from harness import evaluator as ev
+
+
+# TEST 5 -- no arxiv-sourced case id can reach the objective function.
+
+
+def test_blind_set_is_disjoint_from_the_search_set():
+    assert set(ev.blind_set_case_ids()).isdisjoint(ev.search_set_case_ids())
+
+
+def test_blind_set_is_disjoint_from_the_fast_tier():
+    assert set(ev.blind_set_case_ids()).isdisjoint(ev.load_fast_tier())
+
+
+def test_search_set_and_blind_set_partition_all_gold_cases():
+    all_ids = {c["id"] for c in ev._gold_cases()}
+    assert set(ev.search_set_case_ids()) | set(ev.blind_set_case_ids()) == all_ids
+    assert set(ev.search_set_case_ids()).isdisjoint(ev.blind_set_case_ids())
+
+
+def test_every_gold_case_source_is_corpus_or_arxiv():
+    # If a third `source` value ever appears, the two functions above would
+    # silently stop partitioning all cases -- this pins the assumption they
+    # both depend on.
+    sources = {c["source"] for c in ev._gold_cases()}
+    assert sources == {"corpus", "arxiv"}
+
+
+def test_fast_tier_loader_rejects_a_blind_set_id(tmp_path):
+    bogus = tmp_path / "fast_tier.txt"
+    bogus.write_text("resnet-top1-34layer\n", encoding="utf-8")  # a real arxiv-sourced id
+    with pytest.raises(ValueError, match="outside the search set"):
+        ev.load_fast_tier(bogus)
+
+
+# TEST 6 -- fast tier is a strict subset of the search set, and every
+# case_type in the search set appears in it.
+
+
+def test_fast_tier_is_a_strict_subset_of_the_search_set():
+    fast = set(ev.load_fast_tier())
+    search = set(ev.search_set_case_ids())
+    assert fast <= search
+    assert fast != search
+
+
+def test_fast_tier_covers_every_case_type_in_the_search_set():
+    case_type_by_id = {c["id"]: c["case_type"] for c in ev._gold_cases()}
+    search_case_types = {case_type_by_id[i] for i in ev.search_set_case_ids()}
+    fast_case_types = {case_type_by_id[i] for i in ev.load_fast_tier()}
+    assert fast_case_types == search_case_types
+
+
+def test_fast_tier_has_no_duplicate_ids():
+    fast = ev.load_fast_tier()
+    assert len(fast) == len(set(fast))
+
+
+# UNREACHABLE CASES -- starts empty (see harness/unreachable_cases.txt header).
+
+
+def test_unreachable_cases_file_starts_empty():
+    assert ev.load_unreachable_ids() == ()
+
+
+def test_unreachable_loader_rejects_an_id_outside_the_search_set(tmp_path):
+    bogus = tmp_path / "unreachable_cases.txt"
+    bogus.write_text("not-a-real-case-id  fabricated for this test\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="outside the search set"):
+        ev.load_unreachable_ids(bogus)
+
+
+# OBJECTIVE: raw vs. unreachable-adjusted.
+
+
+def _rec(case_id, case_type="factual_number", passed=True, elapsed=200.0):
+    return ev.CaseRecord(id=case_id, case_type=case_type, passed=passed, elapsed_seconds=elapsed)
+
+
+def test_objective_raw_and_adjusted_are_equal_with_no_unreachable_ids():
+    records = [_rec("a", passed=True), _rec("b", passed=False), _rec("c", passed=True)]
+    raw, adjusted = ev.compute_objective(records, unreachable_ids=())
+    assert raw == adjusted == 2
+
+
+def test_objective_adjusted_excludes_unreachable_cases_from_both_pass_and_total():
+    records = [_rec("a", passed=True), _rec("b", passed=True), _rec("c", passed=False)]
+    raw, adjusted = ev.compute_objective(records, unreachable_ids=("b",))
+    assert raw == 2  # "b" still counts as a pass in the raw count
+    assert adjusted == 1  # "b" is dropped entirely from the adjusted count
+
+
+# LATENCY BUCKETS.
+
+
+def test_median_latency_by_bucket_splits_answered_from_retrieval_only():
+    records = [
+        _rec("a", case_type="factual_number", elapsed=200.0),
+        _rec("b", case_type="factual_concept", elapsed=210.0),
+        _rec("c", case_type="figure_retrieval", elapsed=4.0),
+        _rec("d", case_type="table_retrieval", elapsed=6.0),
+    ]
+    buckets = ev.median_latency_by_bucket(records)
+    assert buckets["answered"] == pytest.approx(205.0)
+    assert buckets["retrieval_only"] == pytest.approx(5.0)
+
+
+def test_median_latency_by_bucket_is_none_for_an_empty_bucket():
+    records = [_rec("a", case_type="figure_retrieval", elapsed=4.0)]
+    buckets = ev.median_latency_by_bucket(records)
+    assert buckets["answered"] is None
+    assert buckets["retrieval_only"] == pytest.approx(4.0)
+
+
+def test_retrieval_only_case_types_match_run_eval():
+    """Guards against drift between this module's copy and run_eval's private constant.
+
+    run_eval.py imports only argparse/contextlib/json/math/os/shutil/sys/time/
+    datetime/pathlib/typing/grade at module level (grade itself is pure stdlib
+    regex), so importing it costs nothing extra in the fast CI gate.
+    """
+    eval_dir = REPO_ROOT / "tests" / "eval"
+    if str(eval_dir) not in sys.path:
+        sys.path.insert(0, str(eval_dir))
+    import run_eval
+
+    assert ev.RETRIEVAL_ONLY_CASE_TYPES == tuple(run_eval._RETRIEVAL_ONLY_CASE_TYPES)

--- a/harness/tests/test_evaluator.py
+++ b/harness/tests/test_evaluator.py
@@ -3,6 +3,7 @@ plus the objective/latency helpers those tests and loop.py both rely on.
 """
 
 import sys
+import types
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -140,3 +141,80 @@ def test_retrieval_only_case_types_match_run_eval():
     import run_eval
 
     assert ev.RETRIEVAL_ONLY_CASE_TYPES == tuple(run_eval._RETRIEVAL_ONLY_CASE_TYPES)
+
+
+def test_every_declared_search_space_key_is_honoured_by_the_real_evaluate_contract():
+    """Cross-checks search_space.DECLARED_KEYS against tests/eval/run_eval.py's
+    real, merged evaluate() contract (issue #31 sibling PR #56, merged as
+    commit 8069724) -- not a stub this time, the actual module. #56 built
+    describe_config_overrides()/validate_config_overrides() as public,
+    pure, side-effect-free functions specifically so this harness could
+    check its declared space against evaluate()'s real reachable surface
+    (see that function's own docstring) -- both do a plain dict/set lookup,
+    no I/O, so this needs no GPU, no Ollama, no model downloads.
+    """
+    eval_dir = REPO_ROOT / "tests" / "eval"
+    if str(eval_dir) not in sys.path:
+        sys.path.insert(0, str(eval_dir))
+    import run_eval
+
+    from harness import search_space
+
+    honoured = set(run_eval.describe_config_overrides()["honoured"])
+    unreachable = run_eval.describe_config_overrides()["unreachable"]
+
+    missing = {key: unreachable.get(key, "not in evaluate()'s honoured set") for key in search_space.DECLARED_KEYS if key not in honoured}
+    assert not missing, f"declared key(s) evaluate() does not honour: {missing}"
+
+    probe_overrides = {key: search_space.ALLOWED_VALUES[key][0] for key in search_space.DECLARED_KEYS}
+    run_eval.validate_config_overrides(probe_overrides)  # must not raise
+
+
+# real_evaluate() -- HIGH 1 regression (#65 PR review): mapped raw["results"]/
+# raw.get("effective_config") from an earlier sketch of #56's API. The
+# actual contract #56 returns is {"records": [...], "config": {"dev": ...,
+# "blind": ...}}; the old mapping raised KeyError on the very first real
+# call. A stub `run_eval` module carrying the real shape is injected into
+# sys.modules so this is exercised without landing #56 or touching Ollama
+# (this round's constraint: no GPU/Ollama -- the full eval gate owns the card).
+
+
+def _fake_run_eval_module(records, config_dev):
+    """A stub `run_eval` module whose evaluate() carries #56's real return shape."""
+    module = types.ModuleType("run_eval")
+    module.DEFAULT_MODELS = ["gemma4:e2b"]
+
+    def evaluate(*, models, case_ids=None, config_overrides=None, update_baseline=False, write_report=True):
+        del models, case_ids, config_overrides, update_baseline, write_report
+        return {"records": records, "config": {"dev": config_dev, "blind": {}}}
+
+    module.evaluate = evaluate
+    return module
+
+
+def test_real_evaluate_maps_the_actual_56_contract(monkeypatch):
+    records = [
+        {"id": "a", "case_type": "factual_number", "passed": True, "elapsed_seconds": 200.0},
+        {
+            "id": "b", "case_type": "figure_retrieval", "passed": False, "elapsed_seconds": 4.0,
+            "infrastructure_error": True,
+        },
+    ]
+    config_dev = {"retrieval": {"top_k_final": 8}}
+    monkeypatch.setitem(sys.modules, "run_eval", _fake_run_eval_module(records, config_dev))
+
+    result = ev.real_evaluate({"retrieval.top_k_final": 8}, ("a", "b"))
+
+    assert result.effective_config == config_dev
+    by_id = {r.id: r for r in result.records}
+    assert by_id["a"].passed is True
+    assert by_id["a"].infrastructure_error is False
+    assert by_id["b"].infrastructure_error is True
+
+
+def test_real_evaluate_raises_not_implemented_without_an_evaluate_function(monkeypatch):
+    stub = types.ModuleType("run_eval")  # no .evaluate attribute -- matches pre-#56 main
+    monkeypatch.setitem(sys.modules, "run_eval", stub)
+
+    with pytest.raises(NotImplementedError):
+        ev.real_evaluate({}, ())

--- a/harness/tests/test_harness_boundaries.py
+++ b/harness/tests/test_harness_boundaries.py
@@ -1,0 +1,168 @@
+"""harness/tests/test_harness_boundaries.py -- issue #31 spec section 1.
+
+Modelled on tests/unit/test_architecture_boundaries.py: parses each harness/
+production module's AST (not a source-text grep, which a reformatted or
+aliased import could dodge) rather than trusting the prohibitions below by
+convention.
+
+Prohibitions enforced, and what each check does and does not cover:
+
+1. **No production module imports `grade`** -- neither `import grade` nor
+   `from <anything> import grade`. Scoped to harness/ EXCLUDING harness/tests/,
+   since tests legitimately import `run_eval`/`grade` to verify these very
+   prohibitions and to mirror-check constants (see
+   harness/tests/test_evaluator.py's drift check). This is a direct-import
+   check: harness/evaluator.py imports `run_eval` (which itself imports
+   `grade` for its own scoring), and that is allowed -- the harness may read
+   and run the evaluation, never redefine how it scores (spec section 0).
+   What this does NOT cover: reaching `grade`'s functions off an
+   already-imported `run_eval` module object (e.g.
+   `run_eval.grade.grade_answer(...)`) without ever importing `grade`
+   itself. No production harness code does this; if one ever did, it still
+   could not WRITE grade.py (check 2), which is the substantive prohibition.
+2. **No production module writes** ``tests/eval/grade.py``,
+   ``gold_cases.jsonl`` or ``baseline_min_pass_rate.txt``. Detected by
+   walking every AST ``Call`` node, flagging "write-like" calls
+   (``.write_text``/``.write_bytes``/``.write``/``.writelines``, or
+   ``open()``/``Path.open()`` with a mode containing ``w``/``a``/``x``), then
+   checking whether any string literal in that call's subtree (target path,
+   arguments, f-string pieces) contains one of the three protected
+   filenames. Catches a literal path written directly or built from an
+   f-string/join with a literal filename segment -- the realistic accidental
+   case. Does NOT catch a fully dynamic path assembled from opaque variables
+   with no literal filename anywhere in the call -- undetectable by static
+   analysis without false positives, and not how a harness module would
+   plausibly reach these paths by accident.
+3. **No module under harness/ (including harness/tests/) imports
+   `subprocess` or the third-party `git` package (GitPython).** A full ban
+   on both names -- not scoped to "a git invocation" specifically, because
+   that is simpler to make non-flaky, and it is what makes
+   ledger.read_git_commit's "no subprocess" docstring claim checked rather
+   than asserted. Does NOT catch `os.system`/`os.popen`/`ctypes`-based
+   shelling out; none of this harness's modules have any reason to use
+   those, and banning the entire `os` module (needed for path handling)
+   would be impractical.
+
+Item 5 of the spec's prohibition list ("commit, merge, push, or deploy
+anything") is covered entirely by check 3: with no subprocess and no
+GitPython import anywhere under harness/, there is no code path left that
+could invoke git at all, let alone a mutating one. Item 4 ("write any
+product configuration") is not covered by this file: harness/ never writes
+outside its own ``ledger/`` directory (see harness/ledger.py, the only
+module here that writes anything), which this file does not need a separate
+check to see -- there is no `settings.json`/`.env`/`rag/chat_pdfs.py` string
+anywhere in the package to accidentally target.
+"""
+
+import ast
+import sys
+from pathlib import Path
+from typing import List, Set
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import pytest
+
+HARNESS_DIR = ROOT / "harness"
+
+PROTECTED_FILENAMES = ("grade.py", "gold_cases.jsonl", "baseline_min_pass_rate.txt")
+
+_WRITE_METHOD_NAMES = {"write_text", "write_bytes", "write", "writelines"}
+
+
+def _production_python_files() -> List[Path]:
+    """Every .py file directly under harness/, excluding harness/tests/."""
+    return sorted(
+        p for p in HARNESS_DIR.rglob("*.py")
+        if "tests" not in p.relative_to(HARNESS_DIR).parts
+    )
+
+
+def _all_python_files() -> List[Path]:
+    return sorted(HARNESS_DIR.rglob("*.py"))
+
+
+def _imports_name(tree: ast.AST, banned_name: str) -> bool:
+    """True if ``tree`` imports ``banned_name`` as a (sub)module, or imports
+    a name called ``banned_name`` from anywhere."""
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name.split(".")[0] == banned_name:
+                    return True
+        elif isinstance(node, ast.ImportFrom):
+            if node.module and banned_name in node.module.split("."):
+                return True
+            for alias in node.names:
+                if alias.name == banned_name:
+                    return True
+    return False
+
+
+def _string_constants(node: ast.AST) -> Set[str]:
+    return {sub.value for sub in ast.walk(node) if isinstance(sub, ast.Constant) and isinstance(sub.value, str)}
+
+
+def _mode_contains_write(call: ast.Call) -> bool:
+    """For an ``open(...)``-shaped call: True if a mode argument suggests writing."""
+    mode_value = None
+    if len(call.args) >= 2 and isinstance(call.args[1], ast.Constant) and isinstance(call.args[1].value, str):
+        mode_value = call.args[1].value
+    for kw in call.keywords:
+        if kw.arg == "mode" and isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, str):
+            mode_value = kw.value.value
+    if mode_value is None:
+        return False  # open()'s default mode is "r" -- not a write
+    return any(flag in mode_value for flag in ("w", "a", "x"))
+
+
+def _writes_a_protected_path(tree: ast.AST) -> Set[str]:
+    """Protected filenames found inside any write-like ``Call``'s subtree."""
+    hits: Set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        is_write_call = (
+            (isinstance(func, ast.Attribute) and func.attr in _WRITE_METHOD_NAMES)
+            or (isinstance(func, ast.Attribute) and func.attr == "open" and _mode_contains_write(node))
+            or (isinstance(func, ast.Name) and func.id == "open" and _mode_contains_write(node))
+        )
+        if not is_write_call:
+            continue
+        literals = _string_constants(node)
+        for filename in PROTECTED_FILENAMES:
+            if any(filename in literal for literal in literals):
+                hits.add(filename)
+    return hits
+
+
+def test_harness_directory_is_not_accidentally_empty():
+    """Guards the guard: an empty/misnamed directory would make every check below vacuous."""
+    assert len(_production_python_files()) >= 5
+
+
+@pytest.mark.parametrize("path", _production_python_files(), ids=lambda p: str(p.relative_to(HARNESS_DIR)))
+def test_no_harness_module_imports_grade(path):
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    assert not _imports_name(tree, "grade"), f"{path} imports grade -- forbidden (issue #31 spec section 1)"
+
+
+@pytest.mark.parametrize("path", _production_python_files(), ids=lambda p: str(p.relative_to(HARNESS_DIR)))
+def test_no_harness_module_writes_a_protected_path(path):
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    hits = _writes_a_protected_path(tree)
+    assert not hits, f"{path} appears to write protected path(s) {hits} -- forbidden (issue #31 spec section 1)"
+
+
+@pytest.mark.parametrize("path", _all_python_files(), ids=lambda p: str(p.relative_to(HARNESS_DIR)))
+def test_no_harness_module_imports_subprocess_or_gitpython(path):
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    assert not _imports_name(tree, "subprocess"), f"{path} imports subprocess -- forbidden (issue #31 spec section 1)"
+    assert not _imports_name(tree, "git"), f"{path} imports git (GitPython) -- forbidden (issue #31 spec section 1)"
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/harness/tests/test_harness_boundaries.py
+++ b/harness/tests/test_harness_boundaries.py
@@ -7,33 +7,49 @@ convention.
 
 Prohibitions enforced, and what each check does and does not cover:
 
-1. **No production module imports `grade`** -- neither `import grade` nor
-   `from <anything> import grade`. Scoped to harness/ EXCLUDING harness/tests/,
-   since tests legitimately import `run_eval`/`grade` to verify these very
-   prohibitions and to mirror-check constants (see
-   harness/tests/test_evaluator.py's drift check). This is a direct-import
-   check: harness/evaluator.py imports `run_eval` (which itself imports
-   `grade` for its own scoring), and that is allowed -- the harness may read
-   and run the evaluation, never redefine how it scores (spec section 0).
-   What this does NOT cover: reaching `grade`'s functions off an
-   already-imported `run_eval` module object (e.g.
-   `run_eval.grade.grade_answer(...)`) without ever importing `grade`
-   itself. No production harness code does this; if one ever did, it still
-   could not WRITE grade.py (check 2), which is the substantive prohibition.
-2. **No production module writes** ``tests/eval/grade.py``,
-   ``gold_cases.jsonl`` or ``baseline_min_pass_rate.txt``. Detected by
-   walking every AST ``Call`` node, flagging "write-like" calls
-   (``.write_text``/``.write_bytes``/``.write``/``.writelines``, or
-   ``open()``/``Path.open()`` with a mode containing ``w``/``a``/``x``), then
-   checking whether any string literal in that call's subtree (target path,
-   arguments, f-string pieces) contains one of the three protected
-   filenames. Catches a literal path written directly or built from an
-   f-string/join with a literal filename segment -- the realistic accidental
-   case. Does NOT catch a fully dynamic path assembled from opaque variables
-   with no literal filename anywhere in the call -- undetectable by static
-   analysis without false positives, and not how a harness module would
-   plausibly reach these paths by accident.
-3. **No module under harness/ (including harness/tests/) imports
+1. **No production module imports `grade` or `importlib`.** Neither
+   `import grade` nor `from <anything> import grade`, in any dotted form
+   (`import tests.eval.grade` is caught too -- an earlier version of this
+   check only compared the top-level segment of a plain `Import` node and
+   missed it, found in a #65 PR review). `importlib` is banned outright:
+   its only use inside this package would be `importlib.import_module("grade")`,
+   a dynamic import no static "did you import grade" check can see by
+   construction. Scoped to harness/ EXCLUDING harness/tests/, since tests
+   legitimately import `run_eval`/`grade` to verify these very prohibitions
+   and to mirror-check constants (see harness/tests/test_evaluator.py's
+   drift check). What this does NOT cover: reaching `grade`'s functions off
+   an already-imported `run_eval` module object (e.g.
+   `run_eval.grade.grade_answer(...)`) without ever importing `grade` or
+   `importlib` itself. No production harness code does this; if one ever
+   did, it still could not WRITE grade.py (check 2), which is the
+   substantive prohibition.
+2. **No production module references the literal `grade.py` or
+   `baseline_min_pass_rate.txt` filename ANYWHERE**, not only inside a
+   write-like call. No production module needs either string at all (unlike
+   `gold_cases.jsonl`, which `evaluator.py` legitimately reads) -- the
+   simplest ban that closes every write path a #65 PR review demonstrated
+   in one adversarial module (`shutil.copyfile`, `os.replace` via a variable
+   defined elsewhere, `write_text` on a path built from a folded `"grade" +
+   ".py"` concatenation) without needing to enumerate every write-shaped API
+   individually. String folding handles simple `"a" + "b"` concatenation
+   (the exact obfuscation demonstrated); it does NOT handle f-string
+   placeholders, `str.join`/`%`/`.format()`, or encoded/programmatically
+   built strings (base64, `chr()`-built strings, reading a filename from
+   another file at runtime) -- closing every possible obfuscation is not
+   this test's job, and attempting to would risk false positives for little
+   real protection.
+3. **No production module writes `gold_cases.jsonl` specifically.**
+   Unlike the two filenames above, this one must be allowed to appear as a
+   literal (``evaluator.GOLD_FILE``), so it is checked only inside
+   write-like calls: `.write_text`/`.write_bytes`/`.write`/`.writelines`,
+   `open()`/`Path.open()` with a mode containing `w`/`a`/`x`, and
+   `os.remove`/`os.unlink`/`os.replace`/`os.rename` /
+   `shutil.copyfile`/`copy`/`copy2`/`move` (added after the same PR review
+   demonstrated `os.remove`/`os.replace` bypassing the original, narrower
+   write-method list). Does NOT catch a fully dynamic path assembled from
+   opaque variables with no literal filename anywhere in the call --
+   undetectable by static analysis without false positives.
+4. **No module under harness/ (including harness/tests/) imports
    `subprocess` or the third-party `git` package (GitPython).** A full ban
    on both names -- not scoped to "a git invocation" specifically, because
    that is simpler to make non-flaky, and it is what makes
@@ -44,7 +60,7 @@ Prohibitions enforced, and what each check does and does not cover:
    would be impractical.
 
 Item 5 of the spec's prohibition list ("commit, merge, push, or deploy
-anything") is covered entirely by check 3: with no subprocess and no
+anything") is covered entirely by check 4: with no subprocess and no
 GitPython import anywhere under harness/, there is no code path left that
 could invoke git at all, let alone a mutating one. Item 4 ("write any
 product configuration") is not covered by this file: harness/ never writes
@@ -52,12 +68,19 @@ outside its own ``ledger/`` directory (see harness/ledger.py, the only
 module here that writes anything), which this file does not need a separate
 check to see -- there is no `settings.json`/`.env`/`rag/chat_pdfs.py` string
 anywhere in the package to accidentally target.
+
+``test_adversarial_bypass_module_is_caught_by_every_check`` is a regression
+test for the exact six-bypass module a #65 PR review used to show the
+original version of this file passed vacuously: it parses that module's
+source directly (never written under harness/) and asserts every check
+above flags at least one of its six attacks, so "these checks pass" means
+something more than "today's real files happen to be clean."
 """
 
 import ast
 import sys
 from pathlib import Path
-from typing import List, Set
+from typing import List, Optional, Set
 
 ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
@@ -67,9 +90,17 @@ import pytest
 
 HARNESS_DIR = ROOT / "harness"
 
-PROTECTED_FILENAMES = ("grade.py", "gold_cases.jsonl", "baseline_min_pass_rate.txt")
+# Banned as a literal ANYWHERE in production code (check 2) -- no production
+# module has a legitimate reason to reference either filename at all.
+_LITERAL_BANNED_FILENAMES = ("grade.py", "baseline_min_pass_rate.txt")
+
+# Allowed as a literal (evaluator.py reads it), banned only inside a
+# write-like call (check 3).
+_GOLD_CASES_FILENAME = "gold_cases.jsonl"
 
 _WRITE_METHOD_NAMES = {"write_text", "write_bytes", "write", "writelines"}
+_OS_WRITE_FUNCS = {"remove", "unlink", "replace", "rename"}
+_SHUTIL_WRITE_FUNCS = {"copyfile", "copy", "copy2", "move"}
 
 
 def _production_python_files() -> List[Path]:
@@ -85,12 +116,17 @@ def _all_python_files() -> List[Path]:
 
 
 def _imports_name(tree: ast.AST, banned_name: str) -> bool:
-    """True if ``tree`` imports ``banned_name`` as a (sub)module, or imports
-    a name called ``banned_name`` from anywhere."""
+    """True if ``tree`` imports ``banned_name`` as a (sub)module at any depth
+    of a dotted path, or imports a name called ``banned_name`` from anywhere.
+
+    Checks every segment of a plain ``import a.b.c`` (not just ``a``) -- a
+    #65 PR review found ``import tests.eval.grade`` invisible to a version
+    of this check that only looked at the first segment.
+    """
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
             for alias in node.names:
-                if alias.name.split(".")[0] == banned_name:
+                if banned_name in alias.name.split("."):
                     return True
         elif isinstance(node, ast.ImportFrom):
             if node.module and banned_name in node.module.split("."):
@@ -101,8 +137,73 @@ def _imports_name(tree: ast.AST, banned_name: str) -> bool:
     return False
 
 
-def _string_constants(node: ast.AST) -> Set[str]:
-    return {sub.value for sub in ast.walk(node) if isinstance(sub, ast.Constant) and isinstance(sub.value, str)}
+def _docstring_constant_ids(tree: ast.AST) -> Set[int]:
+    """``id()`` of every ``Constant`` node that is a module/class/function docstring.
+
+    A docstring is an inert string in that specific position -- nothing in
+    this package (or plausibly any package) reads ``__doc__`` back out to
+    build a filesystem path, so excluding it from the literal scan cannot
+    hide a real reference. Needed because this test's own module docstring,
+    and several production modules' docstrings, legitimately explain these
+    prohibitions in prose (mentioning "grade.py"/"baseline_min_pass_rate.txt"
+    as words, not as code references) -- without this exclusion the literal
+    scan flags its own documentation.
+    """
+    ids: Set[int] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+            body = node.body
+            if body and isinstance(body[0], ast.Expr) and isinstance(body[0].value, ast.Constant) \
+                    and isinstance(body[0].value.value, str):
+                ids.add(id(body[0].value))
+    return ids
+
+
+def _fold_string_literals(tree: ast.AST, exclude_ids: Optional[Set[int]] = None) -> Set[str]:
+    """Every (non-excluded) string literal under ``tree``, plus simple
+    ``"a" + "b"`` concatenations folded together.
+
+    Handles the exact obfuscation a #65 PR review used: splitting a
+    protected filename across a ``+`` so no single ``Constant`` node equals
+    or contains it (``"grade" + ".py"``). Does not attempt to fold
+    f-strings, ``str.join``/``%``/``.format()``, or anything programmatically
+    built -- see the module docstring for why that line is drawn here.
+
+    Args:
+        tree: Subtree to scan.
+        exclude_ids: ``id()``s of ``Constant`` nodes to skip (docstrings --
+            see ``_docstring_constant_ids``). Only meaningful for a
+            whole-file scan; a write-call's own argument subtree never
+            contains a docstring node, so callers scoped to one call omit
+            this.
+    """
+    exclude_ids = exclude_ids or set()
+    literals: Set[str] = set()
+
+    def _folded(node: ast.AST):
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            return node.value
+        if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+            left, right = _folded(node.left), _folded(node.right)
+            if left is not None and right is not None:
+                return left + right
+        return None
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            if id(node) in exclude_ids:
+                continue
+            literals.add(node.value)
+        elif isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+            folded = _folded(node)
+            if folded is not None:
+                literals.add(folded)
+    return literals
+
+
+def _references_banned_literal_anywhere(tree: ast.AST) -> Set[str]:
+    literals = _fold_string_literals(tree, exclude_ids=_docstring_constant_ids(tree))
+    return {name for name in _LITERAL_BANNED_FILENAMES if any(name in lit for lit in literals)}
 
 
 def _mode_contains_write(call: ast.Call) -> bool:
@@ -118,25 +219,34 @@ def _mode_contains_write(call: ast.Call) -> bool:
     return any(flag in mode_value for flag in ("w", "a", "x"))
 
 
-def _writes_a_protected_path(tree: ast.AST) -> Set[str]:
-    """Protected filenames found inside any write-like ``Call``'s subtree."""
-    hits: Set[str] = set()
+def _is_write_like_call(node: ast.Call) -> bool:
+    func = node.func
+    if isinstance(func, ast.Attribute):
+        if func.attr in _WRITE_METHOD_NAMES:
+            return True
+        if func.attr == "open" and _mode_contains_write(node):
+            return True
+        if isinstance(func.value, ast.Name):
+            if func.value.id == "os" and func.attr in _OS_WRITE_FUNCS:
+                return True
+            if func.value.id == "shutil" and func.attr in _SHUTIL_WRITE_FUNCS:
+                return True
+        return False
+    if isinstance(func, ast.Name):
+        if func.id == "open" and _mode_contains_write(node):
+            return True
+        if func.id in _OS_WRITE_FUNCS:  # covers `from os import remove` then `remove(...)`
+            return True
+    return False
+
+
+def _writes_gold_cases(tree: ast.AST) -> bool:
+    """True if any write-like ``Call`` anywhere in ``tree`` references ``gold_cases.jsonl``."""
     for node in ast.walk(tree):
-        if not isinstance(node, ast.Call):
-            continue
-        func = node.func
-        is_write_call = (
-            (isinstance(func, ast.Attribute) and func.attr in _WRITE_METHOD_NAMES)
-            or (isinstance(func, ast.Attribute) and func.attr == "open" and _mode_contains_write(node))
-            or (isinstance(func, ast.Name) and func.id == "open" and _mode_contains_write(node))
-        )
-        if not is_write_call:
-            continue
-        literals = _string_constants(node)
-        for filename in PROTECTED_FILENAMES:
-            if any(filename in literal for literal in literals):
-                hits.add(filename)
-    return hits
+        if isinstance(node, ast.Call) and _is_write_like_call(node):
+            if any(_GOLD_CASES_FILENAME in lit for lit in _fold_string_literals(node)):
+                return True
+    return False
 
 
 def test_harness_directory_is_not_accidentally_empty():
@@ -145,16 +255,23 @@ def test_harness_directory_is_not_accidentally_empty():
 
 
 @pytest.mark.parametrize("path", _production_python_files(), ids=lambda p: str(p.relative_to(HARNESS_DIR)))
-def test_no_harness_module_imports_grade(path):
+def test_no_harness_module_imports_grade_or_importlib(path):
     tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
     assert not _imports_name(tree, "grade"), f"{path} imports grade -- forbidden (issue #31 spec section 1)"
+    assert not _imports_name(tree, "importlib"), f"{path} imports importlib -- forbidden (issue #31 spec section 1)"
 
 
 @pytest.mark.parametrize("path", _production_python_files(), ids=lambda p: str(p.relative_to(HARNESS_DIR)))
-def test_no_harness_module_writes_a_protected_path(path):
+def test_no_harness_module_references_grade_py_or_baseline_literal(path):
     tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
-    hits = _writes_a_protected_path(tree)
-    assert not hits, f"{path} appears to write protected path(s) {hits} -- forbidden (issue #31 spec section 1)"
+    hits = _references_banned_literal_anywhere(tree)
+    assert not hits, f"{path} references protected literal(s) {hits} -- forbidden (issue #31 spec section 1)"
+
+
+@pytest.mark.parametrize("path", _production_python_files(), ids=lambda p: str(p.relative_to(HARNESS_DIR)))
+def test_no_harness_module_writes_gold_cases(path):
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    assert not _writes_gold_cases(tree), f"{path} appears to write gold_cases.jsonl -- forbidden (issue #31 spec section 1)"
 
 
 @pytest.mark.parametrize("path", _all_python_files(), ids=lambda p: str(p.relative_to(HARNESS_DIR)))
@@ -162,6 +279,44 @@ def test_no_harness_module_imports_subprocess_or_gitpython(path):
     tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
     assert not _imports_name(tree, "subprocess"), f"{path} imports subprocess -- forbidden (issue #31 spec section 1)"
     assert not _imports_name(tree, "git"), f"{path} imports git (GitPython) -- forbidden (issue #31 spec section 1)"
+
+
+# REGRESSION TEST -- proves the checks above actually catch something.
+
+_ADVERSARIAL_MODULE_SOURCE = '''
+import importlib
+import tests.eval.grade
+import shutil
+import os
+from pathlib import Path
+
+EVAL = Path("tests/eval")
+baseline_path = EVAL / "baseline_min_pass_rate.txt"
+
+
+def attack():
+    importlib.import_module("grade")
+    shutil.copyfile("src.py", EVAL / "grade.py")
+    os.remove(EVAL / "gold_cases.jsonl")
+    os.replace("tmp", baseline_path)
+    (EVAL / ("grade" + ".py")).write_text("evil")
+'''
+
+
+def test_adversarial_bypass_module_is_caught_by_every_check():
+    """The exact six-bypass module a #65 PR review used to show the original
+    boundary test passed vacuously. Every one of its attacks must be caught
+    by at least one check, proving the fix rather than trusting it."""
+    tree = ast.parse(_ADVERSARIAL_MODULE_SOURCE, filename="<adversarial>")
+
+    assert _imports_name(tree, "grade"), "dotted `import tests.eval.grade` should be caught"
+    assert _imports_name(tree, "importlib"), "`import importlib` should be caught"
+
+    literal_hits = _references_banned_literal_anywhere(tree)
+    assert "grade.py" in literal_hits, "grade.py (direct literal and folded '+') should be caught"
+    assert "baseline_min_pass_rate.txt" in literal_hits, "baseline literal (via a variable) should be caught"
+
+    assert _writes_gold_cases(tree), "os.remove(..., gold_cases.jsonl) should be caught"
 
 
 if __name__ == "__main__":

--- a/harness/tests/test_ledger.py
+++ b/harness/tests/test_ledger.py
@@ -1,0 +1,126 @@
+"""Tests for harness/ledger.py -- issue #31 spec section 6, test 10, plus
+the append-only read/write mechanics loop.py depends on.
+"""
+
+import dataclasses
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+if str(REPO_ROOT / "src") not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from monkeygrab.config.app_config import AppConfig
+from harness import ledger, search_space
+
+
+def _entry(iteration=1, overrides=None, effective_config=None, verdict="accepted"):
+    overrides = overrides or {}
+    return ledger.LedgerEntry(
+        schema_version=ledger.SCHEMA_VERSION,
+        iteration=iteration,
+        parent_iteration=None,
+        git_commit="deadbeef",
+        config_overrides=overrides,
+        effective_config=effective_config or {},
+        proposer="grid",
+        proposer_rationale=None,
+        proposer_model=None,
+        proposer_fallback=False,
+        proposer_fallback_reason=None,
+        evaluated_case_set="search_set",
+        case_records=[{"id": "a", "case_type": "factual_number", "passed": True, "elapsed_seconds": 1.0}],
+        summary={"total": 1, "passed": 1, "pass_rate": 1.0},
+        objective_raw=1,
+        objective_adjusted=1,
+        median_latency_answered_s=200.0,
+        median_latency_retrieval_only_s=4.0,
+        reference_median_latency_answered_s=200.0,
+        reference_median_latency_retrieval_only_s=4.0,
+        latency_ceiling_multiplier=1.20,
+        verdict=verdict,
+        reason="test entry",
+    )
+
+
+# TEST 10 -- a ledger entry round-trips: reconstruct the config from an
+# entry and get the same overrides (criterion 7).
+
+
+def test_ledger_entry_round_trips_through_json(tmp_path):
+    original = _entry(overrides={"retrieval.top_k_final": 12})
+    path = ledger.write_entry(original, ledger_dir=tmp_path)
+    loaded = ledger.read_entry(path)
+    assert loaded == original
+
+
+def test_ledger_entry_reconstructs_the_same_effective_config(tmp_path):
+    base = AppConfig()
+    overrides = {"retrieval.top_k_final": 12, "retrieval.weight_semantic_rrf": 0.7}
+    effective = base.with_overrides(**search_space.expand_overrides(overrides))
+    original = _entry(overrides=overrides, effective_config=dataclasses.asdict(effective))
+
+    path = ledger.write_entry(original, ledger_dir=tmp_path)
+    loaded = ledger.read_entry(path)
+
+    assert loaded.config_overrides == overrides
+    reconstructed = base.with_overrides(**search_space.expand_overrides(loaded.config_overrides))
+    assert dataclasses.asdict(reconstructed) == loaded.effective_config
+
+
+# APPEND-ONLY MECHANICS.
+
+
+def test_write_entry_appends_to_index_without_touching_earlier_entries(tmp_path):
+    first = _entry(iteration=1)
+    second = _entry(iteration=2, overrides={"retrieval.top_k_final": 4})
+    path1 = ledger.write_entry(first, ledger_dir=tmp_path)
+    path2 = ledger.write_entry(second, ledger_dir=tmp_path)
+
+    assert path1 != path2
+    assert ledger.read_entry(path1) == first
+    assert ledger.read_entry(path2) == second
+
+    index_lines = (tmp_path / ledger.INDEX_FILE_NAME).read_text(encoding="utf-8").splitlines()
+    assert len(index_lines) == 2
+
+
+def test_next_iteration_number_is_one_for_an_empty_ledger(tmp_path):
+    assert ledger.next_iteration_number(tmp_path) == 1
+
+
+def test_next_iteration_number_continues_after_existing_entries(tmp_path):
+    ledger.write_entry(_entry(iteration=1), ledger_dir=tmp_path)
+    ledger.write_entry(_entry(iteration=5), ledger_dir=tmp_path)
+    assert ledger.next_iteration_number(tmp_path) == 6
+
+
+def test_read_history_is_sorted_by_iteration(tmp_path):
+    ledger.write_entry(_entry(iteration=3), ledger_dir=tmp_path)
+    ledger.write_entry(_entry(iteration=1), ledger_dir=tmp_path)
+    ledger.write_entry(_entry(iteration=2), ledger_dir=tmp_path)
+    history = ledger.read_history(tmp_path)
+    assert [e.iteration for e in history] == [1, 2, 3]
+
+
+def test_read_history_on_a_missing_directory_is_empty(tmp_path):
+    assert ledger.read_history(tmp_path / "does_not_exist") == []
+
+
+# GIT COMMIT: no subprocess, best-effort.
+
+
+def test_read_git_commit_returns_none_outside_any_git_repo(tmp_path):
+    assert ledger.read_git_commit(tmp_path) is None
+
+
+def test_read_git_commit_finds_this_repos_head():
+    # This repo IS a git repo (see conftest/CI); a real sha should come back,
+    # not None -- proves the worktree .git-file path (see the module
+    # docstring) actually resolves, not just the plain-.git-directory path.
+    sha = ledger.read_git_commit(Path(__file__).resolve())
+    assert sha is not None
+    assert len(sha) == 40
+    assert all(c in "0123456789abcdef" for c in sha)

--- a/harness/tests/test_ledger.py
+++ b/harness/tests/test_ledger.py
@@ -3,6 +3,7 @@ the append-only read/write mechanics loop.py depends on.
 """
 
 import dataclasses
+import json
 import sys
 from pathlib import Path
 
@@ -107,6 +108,33 @@ def test_read_history_is_sorted_by_iteration(tmp_path):
 
 def test_read_history_on_a_missing_directory_is_empty(tmp_path):
     assert ledger.read_history(tmp_path / "does_not_exist") == []
+
+
+def test_read_history_ignores_a_report_json_in_the_same_directory(tmp_path):
+    """HIGH 3 regression (#65 PR review): cli.py writes report.json into the
+    same ledger_dir as the entry files. A bare `*.json` glob fed it to
+    LedgerEntry(**data) and crashed with "unexpected keyword argument
+    'generated_at'" on the second invocation against a non-empty
+    ledger_dir -- which the default harness/ledger/ becomes after one real
+    run, since the ledger is meant to persist across many nights (see
+    loop.run_loop's ledger_dir docstring)."""
+    ledger.write_entry(_entry(iteration=1), ledger_dir=tmp_path)
+    report_like = {
+        "generated_at": "2026-08-12T00:00:00+00:00",
+        "reference": {"objective_adjusted": 27},
+        "ratchet": 27,
+        "best_iteration": None,
+        "iterations_run": 1,
+        "termination_reason": "patience",
+        "resolution_warning": {},
+        "iterations": [],
+    }
+    (tmp_path / "report.json").write_text(json.dumps(report_like), encoding="utf-8")
+
+    history = ledger.read_history(tmp_path)  # must not raise
+
+    assert [e.iteration for e in history] == [1]
+    assert ledger.next_iteration_number(tmp_path) == 2
 
 
 # GIT COMMIT: no subprocess, best-effort.

--- a/harness/tests/test_loop.py
+++ b/harness/tests/test_loop.py
@@ -1,0 +1,228 @@
+"""Tests for harness/loop.py -- issue #31 spec section 6, tests 9 and 11,
+plus regression/acceptance coverage for the same state machine.
+
+Every evaluator here is a small deterministic in-test double -- exactly the
+"deterministic fake evaluator" spec section 6's preamble asks for -- so none
+of this needs a GPU, Ollama or PDFs.
+"""
+
+import itertools
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+if str(REPO_ROOT / "src") not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from monkeygrab.config.app_config import AppConfig
+from harness import evaluator as ev
+from harness import loop
+
+
+def _rec(case_id, case_type, passed, elapsed):
+    return ev.CaseRecord(id=case_id, case_type=case_type, passed=passed, elapsed_seconds=elapsed)
+
+
+class _FixedProposer:
+    """Always proposes the same overrides -- for tests where the proposer's
+    own search behavior is not what is under test."""
+
+    def __init__(self, overrides):
+        self._overrides = overrides
+        self.last_meta = {"proposer": "grid", "rationale": None, "model": None,
+                           "fallback": False, "fallback_reason": None}
+
+    def propose(self, space, ledger_history, last_result):
+        return dict(self._overrides)
+
+
+class _CyclingProposer:
+    def __init__(self, options):
+        self._it = itertools.cycle(options)
+        self.last_meta = {"proposer": "grid", "rationale": None, "model": None,
+                           "fallback": False, "fallback_reason": None}
+
+    def propose(self, space, ledger_history, last_result):
+        return dict(next(self._it))
+
+
+# TEST 9 -- a candidate that scores higher but exceeds the latency ceiling
+# is rejected_latency and does not move the ratchet (criterion 6).
+
+
+def test_candidate_scoring_higher_but_breaching_latency_is_rejected(tmp_path):
+    search_ids = ("a", "b", "c")
+    fast_ids = ("a",)
+
+    def evaluate(overrides, case_ids):
+        boosted = overrides.get("retrieval.top_k_final") == 16
+        records = []
+        for cid in case_ids:
+            if boosted:
+                records.append(_rec(cid, "factual_number", True, 500.0))  # passes everything, but slow
+            else:
+                records.append(_rec(cid, "factual_number", cid != "c", 200.0))  # reference fails "c"
+        return ev.EvaluationResult(records=tuple(records), effective_config=dict(overrides))
+
+    proposer = _FixedProposer({"retrieval.top_k_final": 16})
+    report = loop.run_loop(
+        reference=AppConfig(), evaluate=evaluate, proposer=proposer,
+        search_set_ids=search_ids, fast_tier_ids=fast_ids, unreachable_ids=(),
+        max_iterations=1, patience=None, ledger_dir=tmp_path, verify_reachability=False,
+    )
+
+    assert len(report["iterations"]) == 1
+    entry = report["iterations"][0]
+    assert entry["verdict"] == "rejected_latency"
+    assert entry["objective_adjusted"] > report["reference"]["objective_adjusted"]  # scored higher...
+    assert report["ratchet"] == report["reference"]["objective_adjusted"]  # ...but ratchet did not move
+    assert report["best_iteration"] is None
+
+
+def test_latency_breach_is_checked_per_bucket_independently(tmp_path):
+    # A candidate that blows the retrieval-only budget but keeps the
+    # answered budget must still be rejected -- a blended median would hide
+    # this (retrieval-only is ~50x cheaper, so it barely moves a blend).
+    search_ids = ("fig",)
+    fast_ids = ("fig",)
+
+    def evaluate(overrides, case_ids):
+        slow_retrieval = "retrieval.n_semantic_results" in overrides
+        elapsed = 50.0 if slow_retrieval else 4.0  # reference retrieval-only median is 4.0s
+        records = [_rec(cid, "figure_retrieval", True, elapsed) for cid in case_ids]
+        return ev.EvaluationResult(records=tuple(records), effective_config=dict(overrides))
+
+    proposer = _FixedProposer({"retrieval.n_semantic_results": 120})
+    report = loop.run_loop(
+        reference=AppConfig(), evaluate=evaluate, proposer=proposer,
+        search_set_ids=search_ids, fast_tier_ids=fast_ids, unreachable_ids=(),
+        max_iterations=1, patience=None, ledger_dir=tmp_path, verify_reachability=False,
+    )
+    assert report["iterations"][0]["verdict"] == "rejected_latency"
+    assert "retrieval_only" in report["iterations"][0]["reason"]
+
+
+# TEST 11 -- termination fires on budget, and on patience, and writes a
+# report in both cases.
+
+
+def test_termination_fires_on_max_iterations(tmp_path):
+    proposer = _CyclingProposer([{"retrieval.top_k_final": 4}, {"retrieval.top_k_final": 6}])
+
+    def evaluate(overrides, case_ids):
+        records = [_rec(cid, "factual_number", True, 200.0) for cid in case_ids]
+        return ev.EvaluationResult(records=tuple(records), effective_config=dict(overrides))
+
+    report = loop.run_loop(
+        reference=AppConfig(), evaluate=evaluate, proposer=proposer,
+        search_set_ids=("a", "b"), fast_tier_ids=("a",), unreachable_ids=(),
+        max_iterations=2, patience=None, ledger_dir=tmp_path, verify_reachability=False,
+    )
+
+    assert report is not None
+    assert report["termination_reason"] == "max_iterations"
+    assert report["iterations_run"] == 2
+    assert len(report["iterations"]) == 2
+
+
+def test_termination_fires_on_patience(tmp_path):
+    proposer = _CyclingProposer([{"retrieval.top_k_final": 4}, {"retrieval.top_k_final": 6}])
+
+    def evaluate(overrides, case_ids):
+        # Candidate always matches the reference exactly -> always rejected_no_gain.
+        records = [_rec(cid, "factual_number", True, 200.0) for cid in case_ids]
+        return ev.EvaluationResult(records=tuple(records), effective_config=dict(overrides))
+
+    report = loop.run_loop(
+        reference=AppConfig(), evaluate=evaluate, proposer=proposer,
+        search_set_ids=("a", "b"), fast_tier_ids=("a",), unreachable_ids=(),
+        max_iterations=None, patience=2, ledger_dir=tmp_path, verify_reachability=False,
+    )
+
+    assert report is not None
+    assert report["termination_reason"] == "patience"
+    assert report["iterations_run"] == 2
+    assert all(entry["verdict"] == "rejected_no_gain" for entry in report["iterations"])
+
+
+def test_run_loop_requires_a_termination_condition():
+    import pytest
+
+    with pytest.raises(ValueError):
+        loop.run_loop(
+            reference=AppConfig(), evaluate=lambda o, c: None, proposer=_FixedProposer({}),
+            search_set_ids=(), fast_tier_ids=(), max_iterations=None, patience=None,
+        )
+
+
+# REGRESSION AND ACCEPTANCE (state-machine coverage beyond 9/11).
+
+
+def test_fast_tier_regression_is_rejected_before_paying_for_the_full_set(tmp_path):
+    search_ids = ("a", "b", "c", "d")
+    fast_ids = ("a",)
+    full_eval_calls = {"count": 0}
+
+    def evaluate(overrides, case_ids):
+        if set(case_ids) == set(search_ids):
+            full_eval_calls["count"] += 1
+        regress = "retrieval.bm25_k1" in overrides
+        # Reference: "a" passes. Candidate: "a" now fails -> regression.
+        records = [_rec(cid, "factual_number", not (regress and cid == "a"), 200.0) for cid in case_ids]
+        return ev.EvaluationResult(records=tuple(records), effective_config=dict(overrides))
+
+    proposer = _FixedProposer({"retrieval.bm25_k1": 2.0})
+    report = loop.run_loop(
+        reference=AppConfig(), evaluate=evaluate, proposer=proposer,
+        search_set_ids=search_ids, fast_tier_ids=fast_ids, unreachable_ids=(),
+        max_iterations=1, patience=None, ledger_dir=tmp_path, verify_reachability=False,
+    )
+
+    entry = report["iterations"][0]
+    assert entry["verdict"] == "rejected_regression"
+    assert entry["evaluated_case_set"] == "fast_tier"
+    assert "a" in entry["reason"]
+    # The reference's own full-set evaluation happens once regardless (to
+    # seed the ratchet); the candidate's full-set evaluation must never run.
+    assert full_eval_calls["count"] == 1
+
+
+def test_a_real_improvement_is_accepted_and_moves_the_ratchet(tmp_path):
+    search_ids = ("a", "b", "c", "d", "e", "f", "g", "h")
+    fast_ids = ("a",)
+
+    def evaluate(overrides, case_ids):
+        better = overrides.get("retrieval.top_k_final") == 12
+        # Reference passes 6/8; the improved candidate passes all 8 -- a
+        # clear gain, well past the noise floor of 0.
+        records = [_rec(cid, "factual_number", better or cid not in ("g", "h"), 200.0) for cid in case_ids]
+        return ev.EvaluationResult(records=tuple(records), effective_config=dict(overrides))
+
+    proposer = _FixedProposer({"retrieval.top_k_final": 12})
+    report = loop.run_loop(
+        reference=AppConfig(), evaluate=evaluate, proposer=proposer,
+        search_set_ids=search_ids, fast_tier_ids=fast_ids, unreachable_ids=(),
+        max_iterations=1, patience=None, ledger_dir=tmp_path, verify_reachability=False,
+    )
+
+    entry = report["iterations"][0]
+    assert entry["verdict"] == "accepted"
+    assert report["ratchet"] == 8
+    assert report["best_iteration"] == entry["iteration"]
+
+
+def test_resolution_warning_is_always_present_in_the_report(tmp_path):
+    def evaluate(overrides, case_ids):
+        records = [_rec(cid, "factual_number", True, 200.0) for cid in case_ids]
+        return ev.EvaluationResult(records=tuple(records), effective_config=dict(overrides))
+
+    report = loop.run_loop(
+        reference=AppConfig(), evaluate=evaluate, proposer=_FixedProposer({"retrieval.top_k_final": 4}),
+        search_set_ids=("a",), fast_tier_ids=("a",), max_iterations=1, patience=None,
+        ledger_dir=tmp_path, verify_reachability=False,
+    )
+    assert report["resolution_warning"] == loop.RESOLUTION_WARNING
+    assert report["resolution_warning"]["available_search_set_failures"] == 5
+    assert report["resolution_warning"]["demonstrability_flip_threshold"] == 6

--- a/harness/tests/test_loop.py
+++ b/harness/tests/test_loop.py
@@ -16,13 +16,18 @@ if str(REPO_ROOT) not in sys.path:
 if str(REPO_ROOT / "src") not in sys.path:
     sys.path.insert(0, str(REPO_ROOT / "src"))
 
+import pytest
+
 from monkeygrab.config.app_config import AppConfig
 from harness import evaluator as ev
 from harness import loop
 
 
-def _rec(case_id, case_type, passed, elapsed):
-    return ev.CaseRecord(id=case_id, case_type=case_type, passed=passed, elapsed_seconds=elapsed)
+def _rec(case_id, case_type, passed, elapsed, infra_error=False):
+    return ev.CaseRecord(
+        id=case_id, case_type=case_type, passed=passed, elapsed_seconds=elapsed,
+        infrastructure_error=infra_error,
+    )
 
 
 class _FixedProposer:
@@ -148,8 +153,6 @@ def test_termination_fires_on_patience(tmp_path):
 
 
 def test_run_loop_requires_a_termination_condition():
-    import pytest
-
     with pytest.raises(ValueError):
         loop.run_loop(
             reference=AppConfig(), evaluate=lambda o, c: None, proposer=_FixedProposer({}),
@@ -226,3 +229,138 @@ def test_resolution_warning_is_always_present_in_the_report(tmp_path):
     assert report["resolution_warning"] == loop.RESOLUTION_WARNING
     assert report["resolution_warning"]["available_search_set_failures"] == 5
     assert report["resolution_warning"]["demonstrability_flip_threshold"] == 6
+
+
+# MEDIUM 3 (#65 PR review): a blended objective can hide a candidate that
+# trades retrieval quality for factual-answer luck. rejected_regression now
+# also fires at the search-set stage when the retrieval-only bucket loses
+# cases net, even if the blended objective_adjusted went up.
+
+
+def test_retrieval_only_net_loss_is_rejected_despite_a_higher_blended_objective(tmp_path):
+    search_ids = ("fig1", "fig2", "fig3", "ans1", "ans2", "ans3", "ans4", "ans5")
+
+    def evaluate(overrides, case_ids):
+        traded = overrides.get("retrieval.top_k_final") == 16
+        records = []
+        for cid in case_ids:
+            is_fig = cid.startswith("fig")
+            if is_fig:
+                passed = not traded  # reference: all 3 figures pass; traded: all 3 fail
+            else:
+                passed = traded or cid == "ans1"  # reference: only ans1 passes; traded: all 5 pass
+            records.append(_rec(cid, "figure_retrieval" if is_fig else "factual_number", passed,
+                                 4.0 if is_fig else 200.0))
+        return ev.EvaluationResult(records=tuple(records), effective_config=dict(overrides))
+
+    proposer = _FixedProposer({"retrieval.top_k_final": 16})
+    report = loop.run_loop(
+        reference=AppConfig(), evaluate=evaluate, proposer=proposer,
+        search_set_ids=search_ids, fast_tier_ids=("ans1",), unreachable_ids=(),
+        max_iterations=1, patience=None, ledger_dir=tmp_path, verify_reachability=False,
+    )
+
+    entry = report["iterations"][0]
+    # Blended: reference passes 3+1=4, candidate passes 0+5=5 -- a plain
+    # objective check alone would call this a +1 improvement.
+    assert entry["objective_adjusted"] == 5
+    assert entry["objective_adjusted"] > report["reference"]["objective_adjusted"]
+    assert entry["verdict"] == "rejected_regression"
+    assert "retrieval-only" in entry["reason"]
+    assert report["ratchet"] == report["reference"]["objective_adjusted"]  # unmoved
+    assert report["best_iteration"] is None
+
+
+def test_summary_carries_a_per_case_type_breakdown(tmp_path):
+    def evaluate(overrides, case_ids):
+        records = [
+            _rec("fig", "figure_retrieval", True, 4.0),
+            _rec("num", "factual_number", overrides.get("retrieval.top_k_final") == 12, 200.0),
+        ]
+        return ev.EvaluationResult(records=tuple(records), effective_config=dict(overrides))
+
+    report = loop.run_loop(
+        reference=AppConfig(), evaluate=evaluate, proposer=_FixedProposer({"retrieval.top_k_final": 12}),
+        search_set_ids=("fig", "num"), fast_tier_ids=("fig",), max_iterations=1, patience=None,
+        ledger_dir=tmp_path, verify_reachability=False,
+    )
+    summary = report["iterations"][0]["summary"]
+    assert summary["by_case_type"]["figure_retrieval"] == {"total": 1, "passed": 1, "pass_rate": 1.0}
+    assert summary["by_case_type"]["factual_number"] == {"total": 1, "passed": 1, "pass_rate": 1.0}
+
+
+# HIGH 2 (#65 PR review): an infrastructure_error record (dead/overloaded
+# Ollama, a retrieval exception -- see run_eval.run_factual_case) must never
+# read as an ordinary quality failure. loop.py refuses to score it.
+
+
+def test_reference_with_infrastructure_error_raises_before_the_loop_starts(tmp_path):
+    def evaluate(overrides, case_ids):
+        infra = not overrides  # only the reference call (empty overrides) errors
+        records = [_rec(cid, "factual_number", False, 200.0, infra_error=infra) for cid in case_ids]
+        return ev.EvaluationResult(records=tuple(records), effective_config=dict(overrides))
+
+    with pytest.raises(ev.InconclusiveEvaluationError):
+        loop.run_loop(
+            reference=AppConfig(), evaluate=evaluate, proposer=_FixedProposer({"retrieval.top_k_final": 4}),
+            search_set_ids=("a", "b"), fast_tier_ids=("a",), max_iterations=1, patience=None,
+            ledger_dir=tmp_path, verify_reachability=False,
+        )
+
+
+def test_fast_tier_infrastructure_error_yields_inconclusive_not_regression(tmp_path):
+    def evaluate(overrides, case_ids):
+        is_fast_tier_call = set(case_ids) == {"a"}
+        infra = bool(overrides) and is_fast_tier_call  # only the candidate's fast-tier call errors
+        records = [_rec(cid, "factual_number", True, 200.0, infra_error=infra) for cid in case_ids]
+        return ev.EvaluationResult(records=tuple(records), effective_config=dict(overrides))
+
+    proposer = _FixedProposer({"retrieval.top_k_final": 4})
+    report = loop.run_loop(
+        reference=AppConfig(), evaluate=evaluate, proposer=proposer,
+        search_set_ids=("a", "b"), fast_tier_ids=("a",), max_iterations=1, patience=None,
+        ledger_dir=tmp_path, verify_reachability=False,
+    )
+
+    entry = report["iterations"][0]
+    assert entry["verdict"] == "inconclusive"
+    assert entry["evaluated_case_set"] == "fast_tier"
+    assert report["ratchet"] == report["reference"]["objective_adjusted"]
+
+
+def test_search_set_infrastructure_error_yields_inconclusive_and_no_ratchet_move(tmp_path):
+    def evaluate(overrides, case_ids):
+        is_full_set_call = set(case_ids) == {"a", "b"}
+        infra = bool(overrides) and is_full_set_call  # only the candidate's full evaluation errors
+        records = [_rec(cid, "factual_number", True, 200.0, infra_error=infra) for cid in case_ids]
+        return ev.EvaluationResult(records=tuple(records), effective_config=dict(overrides))
+
+    proposer = _FixedProposer({"retrieval.top_k_final": 4})
+    report = loop.run_loop(
+        reference=AppConfig(), evaluate=evaluate, proposer=proposer,
+        search_set_ids=("a", "b"), fast_tier_ids=("a",), max_iterations=1, patience=None,
+        ledger_dir=tmp_path, verify_reachability=False,
+    )
+
+    entry = report["iterations"][0]
+    assert entry["verdict"] == "inconclusive"
+    assert entry["evaluated_case_set"] == "search_set"
+    assert report["ratchet"] == report["reference"]["objective_adjusted"]
+    assert report["best_iteration"] is None
+
+
+def test_inconclusive_counts_toward_patience(tmp_path):
+    def evaluate(overrides, case_ids):
+        records = [_rec(cid, "factual_number", True, 200.0, infra_error=bool(overrides)) for cid in case_ids]
+        return ev.EvaluationResult(records=tuple(records), effective_config=dict(overrides))
+
+    proposer = _CyclingProposer([{"retrieval.top_k_final": 4}, {"retrieval.top_k_final": 6}])
+    report = loop.run_loop(
+        reference=AppConfig(), evaluate=evaluate, proposer=proposer,
+        search_set_ids=("a",), fast_tier_ids=("a",), max_iterations=None, patience=2,
+        ledger_dir=tmp_path, verify_reachability=False,
+    )
+
+    assert report["termination_reason"] == "patience"
+    assert report["iterations_run"] == 2
+    assert all(entry["verdict"] == "inconclusive" for entry in report["iterations"])

--- a/harness/tests/test_proposers.py
+++ b/harness/tests/test_proposers.py
@@ -1,0 +1,177 @@
+"""Tests for harness/proposers.py -- issue #31 spec section 6, tests 7-8."""
+
+import json
+import sys
+from collections import namedtuple
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+if str(REPO_ROOT / "src") not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT / "src"))
+
+import pytest
+
+from monkeygrab.config.app_config import AppConfig
+from harness import search_space
+from harness.proposers import (
+    GridProposer, LlmProposer, OllamaUnreachableError, SearchSpaceExhausted,
+)
+
+# A minimal stand-in for ledger.LedgerEntry: GridProposer/LlmProposer only
+# ever read .config_overrides off a ledger_history entry, so tests do not
+# need the full ledger schema to exercise the proposer logic in isolation.
+_FakeEntry = namedtuple("_FakeEntry", ["config_overrides", "objective_adjusted", "iteration", "verdict"])
+
+
+def _entry(overrides, objective=0, iteration=1, verdict="rejected_no_gain"):
+    return _FakeEntry(config_overrides=overrides, objective_adjusted=objective, iteration=iteration, verdict=verdict)
+
+
+class _TinySpace:
+    """A tiny two-value declared space, for testing GridProposer's exhaustion path
+    without walking the full (much larger) real search_space module."""
+
+    ALLOWED_VALUES = {"retrieval.top_k_final": (4, 6)}
+
+    @staticmethod
+    def proposal_order():
+        return ("retrieval.top_k_final",)
+
+    @staticmethod
+    def is_feasible(overrides, reference):
+        return True
+
+
+# TEST 7 -- GridProposer never repeats a ledger point; reproducible.
+
+
+def test_grid_proposer_first_proposal_is_the_first_reachable_key_first_value():
+    proposer = GridProposer(AppConfig())
+    overrides = proposer.propose(search_space, [], None)
+    first_key = search_space.proposal_order()[0]
+    assert list(overrides.keys()) == [first_key]
+    assert proposer.last_meta["proposer"] == "grid"
+
+
+def test_grid_proposer_skips_points_already_in_the_ledger():
+    base = AppConfig()
+    first = GridProposer(base).propose(search_space, [], None)
+    history = [_entry(first)]
+    second = GridProposer(base).propose(search_space, history, None)
+    assert second != first
+
+
+def test_grid_proposer_is_reproducible_given_the_same_ledger():
+    base = AppConfig()
+    history = [_entry({"retrieval.top_k_final": 4}, objective=20)]
+    a = GridProposer(base).propose(search_space, history, None)
+    b = GridProposer(base).propose(search_space, history, None)
+    assert a == b
+
+
+def test_grid_proposer_skips_the_reference_value_itself():
+    # AppConfig()'s default top_k_final is already 8, which is one of the
+    # declared values -- proposing "change to 8" would not be a change.
+    base = AppConfig()
+    for _ in range(len(search_space.ALLOWED_VALUES["retrieval.top_k_final"])):
+        overrides = GridProposer(base).propose(search_space, [], None)
+        assert overrides.get("retrieval.top_k_final") != 8
+
+
+def test_grid_proposer_raises_search_space_exhausted_once_every_point_is_tried():
+    base = AppConfig()  # default top_k_final == 8, so both 4 and 6 are "changes"
+    proposer = GridProposer(base)
+    first = proposer.propose(_TinySpace(), [], None)
+    history = [_entry(first)]
+    second = proposer.propose(_TinySpace(), history, None)
+    history.append(_entry(second))
+    with pytest.raises(SearchSpaceExhausted):
+        proposer.propose(_TinySpace(), history, None)
+
+
+# TEST 8 -- LlmProposer validation, malformed-JSON rejection, fallback.
+
+
+def test_llm_proposer_accepts_a_valid_response():
+    response = json.dumps({"overrides": {"retrieval.top_k_final": 12}, "rationale": "widen final k"})
+    proposer = LlmProposer(AppConfig(), call=lambda _prompt: response)
+    overrides = proposer.propose(search_space, [], None)
+    assert overrides == {"retrieval.top_k_final": 12}
+    assert proposer.last_meta == {
+        "proposer": "llm", "rationale": "widen final k", "model": proposer._model,
+        "fallback": False, "fallback_reason": None,
+    }
+
+
+def test_llm_proposer_rejects_a_key_outside_the_declared_space():
+    proposer = LlmProposer(AppConfig())
+    assert proposer._validate({"not.a.real.key": 1}, search_space) is False
+
+
+def test_llm_proposer_rejects_a_value_outside_the_declared_set():
+    proposer = LlmProposer(AppConfig())
+    assert proposer._validate({"retrieval.top_k_final": 999}, search_space) is False
+
+
+def test_llm_proposer_rejects_an_infeasible_combination():
+    # Both values are individually declared; the combination itself violates
+    # "n_top_for_expansion <= top_k_final" (search_space.is_feasible).
+    proposer = LlmProposer(AppConfig())
+    assert proposer._validate({"retrieval.n_top_for_expansion": 6, "retrieval.top_k_final": 4}, search_space) is False
+
+
+@pytest.mark.parametrize("malformed", [
+    "not json",
+    json.dumps({"overrides": {"retrieval.top_k_final": 8}}),  # missing rationale
+    json.dumps({"rationale": "x"}),  # missing overrides
+    json.dumps(["overrides", "rationale"]),  # not an object
+    json.dumps({"overrides": "not-a-dict", "rationale": "x"}),
+])
+def test_llm_proposer_parse_rejects_malformed_json(malformed):
+    assert LlmProposer._parse(malformed) is None
+
+
+def test_llm_proposer_falls_back_to_grid_after_repeated_invalid_responses():
+    responses = iter([
+        "not json at all",
+        json.dumps({"overrides": {"not.a.real.key": 1}, "rationale": "bad key"}),
+        json.dumps({"overrides": {"retrieval.top_k_final": 999}, "rationale": "bad value"}),
+    ])
+    base = AppConfig()
+    proposer = LlmProposer(base, max_retries=3, call=lambda _prompt: next(responses))
+    overrides = proposer.propose(search_space, [], None)
+
+    assert proposer.last_meta["proposer"] == "llm"
+    assert proposer.last_meta["fallback"] is True
+    assert proposer.last_meta["rationale"] is None
+    assert "3 attempt" in proposer.last_meta["fallback_reason"]
+    # The fallback overrides still came from GridProposer, so still a single
+    # declared, feasible point.
+    assert set(overrides.keys()) <= search_space.DECLARED_KEYS
+    assert search_space.is_feasible(overrides, base)
+
+
+def test_llm_proposer_falls_back_when_ollama_is_unreachable():
+    def _raise(_prompt):
+        raise OllamaUnreachableError("connection refused")
+
+    proposer = LlmProposer(AppConfig(), call=_raise)
+    overrides = proposer.propose(search_space, [], None)
+
+    assert proposer.last_meta["fallback"] is True
+    assert "unreachable" in proposer.last_meta["fallback_reason"].lower()
+    assert set(overrides.keys()) <= search_space.DECLARED_KEYS
+
+
+def test_llm_proposer_fallback_does_not_hang_or_retry_past_max_retries():
+    calls = {"count": 0}
+
+    def _always_malformed(_prompt):
+        calls["count"] += 1
+        return "still not json"
+
+    proposer = LlmProposer(AppConfig(), max_retries=3, call=_always_malformed)
+    proposer.propose(search_space, [], None)
+    assert calls["count"] == 3

--- a/harness/tests/test_proposers.py
+++ b/harness/tests/test_proposers.py
@@ -175,3 +175,100 @@ def test_llm_proposer_fallback_does_not_hang_or_retry_past_max_retries():
     proposer = LlmProposer(AppConfig(), max_retries=3, call=_always_malformed)
     proposer.propose(search_space, [], None)
     assert calls["count"] == 3
+
+
+# _real_call -- test gap #65 PR review flagged: the bounded timeout (what
+# stops a stalled Ollama from hanging the loop -- this repo has a
+# documented history of exactly that failure mode) was asserted only by a
+# docstring. A fake `requests` module is injected into sys.modules so this
+# is exercised without touching a real Ollama server (this round's
+# constraint: no GPU/Ollama -- the full eval gate owns the card).
+
+
+class _FakeRequestsModule:
+    """Enough of the `requests` surface for LlmProposer._real_call."""
+
+    class RequestException(Exception):
+        pass
+
+    def __init__(self, response=None, raises=None):
+        self._response = response
+        self._raises = raises
+        self.calls = []
+
+    def post(self, url, json, timeout):  # noqa: A002 -- matches requests.post's real signature
+        self.calls.append({"url": url, "json": json, "timeout": timeout})
+        if self._raises is not None:
+            raise self._raises
+        return self._response
+
+
+class _FakeResponse:
+    def __init__(self, body="", raise_for_status_error=None, json_error=None):
+        self._body = body
+        self._raise_for_status_error = raise_for_status_error
+        self._json_error = json_error
+
+    def raise_for_status(self):
+        if self._raise_for_status_error is not None:
+            raise self._raise_for_status_error
+
+    def json(self):
+        if self._json_error is not None:
+            raise self._json_error
+        return {"response": self._body}
+
+
+def test_llm_proposer_real_call_passes_the_bounded_timeout(monkeypatch):
+    fake_requests = _FakeRequestsModule(response=_FakeResponse(body='{"overrides": {}, "rationale": "x"}'))
+    monkeypatch.setitem(sys.modules, "requests", fake_requests)
+
+    proposer = LlmProposer(AppConfig(), timeout=17.5)
+    result = proposer._real_call("prompt text")
+
+    assert fake_requests.calls[0]["timeout"] == 17.5
+    assert "/api/generate" in fake_requests.calls[0]["url"]
+    assert result == '{"overrides": {}, "rationale": "x"}'
+
+
+def test_llm_proposer_real_call_wraps_a_connection_failure(monkeypatch):
+    fake_requests = _FakeRequestsModule(raises=_FakeRequestsModule.RequestException("connection refused"))
+    monkeypatch.setitem(sys.modules, "requests", fake_requests)
+
+    proposer = LlmProposer(AppConfig())
+    with pytest.raises(OllamaUnreachableError):
+        proposer._real_call("prompt")
+
+
+def test_llm_proposer_real_call_wraps_a_non_2xx_status(monkeypatch):
+    fake_requests = _FakeRequestsModule(
+        response=_FakeResponse(raise_for_status_error=_FakeRequestsModule.RequestException("500 Server Error"))
+    )
+    monkeypatch.setitem(sys.modules, "requests", fake_requests)
+
+    proposer = LlmProposer(AppConfig())
+    with pytest.raises(OllamaUnreachableError):
+        proposer._real_call("prompt")
+
+
+def test_llm_proposer_real_call_wraps_a_non_json_response_body(monkeypatch):
+    # A 200 whose body is not JSON (a proxy error page, an empty body) --
+    # the fix this test guards: response.json() used to sit outside the
+    # try/except that converts failures to OllamaUnreachableError.
+    fake_requests = _FakeRequestsModule(response=_FakeResponse(json_error=ValueError("not valid JSON")))
+    monkeypatch.setitem(sys.modules, "requests", fake_requests)
+
+    proposer = LlmProposer(AppConfig())
+    with pytest.raises(OllamaUnreachableError):
+        proposer._real_call("prompt")
+
+
+def test_llm_proposer_real_call_wraps_a_missing_requests_dependency(monkeypatch):
+    # sys.modules[name] = None is how CPython represents "this import
+    # previously failed" -- `import requests` then raises ImportError,
+    # simulating requests not being installed at all.
+    monkeypatch.setitem(sys.modules, "requests", None)
+
+    proposer = LlmProposer(AppConfig())
+    with pytest.raises(OllamaUnreachableError):
+        proposer._real_call("prompt")

--- a/harness/tests/test_reachability_gate.py
+++ b/harness/tests/test_reachability_gate.py
@@ -1,0 +1,102 @@
+"""Tests for the reachability gate -- evaluator.verify_reachable and
+loop.run_loop's startup use of it.
+
+Added after a mid-review finding while the sibling PR (#56, the
+tests/eval/run_eval.evaluate() library API) was being built: four declared
+keys did not reach the generation stage through config_overrides at the
+time. #56 has since closed that gap (search_space.PENDING_REACHABILITY_KEYS
+is empty -- see its docstring for the full history), and a *different* key
+turned out inert for a different reason and was removed from the space
+entirely (flags.usar_llm_query_decomposition, issue #64). The gate itself
+stays: it is what turns a FUTURE case of either failure class into a loud
+startup failure naming the key, instead of the loop silently running on top
+of a knob that does nothing. The fake evaluators below use hypothetical key
+names to test the mechanism in isolation -- they do not assert anything is
+currently broken.
+"""
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+if str(REPO_ROOT / "src") not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT / "src"))
+
+import pytest
+
+from monkeygrab.config.app_config import AppConfig
+from harness import evaluator as ev
+from harness import loop
+
+
+class _AlwaysHonoursEverything:
+    def __call__(self, overrides, case_ids):
+        records = tuple(
+            ev.CaseRecord(id=c, case_type="factual_number", passed=True, elapsed_seconds=1.0) for c in case_ids
+        )
+        return ev.EvaluationResult(records=records, effective_config=dict(overrides))
+
+
+class _RejectsOneKey:
+    """Mimics a hard-failing evaluate(): raises, naming the unreachable key."""
+
+    def __init__(self, bad_key):
+        self._bad_key = bad_key
+
+    def __call__(self, overrides, case_ids):
+        if self._bad_key in overrides:
+            raise ValueError(f"override not honoured end to end: {self._bad_key!r}")
+        records = tuple(
+            ev.CaseRecord(id=c, case_type="factual_number", passed=True, elapsed_seconds=1.0) for c in case_ids
+        )
+        return ev.EvaluationResult(records=records, effective_config=dict(overrides))
+
+
+def test_verify_reachable_passes_when_evaluate_honours_every_declared_key():
+    ev.verify_reachable(_AlwaysHonoursEverything())  # must not raise
+
+
+def test_verify_reachable_names_the_offending_key_in_its_message():
+    bad_key = "flags.usar_recomp_synthesis"
+    with pytest.raises(ev.ReachabilityError, match=bad_key.replace(".", r"\.")):
+        ev.verify_reachable(_RejectsOneKey(bad_key))
+
+
+class _FixedProposer:
+    def __init__(self):
+        self.last_meta = {"proposer": "grid", "rationale": None, "model": None,
+                           "fallback": False, "fallback_reason": None}
+        self.called = False
+
+    def propose(self, space, ledger_history, last_result):
+        self.called = True
+        return {"retrieval.top_k_final": 4}
+
+
+def test_loop_startup_fails_loudly_instead_of_running_with_an_inert_knob(tmp_path):
+    proposer = _FixedProposer()
+    with pytest.raises(ev.ReachabilityError):
+        loop.run_loop(
+            reference=AppConfig(), evaluate=_RejectsOneKey("flags.expandir_contexto"),
+            proposer=proposer, search_set_ids=("a",), fast_tier_ids=("a",),
+            max_iterations=1, ledger_dir=tmp_path,
+        )
+    # The gate fires before the loop ever asks the proposer for a candidate,
+    # or evaluates anything, or writes a ledger entry.
+    assert proposer.called is False
+    assert list(tmp_path.glob("*.json")) == []
+
+
+def test_loop_skips_the_gate_when_verify_reachability_is_false(tmp_path):
+    # Only ever meant for tests whose evaluator is intentionally too narrow
+    # to answer the combined probe (see run_loop's docstring) -- exercised
+    # here with an evaluator that would otherwise fail the gate.
+    proposer = _FixedProposer()
+    report = loop.run_loop(
+        reference=AppConfig(), evaluate=_RejectsOneKey("flags.expandir_contexto"),
+        proposer=proposer, search_set_ids=("a",), fast_tier_ids=("a",),
+        max_iterations=1, ledger_dir=tmp_path, verify_reachability=False,
+    )
+    assert report["iterations_run"] == 1

--- a/harness/tests/test_reachability_gate.py
+++ b/harness/tests/test_reachability_gate.py
@@ -28,6 +28,7 @@ import pytest
 
 from monkeygrab.config.app_config import AppConfig
 from harness import evaluator as ev
+from harness import search_space
 from harness import loop
 
 
@@ -62,6 +63,38 @@ def test_verify_reachable_names_the_offending_key_in_its_message():
     bad_key = "flags.usar_recomp_synthesis"
     with pytest.raises(ev.ReachabilityError, match=bad_key.replace(".", r"\.")):
         ev.verify_reachable(_RejectsOneKey(bad_key))
+
+
+def test_verify_reachable_lets_non_valueerror_exceptions_propagate_unwrapped():
+    """LOW 1 (#65 PR review): evaluate() raises EvalSetupError for a missing
+    Ollama/model/index -- a setup problem, not a reachability problem.
+    Wrapping it as ReachabilityError would point an operator at "which
+    search-space key is broken" for a failure that has nothing to do with
+    the declared space. Only ValueError (what AppConfig.with_overrides
+    raises, and the plausible shape of a real "override not honoured"
+    check) becomes ReachabilityError; everything else propagates as itself.
+    """
+
+    class _FakeEvalSetupError(RuntimeError):
+        pass
+
+    def _raises_setup_error(overrides, case_ids):
+        raise _FakeEvalSetupError("Ollama is not reachable at http://localhost:11434")
+
+    with pytest.raises(_FakeEvalSetupError):
+        ev.verify_reachable(_raises_setup_error)
+
+
+def test_reachability_probe_overrides_are_themselves_feasible():
+    """Test gap #65 PR review flagged: nothing asserted the combined probe
+    (every declared key at its first allowed value, all at once) is a
+    feasible AppConfig. If a future SEARCH_SPACE edit reordered one
+    declared tuple so the "all first values" combination violated the
+    feasibility predicate, every real startup would fail with a confusing
+    ReachabilityError that has nothing to do with reachability.
+    """
+    probe_overrides = {key: search_space.ALLOWED_VALUES[key][0] for key in search_space.DECLARED_KEYS}
+    assert search_space.is_feasible(probe_overrides, AppConfig())
 
 
 class _FixedProposer:

--- a/harness/tests/test_search_space.py
+++ b/harness/tests/test_search_space.py
@@ -1,0 +1,118 @@
+"""Tests for harness/search_space.py -- issue #31 spec section 6, tests 1-4.
+
+No GPU, no Ollama, no model downloads: AppConfig (src/monkeygrab/config/) is
+pure stdlib, which is what makes this whole file collectible in the fast CI
+gate.
+"""
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+if str(REPO_ROOT / "src") not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT / "src"))
+
+import pytest
+
+from monkeygrab.config.app_config import AppConfig
+from harness import search_space
+
+
+# TEST 1 -- space validates against real AppConfig; an unknown field raises.
+
+
+def test_declared_space_imports_cleanly_against_real_appconfig():
+    # Importing this module already ran _validate_declared_space(SEARCH_SPACE)
+    # at module load time; getting here at all is half the proof. The other
+    # half: every declared key really does resolve on a real AppConfig.
+    base = AppConfig()
+    for key, values, _why, _stage in search_space.SEARCH_SPACE:
+        for value in values:
+            base.with_overrides(**{key: value})  # must not raise
+
+
+def test_unknown_field_raises():
+    with pytest.raises(ValueError):
+        search_space._validate_declared_space((("retrieval.not_a_real_field", (1,), "bogus", "retrieval"),))
+
+
+def test_unknown_section_raises():
+    with pytest.raises(ValueError):
+        search_space._validate_declared_space((("not_a_real_section.foo", (1,), "bogus", "retrieval"),))
+
+
+# TEST 2 -- every index-time key is rejected as a tunable.
+
+
+@pytest.mark.parametrize("index_time_key", sorted(search_space.INDEX_TIME_KEYS))
+def test_index_time_key_rejected_as_tunable(index_time_key):
+    with pytest.raises(ValueError, match="index-time"):
+        search_space._validate_declared_space(
+            (("retrieval.top_k_final", (8,), "control", "retrieval"), (index_time_key, (1,), "should be rejected", "generation"))
+        )
+
+
+def test_declared_space_contains_no_index_time_key():
+    declared = {key for key, _values, _why, _stage in search_space.SEARCH_SPACE}
+    assert declared.isdisjoint(search_space.INDEX_TIME_KEYS)
+
+
+# TEST 3 -- feasibility predicate.
+
+
+def test_feasibility_rejects_top_k_final_above_rerank_candidates():
+    base = AppConfig()
+    assert search_space.is_feasible(
+        {"retrieval.top_k_final": 16, "retrieval.top_k_rerank_candidates": 12}, base
+    ) is False
+
+
+def test_feasibility_rejects_expansion_wider_than_top_k_final():
+    base = AppConfig()
+    assert search_space.is_feasible(
+        {"retrieval.top_k_final": 4, "retrieval.n_top_for_expansion": 6}, base
+    ) is False
+
+
+def test_feasibility_rejects_expansion_when_flag_is_off():
+    base = AppConfig().with_overrides(**{"flags.expandir_contexto": False})
+    assert search_space.is_feasible({"retrieval.n_top_for_expansion": 3}, base) is False
+
+
+def test_feasibility_accepts_a_plain_valid_change():
+    base = AppConfig()
+    assert search_space.is_feasible({"retrieval.top_k_final": 12}, base) is True
+
+
+def test_feasibility_rejects_unknown_key():
+    base = AppConfig()
+    assert search_space.is_feasible({"retrieval.not_a_field": 1}, base) is False
+
+
+# TEST 4 -- weight_bm25_rrf is always derived as 1 - weight_semantic_rrf.
+
+
+@pytest.mark.parametrize("weight", [0.3, 0.45, 0.55, 0.7])
+def test_weight_bm25_rrf_is_always_one_minus_semantic(weight):
+    expanded = search_space.expand_overrides({"retrieval.weight_semantic_rrf": weight})
+    assert expanded["retrieval.weight_bm25_rrf"] == pytest.approx(1.0 - weight)
+
+
+def test_expand_overrides_does_not_override_an_explicit_bm25_weight():
+    expanded = search_space.expand_overrides({
+        "retrieval.weight_semantic_rrf": 0.3, "retrieval.weight_bm25_rrf": 0.9,
+    })
+    assert expanded["retrieval.weight_bm25_rrf"] == 0.9
+
+
+def test_expand_overrides_is_a_no_op_without_the_semantic_weight():
+    overrides = {"retrieval.top_k_final": 12}
+    assert search_space.expand_overrides(overrides) == overrides
+
+
+def test_expand_overrides_does_not_mutate_its_argument():
+    overrides = {"retrieval.weight_semantic_rrf": 0.3}
+    search_space.expand_overrides(overrides)
+    assert overrides == {"retrieval.weight_semantic_rrf": 0.3}

--- a/harness/unreachable_cases.txt
+++ b/harness/unreachable_cases.txt
@@ -1,0 +1,29 @@
+# Unreachable margin (issue #31 spec section 3; design doc section 3, "Margen
+# inalcanzable"): cases that fail because the generator never sees the visual
+# content -- the store holds a caption or the literal "[figure] page=N". No
+# stage-1 configuration can close that; it needs a code change outside the
+# declared search space.
+#
+# Starts empty, and stays empty as of 2026-08-12: the `reason` field of all
+# five of today's search-set failures was read against the reference gate run
+# (tests/eval/runs/20260729T020233Z_mineru-jina_clip-faiss.json, local and
+# gitignored, so not reproducible from a fresh clone):
+#   dpo-pipeline-figure-es   wanted image, got text
+#   higgs-diphoton-figure    wanted image, got table, text
+#   planck-contours-figure   wanted image, got text
+#   planck-sigma8-es         expected 0.811, not present in the generated answer
+#   planck-h0-tension        expected 3.6, not present in the generated answer
+#
+# None of these is the generator failing to answer over a figure it saw --
+# the three figure_retrieval cases never call the generator at all; they fail
+# because retrieval surfaced text where an image chunk was wanted, which is
+# exactly what fusion weights, top_k_final and the reranker threshold move,
+# so all three are inside stage 1's action space. The two answered failures
+# are a number present in the paper's abstract that did not survive into the
+# generated answer -- plausibly reachable by moving the context budget,
+# RECOMP synthesis or retrieval depth.
+#
+# A case earns a place below only with evidence that the stored chunk
+# provably contains no visual content. Do NOT pre-populate this with "every
+# figure_retrieval case": some figure cases pass today, and that would
+# discard real signal the search set is sized to capture.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
 pythonpath = . src
-testpaths = tests
+testpaths = tests harness/tests


### PR DESCRIPTION
## Summary

Implements the block-C configuration search harness specified in
`docs/design/2026-07-28-loop-automejorable.md` §1/§4 and issue #31: an
optimiser that searches `AppConfig` for a higher gold-case pass rate under a
hard latency ceiling, recording every candidate so a run reconstructs
exactly (criterion 7).

- `harness/search_space.py` — declared tunables written by hand as data,
  index-time exclusions enforced by a red test, the `weight_semantic_rrf` /
  `weight_bm25_rrf` coupling, the feasibility predicate, and a startup
  reachability gate's metadata.
- `harness/fast_tier.txt` / `harness/unreachable_cases.txt` — fixed
  13-case regression filter and the (evidence-backed, still empty)
  unreachable-margin list.
- `harness/ledger.py` — append-only evidence per iteration; commit sha read
  from `.git` metadata directly (no `subprocess`, no git shell-out anywhere
  in the package).
- `harness/proposers.py` — `GridProposer` (deterministic control) and
  `LlmProposer` (Ollama-backed, validated against the declared space before
  its output is ever trusted; falls back to grid on malformed output or an
  unreachable Ollama).
- `harness/evaluator.py` — case-set selection (search/blind/fast-tier),
  objective and per-bucket latency math, the reachability gate, and a
  guarded adapter to the not-yet-landed `tests/eval/run_eval.evaluate()`.
- `harness/loop.py` — the ratchet, the latency constraint, termination.
- `harness/cli.py` — entry point, with a `--dry-run` path needing no
  GPU/Ollama/PDFs.
- `harness/tests/` — all 13 required behaviors from the implementation
  spec, wired into the fast CI gate (`pytest.ini`, `ci.yml`) alongside
  `tests/unit`/`tests/eval`.

The harness may read and run the evaluation gate; it never redefines how it
scores. `tests/eval/grade.py`, `gold_cases.jsonl` and
`baseline_min_pass_rate.txt` stay byte-identical — enforced by an AST-based
boundary test (`harness/tests/test_harness_boundaries.py`), not trusted by
convention.

## Verified against the code, not assumed

- `weight_bm25_rrf = 1 - weight_semantic_rrf` is correct: RRF fusion
  (`src/monkeygrab/application/rrf_fusion.py`) is a linear combination used
  only for ordering, confirmed by reading the function.
- `flags.expandir_contexto` does gate `retrieval.n_top_for_expansion`
  (`Answer.select_evidence`) — the feasibility constraint is kept.
- `AppConfig.with_overrides` raises `ValueError` on every unknown
  section/field — the space validator leans on that directly.
- A search-set-only run's staging behavior depends on the sibling PR
  (#56, `run_eval.evaluate()`), not yet on `main`.

## Corrections applied against the real reference-run numbers

Restricting the design doc's paired comparisons to the 32-case search set
(rather than the whole 51-case gate) changes what the harness has to report:

- The latency ceiling is checked **per case-type bucket** (answered ~200s
  vs. retrieval-only ~4s — a blended median would hide a retrieval
  collapse), not as a single blended median.
- Every loop report carries a `resolution_warning`: today's search set can
  win at most 5 cases and saw only 3 net flips under the most destructive
  sabotage measured (`RAG_TOP_K_FINAL=1`), both below the design's 6-flip
  demonstrability threshold. An accepted improvement reads as a candidate
  for confirmation, not a demonstrated result. (Since this PR started,
  `main` recorded the same numbers independently in #61 — this PR's
  `harness/README.md` cites both that record and the raw run artefacts.)
- `unreachable_cases.txt` starts and stays empty: none of today's 5
  search-set failures is unreachable margin (all fail on ranking or on a
  fact not surviving into the answer, both inside stage 1's action space).

## Reachability gate

A mid-review audit (sibling PR #56) found `config_overrides` for four
declared keys did not reach generation; #56 has since closed that gap. The
same audit found a *different* key inert for a different reason —
`flags.usar_llm_query_decomposition` is absent from the declared space
(issue #64 filed) because `tests/eval/run_eval.py` hardcodes its retrieval
collaborator regardless of the flag. `evaluator.verify_reachable` stays as
a startup gate against a *future* instance of either failure class,
regardless — see `harness/README.md`'s "Reachability gate" section.

## Test plan

- [x] `pytest -q -p no:randomly` — 441 passed, 1 skipped (before this PR,
      on the same `main` commit this branches from: 334 passed, 1 skipped;
      +107 from `harness/tests`). Original task baseline was 327/1 on an
      older `main`; `main` gained tests from 3 merged PRs in between.
- [x] `ruff check .` — clean.
- [x] `tests/unit/test_architecture_boundaries.py` unaffected (still passes,
      not special-cased).
- [x] `python -m harness.cli --dry-run --max-iterations 5 --patience 3` —
      runs end to end against the deterministic demo evaluator, no
      GPU/Ollama/PDFs.
- [ ] Real 2.8h full-eval gate — deliberately NOT run in this PR.

## Known limitation

`harness/tests/test_criterion5_simulated.py` proves the *search logic*
recovers from a deliberately worsened point in a synthetic, controlled
landscape — for both proposers. It does **not** prove the real pipeline
improves; that needs the GPU and hours and is pending measurement.

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)