### PR TITLE
Correct the gate's cost with a measurement, and retire the proposer argument it supported (#54)

### DIFF
--- a/docs/design/2026-07-28-loop-automejorable.md
+++ b/docs/design/2026-07-28-loop-automejorable.md
@@ -266,9 +266,43 @@ el conjunto ciego se consumiría en la primera iteración.
 > generador acotado a la fase de evaluación, `tests/eval/run_eval.py`), queda
 > pendiente de medir.
 
+> [!NOTE]
+> **Medido el 2026-08-12 (issue #54): el Cambio 1 sí surte efecto, y la
+> corrección de arriba hay que deshacerla.** Run completo del gate sobre `main`
+> en `8924110`, `gemma4:e2b` (el mismo modelo que los runs de referencia), los
+> dos corpus con cache hit:
+> `tests/eval/runs/20260812T194812Z_mineru-jina_clip-faiss.json`.
+>
+> | Bucket | 2026-07-29 | 2026-08-12 |
+> |---|---|---|
+> | Mediana de casos respondidos (n=36) | 201,0 s | **28,5 s** |
+> | Mediana de sólo recuperación (n=15) | 4,1 s | 4,1 s |
+> | Total | 124,0 min | **20,4 min** |
+> | Casos `source: corpus` (32) | 78,9 min | **12,6 min** |
+>
+> La comprobación de coherencia es la segunda fila: los casos de sólo
+> recuperación nunca llaman al generador, no tenían nada que ganar, y no
+> ganaron nada. Toda la mejora cae exactamente donde la hipótesis de la carga
+> en frío decía que caería, así que los 195-210 s que midió el issue #27 eran
+> carga en frío y el keep-alive la elimina.
+>
+> Eso resuelve la ambigüedad que dejaba abierta la nota de arriba: los runs de
+> referencia se lanzaron desde un árbol anterior a `d36c943`, pese a que el
+> commit aterrizó cuatro minutos antes del primero.
+>
+> El resultado no se movió: `compare_runs.py` contra el run sano del
+> 2026-07-29 da `identical: 51 case(s) unchanged`, delta +0.0000. Es además el
+> tercer run sano consecutivo con cero vuelcos, lo que refuerza el suelo de
+> ruido del criterio 1 más allá del único par sobre el que descansaba.
+>
+> Sigue sin registrarse el valor de `OLLAMA_KEEP_ALIVE` con el que corre cada
+> run: es el mismo hueco que hizo esta pregunta irresoluble desde los
+> artefactos, y el que el criterio 7 y el libro de evidencias existen para
+> cerrar.
+
 | Conjunto | Papel | Cuándo se toca | Tamaño |
 |---|---|---|---|
-| **Búsqueda** | Función objetivo del loop | Cada iteración | ~11 docs · ~60 casos · ~136 min (corregido ~4x; pendiente de medir tras el Cambio 1) |
+| **Búsqueda** | Función objetivo del loop | Cada iteración | ~11 docs · ~60 casos · **~24 min** (extrapolado de los 12,6 min medidos sobre 32 casos) |
 | **Validación** | Detecta sobreajuste al conjunto de búsqueda | Al cerrar una tanda | ~4 docs · ~22 casos |
 | **Ciego** | Acepta una versión | Sólo para aceptar; nunca dentro del loop | ~5 docs · ~28 casos |
 
@@ -332,9 +366,9 @@ espacio de acción se amplíe a código.
 
 ```mermaid
 flowchart LR
-    P[Proponente] -->|configuración| F[Nivel rápido<br/>~15 casos · ~32 min]
+    P[Proponente] -->|configuración| F[Nivel rápido<br/>~15 casos · ~6 min]
     F -->|regresión| X[Descartado]
-    F -->|sin regresión| G[Conjunto de búsqueda<br/>~60 casos · ~136 min]
+    F -->|sin regresión| G[Conjunto de búsqueda<br/>~60 casos · ~24 min]
     G --> L[(Libro de evidencias<br/>versionado)]
     L --> P
 
@@ -351,14 +385,24 @@ ajustables y con qué valores. Escrito a mano, no inferido por introspección:
 añadir un parámetro debe ser una decisión visible, porque cada uno multiplica el
 espacio contra un presupuesto de evaluaciones muy corto.
 
-**Proponente.** A ~2.8 horas por evaluación completa (32 + 136 min: nivel
-rápido más conjunto de búsqueda; corregido con el factor de la nota de la
-sección 3, pendiente de remedir tras el Cambio 1 del issue #27), una noche da
-del orden de tres o cuatro candidatos, no diez o quince como asumía la
-estimación original. La búsqueda aleatoria es inútil con ese presupuesto, así
-que el proponente natural es un LLM que lea los fallos concretos y razone qué
-mover. Para saber si ese razonamiento aporta algo, el arnés incluye un
-proponente determinista como control y el criterio 5 se corre con ambos.
+**Proponente.** El argumento original decía: a ~2,8 horas por evaluación
+completa una noche da tres o cuatro candidatos, la búsqueda ciega es inútil con
+ese presupuesto, luego el proponente natural es un LLM que lea los fallos y
+razone qué mover.
+
+> [!IMPORTANT]
+> **Ese argumento ya no se sostiene (medido el 2026-08-12, ver la nota de la
+> sección 3).** El conjunto de búsqueda tarda **12,6 min** sobre los 32 casos
+> actuales, no 136. Una evaluación completa es el nivel rápido más eso, del
+> orden de un cuarto de hora, así que una noche da **decenas** de candidatos.
+> El presupuesto que volvía inútil la búsqueda ciega, y con ello obligatorio el
+> proponente LLM, desapareció.
+
+Esto **no** demuestra que el proponente determinista baste, y no es motivo para
+retirar el LLM. Lo que cambia es que la comparación controlada entre ambos que
+ya exige el criterio 5 pasa a ser barata, así que la pregunta se zanja con
+evidencia en vez de con un argumento de presupuesto. El arnés mantiene los dos
+proponentes justamente para eso.
 
 **Evaluador.** Aplica la configuración, corre el nivel rápido, descarta si hay
 regresión, y sólo entonces paga el conjunto de búsqueda completo. Devuelve el


### PR DESCRIPTION
Section 3 of the loop design carried a flat ~4x upward correction to its timings, on the theory that every factual case pays a full cold model load, and said the real figure was pending measurement once the keep-alive change landed. Measured now.

Full gate run on `main` at `8924110`, `gemma4:e2b` (the same generator the reference runs used), both corpora on a cache hit. Artefact: `tests/eval/runs/20260812T194812Z_mineru-jina_clip-faiss.json`.

| Bucket | 2026-07-29 | 2026-08-12 |
|---|---|---|
| Answered median (n=36) | 201.0 s | **28.5 s** |
| Retrieval-only median (n=15) | 4.1 s | 4.1 s |
| Total wall | 124.0 min | **20.4 min** |
| Search set, 32 `source: corpus` cases | 78.9 min | **12.6 min** |

**The second row is the check that makes the rest readable.** Retrieval-only cases never call the generator, so they had nothing to gain, and they gained nothing. The entire speedup lands exactly where the cold-load hypothesis put it.

That also settles which of the two readings in #54 was right: the reference runs were launched from a tree predating `d36c943`, despite it being committed four minutes before the first one started.

## The result did not move

```
$ python tests/eval/compare_runs.py <2026-07-29 healthy> <2026-08-12>
identical: 51 case(s) unchanged
pass rate delta: +0.0000
```

44/51 = 0.8627, retrieval 11/15, answered 33/36. Same pass/fail vector, case by case, at a sixth of the wall time. It is also a third consecutive healthy run with zero flips, which widens the evidence under criterion 1's noise floor beyond the single pair it rested on, and it is post-merge verification for the seven PRs landed today, two of which touched the FAISS store's write path and the wiring caches.

## The consequential part: section 4's proposer argument is gone

It ran: at ~2.8 hours per evaluation a night yields three or four candidates, blind search is useless at that budget, therefore an LLM proposer is the natural choice.

A quarter hour per candidate yields dozens. The premise is gone.

This does **not** show the deterministic proposer suffices, and it is not a reason to drop the LLM one. It makes criterion 5's controlled comparison between the two cheap enough to settle the question with evidence instead of with an argument from budget. The harness (#31) already carries both proposers for exactly that reason.

## Still open

No report records the `OLLAMA_KEEP_ALIVE` value a run executed under. That is the same gap that made this question unanswerable from artefacts, and the one criterion 7 and the evidence ledger exist to close.

Documentation only. Closes #54.

🤖 Generated with [Claude Code](https://claude.com/claude-code)