### PR TITLE
Make the concurrency test say which way it failed (#50)

### DIFF
--- a/tests/unit/adapters/test_jina_clip_embedder.py
+++ b/tests/unit/adapters/test_jina_clip_embedder.py
@@ -456,6 +456,17 @@ def test_concurrent_embed_calls_each_get_their_own_vector_and_the_worker_survive
     t_a.join(timeout=5)
     t_b.join(timeout=5)
 
+    # join(timeout=...) returns silently on overrun, so without these the two
+    # ways this test can go red under load are indistinguishable in the output:
+    # a request that exceeded request_timeout_s lands in errors{} and names the
+    # timeout, but a thread that simply never finished leaves results{} empty
+    # and the test dies on KeyError three lines down, pointing at nothing. Issue
+    # #50 saw one unexplained failure in a full-suite run and the output was not
+    # preserved; 176 reproduction attempts across three load profiles never
+    # recaptured it, so the next occurrence has to diagnose itself.
+    assert not t_a.is_alive(), "call-a's thread did not finish within 5s (hung, not slow)"
+    assert not t_b.is_alive(), "call-b's thread did not finish within 5s (hung, not slow)"
+
     assert not errors, f"concurrent embed() calls raised: {errors}"
     assert results["a"] == vector_a
     assert results["b"] == vector_b


### PR DESCRIPTION
Issue #50 recorded one unexplained failure of `test_concurrent_embed_calls_each_get_their_own_vector_and_the_worker_survives` in a full-suite run. The output was never preserved.

## Reproduction: 176 attempts, three load profiles, zero reproductions

| Profile | Attempts | Result |
|---|---|---|
| Full suite, ordinary concurrent load | 20 | all green |
| Targeted test only, 12 saturating burner processes on 16 cores | 150 | all green, wall per run min 4.08 s / median 5.79 s / max 15.08 s |
| Full suite, same 12-burner saturation | 6 | all green, 77 s to 102 s per run |

Each profile was chosen to cover something the previous one missed. The targeted runs give two orders of magnitude more samples per hour but use a fresh interpreter each time, so the test runs alone. The saturated full-suite runs restore the real shape, where the test executes after ~330 other tests in the same interpreter and inherits their threads, GC pressure and heap.

There is no reason to expect a fourth attempt to do better. So the next occurrence has to diagnose itself.

## The change, and why it strengthens rather than loosens

Reading the test turns up something the reproduction attempts could not: **it can go red under load in two ways, and they are not equally legitimate to fix.**

| Cause | How it surfaces today |
|---|---|
| A request exceeds `request_timeout_s=2.0` | Captured into `errors{}`, `assert not errors` fires and names the timeout |
| A thread overruns `join(timeout=5)` | `join` returns silently, `results` is never populated, the test dies on `KeyError: 'a'` three lines later |

The issue's own instruction is that *"if the cause is the timeout under load, raising it is legitimate; loosening what the test asserts is not."* Only the first case justifies raising the timeout. The second is a non-fatal join hiding a hang, and today the two produce indistinguishable evidence, which is exactly why the original failure could not be diagnosed from what was kept.

Asserting the threads are done adds a condition that was previously assumed and turns a silent overrun into a named one. **It does not touch the timeout**: 176 clean attempts are no evidence that 2.0 s was ever the cause, and changing it now would be guessing.

Test-only change. `tests/unit/adapters/`, not `tests/characterization/`. No assertion weakened, none removed.

Leaves #50 open: the flake is uncaptured, not fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)