### PR TITLE
Remove unwired image-extraction knobs from .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -86,11 +86,6 @@
 #RAG_MIN_CHUNK_LENGTH=150                       # discard chunks shorter than this
 #CONTEXTUAL_DOC_CHARS=24000                     # document sample passed to contextual retrieval
 
-# Multimodal image extraction (changing these requires reindexing)
-#RAG_MAX_IMAGES_PER_PAGE=5
-#RAG_MIN_IMAGE_SIZE_PX=100
-#RAG_CAPTION_MARGIN_PX=80
-
 # Retrieval and fusion
 #RAG_N_RESULTADOS_SEMANTICOS=80                 # results per semantic query
 #RAG_N_RESULTADOS_KEYWORD=40                    # results per BM25 search


### PR DESCRIPTION
`RAG_MAX_IMAGES_PER_PAGE`, `RAG_MIN_IMAGE_SIZE_PX` and `RAG_CAPTION_MARGIN_PX` were documented under "Multimodal image extraction (changing these requires reindexing)" but had no consumer anywhere in the tree: no `AppConfig.from_env()` field, no `rag/chat_pdfs.py` global, no read in the extraction adapter.

They are leftovers from the pre-MinerU image path. `MineruExtractor` now takes its figures straight from MinerU's content-list JSON (`_content_list_to_images`), which emits every `image`/`chart` block with the caption already resolved — there is no per-page cap, no minimum-size filter and no caption search window left to tune. Wiring them would mean inventing new filters over MinerU's output, not reconnecting something that exists.

Left in place they were worse than noise: the block header promised that changing them requires reindexing, so anyone who set one would have paid a full reindex for zero change in the index.

Same reasoning and shape as #48 (unwired `num_ctx`/`aux_num_ctx`). Nothing else in `.env.example` is touched.

## Verification

- `git grep` for the three names and for snake_case/prefix-free variants: no hits outside `.env.example`.
- `ruff check .` — clean.
- `pytest` — 354 passed, 1 skipped (pre-existing skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)