### PR TITLE
Route every Ollama call through the configured base URL

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -120,7 +120,9 @@ the defaults. Jina CLIP v2 and BGE Reranker v2 M3 are fixed.
 | RECOMP synthesis | `OLLAMA_RECOMP_MODEL` | Pre-generation context synthesis (`USAR_RECOMP_SYNTHESIS`) |
 | Reranker | fixed | `BAAI/bge-reranker-v2-m3`; not an Ollama model |
 
-Other env vars: `DOCS_FOLDER` (default `rag/docs/en/`), `MONKEYGRAB_DATA_DIR` (writable root for `vector_db`/history/debug; defaults to the package dir in dev, `%LOCALAPPDATA%/MonkeyGrab` in the packaged app), `MONKEYGRAB_LANG` (default `es`; `en`/`ca`).
+Other env vars: `DOCS_FOLDER` (default `rag/docs/en/`), `MONKEYGRAB_DATA_DIR` (writable root for `vector_db`/history/debug; defaults to the package dir in dev, `%LOCALAPPDATA%/MonkeyGrab` in the packaged app), `MONKEYGRAB_LANG` (default `es`; `en`/`ca`), `OLLAMA_BASE_URL` (default `http://localhost:11434`, falling back to Ollama's own `OLLAMA_HOST`).
+
+The Ollama endpoint has exactly one reader, `monkeygrab.config.env.read_env_ollama_base_url`, feeding `AppConfig.models.ollama.base_url` and `rag.chat_pdfs.OLLAMA_BASE_URL`. Every generation call, both `/chat` modes and both reachability checks (CLI startup, web control panel) resolve through it. Do not re-read the variable at a call site: a second resolution is how the CLI health check ended up reporting a server the pipeline never talked to.
 
 Desktop app: `rag/web/desktop.py` is the pywebview entry point frozen by PyInstaller (`packaging/MonkeyGrab.spec`, `packaging/build_exe.py`) into `MonkeyGrab.exe`. Built-in corpora ship in the bundle; Ollama is an external prerequisite. See [`packaging/README.md`](../packaging/README.md).
 

--- a/.env.example
+++ b/.env.example
@@ -36,8 +36,11 @@
 
 
 # ── Ollama connection ───────────────────────────────────────────────────────
-#OLLAMA_HOST=http://127.0.0.1:11434             # read natively by the `ollama` client and by the web control panel's Ollama probes (/api/ollama, /api/models)
-#OLLAMA_BASE_URL=http://localhost:11434         # only read by the CLI's own startup reachability check; generation/embedding calls do not use it (tracked in #62)
+# One endpoint for everything: generation, chat, query decomposition, RECOMP
+# synthesis, contextual enrichment, and the reachability checks the CLI and the
+# web control panel show. Point it at another machine to use a remote Ollama.
+#OLLAMA_BASE_URL=http://localhost:11434         # takes precedence; a value with no scheme (127.0.0.1:11434) gets http:// prepended
+#OLLAMA_HOST=http://127.0.0.1:11434             # Ollama's own variable, read as the fallback when OLLAMA_BASE_URL is unset
 
 
 # ── Ollama context windows (tokens) ─────────────────────────────────────────

--- a/README.md
+++ b/README.md
@@ -235,8 +235,10 @@ is used.
 
 Copy [`.env.example`](.env.example) to `.env` at the project root; it documents
 every supported variable with its default. The shell environment always wins over
-the file. `MONKEYGRAB_LANG` sets the interface language (`es`, `en`, `ca`) and
-`DOCS_FOLDER` the corpus.
+the file. `MONKEYGRAB_LANG` sets the interface language (`es`, `en`, `ca`),
+`DOCS_FOLDER` the corpus, and `OLLAMA_BASE_URL` the Ollama server — point it at
+another machine and every call follows, generation included, which is the way
+out when the local card cannot hold the generator you want.
 
 Each corpus has its own Jina CLIP and FAISS index under `rag/vector_db/`. Both
 interfaces detect when a stored index no longer matches the active chunking,

--- a/rag/cli/app.py
+++ b/rag/cli/app.py
@@ -218,14 +218,14 @@ class MonkeyGrabCLI:
         Returns:
             The full assembled response text.
         """
-        import ollama
+        from monkeygrab.adapters.chat.ollama_chat import ollama_client_for
 
         messages = [{"role": "system", "content": self.rag.SYSTEM_PROMPT_CHAT}]
         mensajes_recientes = self.historial_chat[-(self.rag.MAX_HISTORIAL_MENSAJES):]
         messages.extend(mensajes_recientes)
         messages.append({"role": "user", "content": pregunta})
 
-        stream = ollama.chat(
+        stream = ollama_client_for(self.rag.OLLAMA_BASE_URL).chat(
             model=self.rag.MODELO_CHAT,
             messages=messages,
             stream=True,
@@ -602,11 +602,11 @@ class MonkeyGrabCLI:
         reported once at startup without blocking the rest of initialization,
         so the user understands why later calls will fail.
         """
-        base = (
-            os.getenv("OLLAMA_BASE_URL")
-            or getattr(self.rag, "OLLAMA_BASE_URL", None)
-            or "http://localhost:11434"
-        )
+        # Read off the engine rather than the environment: the engine already
+        # resolved OLLAMA_BASE_URL/OLLAMA_HOST into the endpoint its adapters
+        # generate against, and re-reading the raw variable here is how this
+        # check used to report a server the pipeline never talked to.
+        base = getattr(self.rag, "OLLAMA_BASE_URL", None) or "http://localhost:11434"
         try:
             import requests
             r = requests.get(f"{base}/api/tags", timeout=timeout)

--- a/rag/engine/generation.py
+++ b/rag/engine/generation.py
@@ -16,14 +16,19 @@ import time
 from typing import Any, Dict, List, Optional, Tuple
 
 from rag.engine import wiring
+from monkeygrab.config.env import read_env_ollama_base_url
 from monkeygrab.ports.vector_store import VectorStore
 from rag.engine.runtime import get_runtime
 
 cfg = get_runtime()
 
-# The generator's HTTP endpoint. Kept as a module constant, not an AppConfig
-# field, because the web layer reads it to report Ollama's reachability.
-OLLAMA_BASE_URL = "http://localhost:11434"
+# The generator's HTTP endpoint, re-exported by rag/chat_pdfs.py because the
+# CLI health check and the web control panel both report Ollama's reachability
+# from it. Resolved through the same reader AppConfig uses for
+# models.ollama.base_url, so what those two report is the server the adapters
+# actually send generation to -- it used to be a literal, which made setting
+# OLLAMA_BASE_URL move the diagnostic without moving the traffic.
+OLLAMA_BASE_URL = read_env_ollama_base_url()
 
 
 class _NoCollection:

--- a/rag/engine/indexing.py
+++ b/rag/engine/indexing.py
@@ -75,6 +75,7 @@ def indexar_documentos(
             generate_retries=ollama.generate_retries,
             generate_retry_delay=ollama.generate_retry_delay,
             options={"temperature": 0.1, "num_predict": 250},
+            base_url=ollama.base_url,
         )
 
     image_extractor = None

--- a/rag/engine/wiring.py
+++ b/rag/engine/wiring.py
@@ -137,7 +137,8 @@ def rag_chat_model(config: AppConfig) -> OllamaChatModel:
             "repeat_last_n": 64,
             "num_predict": -1,
         },
-        model_unloader=OllamaModelUnloader(config.models),
+        base_url=ollama.base_url,
+        model_unloader=OllamaModelUnloader(config.models, base_url=ollama.base_url),
     )
 
 
@@ -157,6 +158,7 @@ def recomp_chat_model(config: AppConfig) -> OllamaChatModel:
             "top_p": 0.9,
             "repeat_penalty": 1.15,
         },
+        base_url=ollama.base_url,
     )
 
 
@@ -176,6 +178,7 @@ def query_decomposer(config: AppConfig) -> OllamaChatModel:
         generate_retries=ollama.generate_retries,
         generate_retry_delay=ollama.generate_retry_delay,
         options={"temperature": 0.5, "num_predict": 400, "stop": ["\n\n\n"]},
+        base_url=ollama.base_url,
     )
 
 

--- a/rag/web/app.py
+++ b/rag/web/app.py
@@ -86,9 +86,10 @@ _BUILTIN_STORES = {
     "ca": "Valencià",
 }
 
-# Ollama runtime control. The ollama client honours OLLAMA_HOST itself; we use
-# the same value for the version/start probes exposed to the control panel.
-OLLAMA_HOST = os.getenv("OLLAMA_HOST", "http://127.0.0.1:11434").rstrip("/")
+# Ollama runtime control. Taken from the engine rather than re-read from the
+# environment so the endpoint the control panel probes is the one the pipeline
+# generates against; resolving it twice is how the two used to disagree.
+OLLAMA_BASE_URL = rag_engine.OLLAMA_BASE_URL
 _model_caps_cache: dict = {}  # digest -> capabilities list
 
 # Persisted UI choices (model roles, active store, pipeline flags) so the desktop
@@ -214,14 +215,14 @@ def _chat_stream(pregunta: str) -> Generator[str, None, None]:
     Yields:
         Token strings as they are produced by the model.
     """
-    import ollama
+    from monkeygrab.adapters.chat.ollama_chat import ollama_client_for
 
     messages = [{"role": "system", "content": rag_engine.SYSTEM_PROMPT_CHAT}]
     mensajes_recientes = _state["historial_chat"][-(rag_engine.MAX_HISTORIAL_MENSAJES):]
     messages.extend(mensajes_recientes)
     messages.append({"role": "user", "content": pregunta})
 
-    stream = ollama.chat(
+    stream = ollama_client_for(OLLAMA_BASE_URL).chat(
         model=rag_engine.MODELO_CHAT,
         messages=messages,
         stream=True,
@@ -315,7 +316,7 @@ def _collection_document_details(coll) -> list:
 def _ollama_version() -> Optional[str]:
     """Return the running Ollama version string, or ``None`` if unreachable."""
     try:
-        r = requests.get(f"{OLLAMA_HOST}/api/version", timeout=2)
+        r = requests.get(f"{OLLAMA_BASE_URL}/api/version", timeout=2)
         if r.ok:
             return r.json().get("version")
     except requests.RequestException:
@@ -326,7 +327,7 @@ def _ollama_version() -> Optional[str]:
 def _ollama_capabilities(name: str) -> list:
     """Best-effort capability list (``embedding``/``vision``/...) for a model."""
     try:
-        r = requests.post(f"{OLLAMA_HOST}/api/show", json={"model": name}, timeout=5)
+        r = requests.post(f"{OLLAMA_BASE_URL}/api/show", json={"model": name}, timeout=5)
         if r.ok:
             return r.json().get("capabilities") or []
     except requests.RequestException:
@@ -340,7 +341,7 @@ def _ollama_models() -> list:
     Capabilities come from ``/api/show`` and are cached by digest so repeated
     panel refreshes stay cheap.
     """
-    r = requests.get(f"{OLLAMA_HOST}/api/tags", timeout=5)
+    r = requests.get(f"{OLLAMA_BASE_URL}/api/tags", timeout=5)
     r.raise_for_status()
     models = []
     for m in r.json().get("models", []):
@@ -1118,7 +1119,7 @@ def api_settings_post():
 def api_ollama_status():
     """Report whether the local Ollama server is reachable."""
     version = _ollama_version()
-    return jsonify({"ok": True, "running": version is not None, "version": version, "host": OLLAMA_HOST})
+    return jsonify({"ok": True, "running": version is not None, "version": version, "host": OLLAMA_BASE_URL})
 
 
 @app.route("/api/ollama/start", methods=["POST"])

--- a/src/monkeygrab/adapters/chat/ollama_chat.py
+++ b/src/monkeygrab/adapters/chat/ollama_chat.py
@@ -4,11 +4,13 @@ import base64
 import json
 import logging
 import time
+from functools import lru_cache
 from typing import Any, Dict, Iterator, Optional, Sequence
 
 import ollama
 import requests
 
+from monkeygrab.config.env import DEFAULT_OLLAMA_BASE_URL
 from monkeygrab.domain.generation_chunk import GenerationChunk
 from monkeygrab.ports.model_unloader import ModelUnloader
 
@@ -16,11 +18,25 @@ from monkeygrab.ports.model_unloader import ModelUnloader
 # conformance here is structural (duck typing), the same contract every other
 # adapter in this package satisfies without inheriting its port.
 
-# Not derived from AppConfig: rag/engine/generation.py hardcodes this same
-# value (`OLLAMA_BASE_URL = "http://localhost:11434"`) rather than reading it
-# from an env var, so there is no config field to source it from without
-# inventing one outside this task's scope.
-_DEFAULT_BASE_URL = "http://localhost:11434"
+# Only the fallback for a caller that names no endpoint; the pipeline always
+# passes config.models.ollama.base_url, which is where OLLAMA_BASE_URL lands.
+_DEFAULT_BASE_URL = DEFAULT_OLLAMA_BASE_URL
+
+
+@lru_cache(maxsize=None)
+def ollama_client_for(base_url: str) -> ollama.Client:
+    """Return the shared ``ollama.Client`` for one endpoint.
+
+    Cached per URL because ``wiring`` builds a fresh adapter for every query:
+    a client per instance would open a new HTTP connection pool per question
+    and never close it. The module-level ``ollama.chat`` this replaced had the
+    same one-client-per-process behaviour, minus the configurable host.
+
+    Public because the CLI and web ``/chat`` modes call ``ollama.chat``
+    directly instead of going through this adapter, and they must reach the
+    same server the RAG pipeline does.
+    """
+    return ollama.Client(host=base_url)
 
 
 class OllamaChatModel:
@@ -39,7 +55,8 @@ class OllamaChatModel:
     shapes: a one-turn prompt, and a system plus user message with optional
     image bytes. ``stream`` instead talks to ``/api/generate`` over raw HTTP,
     because it needs line-by-line JSON and a retry policy limited to 5xx --
-    neither of which the client exposes.
+    neither of which the client exposes. Both are bound to ``base_url``, so
+    the two paths cannot end up talking to different servers.
 
     ``model_unloader`` frees VRAM before streaming starts, and again before
     retrying a 5xx. It is injected rather than computed here because
@@ -76,9 +93,10 @@ class OllamaChatModel:
             options: Role-specific sampling defaults (temperature,
                 num_predict, top_p, repeat_penalty, stop, ...), merged with
                 ``num_ctx`` on every call.
-            base_url: Ollama HTTP server base URL, used by ``stream`` only
-                (``generate`` goes through the ``ollama`` client, which reads
-                its own ``OLLAMA_HOST``).
+            base_url: Ollama HTTP server base URL, used by both ``generate``
+                and ``stream``. Passing it explicitly to the client is what
+                makes it win over the ambient ``OLLAMA_HOST`` the client would
+                otherwise read on its own.
             model_unloader: ``ModelUnloader`` used by ``stream`` to free VRAM
                 before generating (and before retrying a 5xx), or ``None`` to
                 skip that entirely -- see the class docstring.
@@ -127,7 +145,7 @@ class OllamaChatModel:
             messages.insert(0, {"role": "system", "content": system})
 
         try:
-            response = ollama.chat(
+            response = ollama_client_for(self._base_url).chat(
                 model=self._model,
                 messages=messages,
                 think=False,

--- a/src/monkeygrab/adapters/chat/ollama_model_unloader.py
+++ b/src/monkeygrab/adapters/chat/ollama_model_unloader.py
@@ -5,13 +5,16 @@ from typing import Optional, Set
 
 import requests
 
+from monkeygrab.config.env import DEFAULT_OLLAMA_BASE_URL
 from monkeygrab.config.models import ModelsConfig
 
 # Not subclassed from monkeygrab.ports.model_unloader.ModelUnloader: Protocol
 # conformance here is structural (duck typing), the same contract every other
 # adapter in this package satisfies without inheriting its port.
 
-_DEFAULT_BASE_URL = "http://localhost:11434"
+# Only the fallback for a caller that names no endpoint; the pipeline always
+# passes config.models.ollama.base_url, which is where OLLAMA_BASE_URL lands.
+_DEFAULT_BASE_URL = DEFAULT_OLLAMA_BASE_URL
 
 
 class OllamaModelUnloader:

--- a/src/monkeygrab/config/app_config.py
+++ b/src/monkeygrab/config/app_config.py
@@ -109,6 +109,7 @@ class AppConfig:
                 keep_alive=env.read_env_int("OLLAMA_KEEP_ALIVE", 0),
                 generate_retries=env.read_env_int("OLLAMA_GENERATE_RETRIES", 2),
                 generate_retry_delay=env.read_env_int("OLLAMA_GENERATE_RETRY_DELAY", 3),
+                base_url=env.read_env_ollama_base_url(),
             ),
         )
 

--- a/src/monkeygrab/config/env.py
+++ b/src/monkeygrab/config/env.py
@@ -13,6 +13,33 @@ never had to handle correctly because nobody had set it yet.
 
 import os
 
+DEFAULT_OLLAMA_BASE_URL = "http://localhost:11434"
+
+
+def read_env_ollama_base_url() -> str:
+    """Resolve the Ollama HTTP endpoint every component must talk to.
+
+    ``OLLAMA_BASE_URL`` is this project's own name for it and the one
+    ``.env.example`` documents. ``OLLAMA_HOST`` is Ollama's own name, honoured
+    by the ``ollama`` client and by the web control panel's probes before this
+    was wired, so it stays as a fallback rather than silently ceasing to work.
+
+    Ollama documents ``OLLAMA_HOST`` without a scheme (``127.0.0.1:11434``),
+    which the raw ``requests`` calls in the adapters would reject as an invalid
+    URL. A missing scheme is filled in instead, and a trailing slash dropped,
+    so that ``f"{base_url}/api/generate"`` is well-formed for every accepted
+    spelling.
+
+    Returns:
+        The base URL, without a trailing slash.
+    """
+    raw = (os.getenv("OLLAMA_BASE_URL") or os.getenv("OLLAMA_HOST") or "").strip()
+    if not raw:
+        return DEFAULT_OLLAMA_BASE_URL
+    if "://" not in raw:
+        raw = f"http://{raw}"
+    return raw.rstrip("/")
+
 
 def read_env_int(name: str, default: int) -> int:
     """Read an integer environment variable, or ``default`` if unset.

--- a/src/monkeygrab/config/models.py
+++ b/src/monkeygrab/config/models.py
@@ -2,6 +2,8 @@
 
 from dataclasses import dataclass
 
+from monkeygrab.config.env import DEFAULT_OLLAMA_BASE_URL
+
 
 @dataclass(frozen=True)
 class OllamaRuntimeConfig:
@@ -13,6 +15,7 @@ class OllamaRuntimeConfig:
     keep_alive: int = 0
     generate_retries: int = 2
     generate_retry_delay: int = 3
+    base_url: str = DEFAULT_OLLAMA_BASE_URL
 
 
 @dataclass(frozen=True)

--- a/tests/eval/run_eval.py
+++ b/tests/eval/run_eval.py
@@ -907,6 +907,11 @@ _UNREACHABLE_CONFIG_OVERRIDE_REASONS = {
     ),
     "models.ollama.generate_retries": "see models.ollama.rag_num_ctx",
     "models.ollama.generate_retry_delay": "see models.ollama.rag_num_ctx",
+    "models.ollama.base_url": (
+        "see models.ollama.rag_num_ctx; and this module posts its per-case "
+        "generations to its own OLLAMA_BASE_URL constant, so the endpoint the "
+        "gate uses would not move with the threaded config either"
+    ),
     "retrieval.min_question_length": "not read anywhere in src/monkeygrab -- Retrieve.run() has no question-length gate",
     "flags.usar_llm_query_decomposition": (
         "ensure_indexed hardcodes query_decomposer=None, so this flag can "

--- a/tests/test_ollama_endpoint_wiring.py
+++ b/tests/test_ollama_endpoint_wiring.py
@@ -1,0 +1,120 @@
+"""End-to-end check that OLLAMA_BASE_URL redirects real requests.
+
+The acceptance criterion of #62 is deliberately not "the constant changed":
+before this was wired, ``rag.chat_pdfs.OLLAMA_BASE_URL`` and the CLI health
+check did read the variable, and generation still went to localhost anyway.
+So these tests set the environment variable, build the models through
+``rag.engine.wiring`` exactly as the pipeline does, and assert the URL the
+adapter would have sent to -- intercepted at the HTTP boundary.
+
+Lives outside ``tests/unit`` because it imports ``rag.engine.wiring``, which
+pulls in the engine; the fast CI gate's ``architecture`` job installs no
+infrastructure and only runs ``tests/unit``.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+for path in (ROOT, ROOT / "src"):
+    if str(path) not in sys.path:
+        sys.path.insert(0, str(path))
+
+
+class _FakeStreamResponse:
+    def __init__(self, lines):
+        self._lines = lines
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        return False
+
+    def raise_for_status(self):
+        return None
+
+    def iter_lines(self):
+        return iter(self._lines)
+
+
+@pytest.fixture
+def posted_urls(monkeypatch):
+    """Capture every URL the chat adapter POSTs to, answering with one done line."""
+    from monkeygrab.adapters.chat import ollama_chat
+
+    urls = []
+
+    def fake_post(url, json_=None, **kwargs):
+        urls.append(url)
+        return _FakeStreamResponse([json.dumps({"response": "hi", "done": True}).encode()])
+
+    monkeypatch.setattr(
+        ollama_chat.requests, "post",
+        lambda url, **kwargs: fake_post(url, **kwargs),
+    )
+    return urls
+
+
+def _wiring_with_env(monkeypatch, base_url=None, host=None):
+    """Return ``rag.engine.wiring`` with the endpoint variables set as given.
+
+    No module reload: ``app_config_from_runtime`` calls ``AppConfig.from_env``
+    on every invocation, which is what lets a runtime config change take
+    effect on the next query. Setting the variable and asking for a model is
+    therefore the same sequence a running process goes through.
+    """
+    monkeypatch.delenv("OLLAMA_BASE_URL", raising=False)
+    monkeypatch.delenv("OLLAMA_HOST", raising=False)
+    if base_url is not None:
+        monkeypatch.setenv("OLLAMA_BASE_URL", base_url)
+    if host is not None:
+        monkeypatch.setenv("OLLAMA_HOST", host)
+
+    # rag.chat_pdfs first: it is the facade every entry point imports, and
+    # rag.engine.wiring imports back into it, so importing wiring on its own
+    # lands in a half-initialized module.
+    import rag.chat_pdfs  # noqa: F401
+    import rag.engine.wiring as wiring
+
+    return wiring
+
+
+def test_setting_ollama_base_url_redirects_the_rag_generator(monkeypatch, posted_urls):
+    wiring = _wiring_with_env(monkeypatch, base_url="http://gpu-box:11434")
+
+    model = wiring.rag_chat_model(wiring.app_config_from_runtime())
+    list(model.stream("prompt"))
+
+    assert posted_urls == ["http://gpu-box:11434/api/generate"]
+
+
+def test_ollama_host_alone_also_redirects_the_rag_generator(monkeypatch, posted_urls):
+    wiring = _wiring_with_env(monkeypatch, host="http://gpu-box:11434")
+
+    model = wiring.rag_chat_model(wiring.app_config_from_runtime())
+    list(model.stream("prompt"))
+
+    assert posted_urls == ["http://gpu-box:11434/api/generate"]
+
+
+def test_unset_variables_keep_every_role_on_the_local_server(monkeypatch):
+    """The default path must be byte-identical to before this was wired."""
+    wiring = _wiring_with_env(monkeypatch)
+    config = wiring.app_config_from_runtime()
+
+    endpoints = {
+        wiring.rag_chat_model(config)._base_url,
+        wiring.recomp_chat_model(config)._base_url,
+        wiring.query_decomposer(config)._base_url,
+        wiring.rag_chat_model(config)._model_unloader._base_url,
+    }
+
+    assert endpoints == {"http://localhost:11434"}
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/unit/adapters/test_ollama_chat.py
+++ b/tests/unit/adapters/test_ollama_chat.py
@@ -1,7 +1,7 @@
 """Unit tests for monkeygrab.adapters.chat.ollama_chat.OllamaChatModel.
 
-Stubs ollama.chat and requests.post entirely -- no Ollama server, no network
--- so these run in milliseconds.
+Stubs the ollama client and requests.post entirely -- no Ollama server, no
+network -- so these run in milliseconds.
 """
 
 import logging
@@ -19,12 +19,28 @@ from monkeygrab.adapters.chat.ollama_chat import OllamaChatModel
 from monkeygrab.domain.generation_chunk import GenerationChunk
 
 
+def _stub_chat(monkeypatch, calls, content="", error=None):
+    """Replace the cached client factory with one recording every chat call.
+
+    Each recorded call carries the ``host`` its client was built for, so a test
+    can assert which server the adapter would have talked to.
+    """
+    class _FakeClient:
+        def __init__(self, host):
+            self._host = host
+
+        def chat(self, **kwargs):
+            calls.append({**kwargs, "host": self._host})
+            if error is not None:
+                raise error
+            return {"message": {"content": content}}
+
+    monkeypatch.setattr(module, "ollama_client_for", _FakeClient)
+
+
 def test_generate_uses_the_injected_model_and_num_ctx_not_frozen_defaults(monkeypatch):
     calls = []
-    monkeypatch.setattr(
-        module.ollama, "chat",
-        lambda **kwargs: calls.append(kwargs) or {"message": {"content": "answer"}},
-    )
+    _stub_chat(monkeypatch, calls, content="answer")
 
     chat_model = OllamaChatModel(
         "my-role-model:latest", num_ctx=1234, options={"temperature": 0.5}
@@ -39,22 +55,28 @@ def test_generate_uses_the_injected_model_and_num_ctx_not_frozen_defaults(monkey
 
 def test_generate_always_disables_thinking(monkeypatch):
     calls = []
-    monkeypatch.setattr(
-        module.ollama, "chat",
-        lambda **kwargs: calls.append(kwargs) or {"message": {"content": ""}},
-    )
+    _stub_chat(monkeypatch, calls)
 
     OllamaChatModel("m", num_ctx=100).generate("hello")
 
     assert calls[0]["think"] is False
 
 
+def test_generate_talks_to_the_configured_base_url(monkeypatch):
+    """Single-shot generation (RECOMP, query decomposition, contextual
+    enrichment) must reach the same server streaming does -- it used to go
+    wherever the client's ambient OLLAMA_HOST pointed."""
+    calls = []
+    _stub_chat(monkeypatch, calls)
+
+    OllamaChatModel("m", num_ctx=100, base_url="http://gpu-box:11434").generate("hello")
+
+    assert calls[0]["host"] == "http://gpu-box:11434"
+
+
 def test_generate_puts_the_system_prompt_first(monkeypatch):
     calls = []
-    monkeypatch.setattr(
-        module.ollama, "chat",
-        lambda **kwargs: calls.append(kwargs) or {"message": {"content": ""}},
-    )
+    _stub_chat(monkeypatch, calls)
 
     OllamaChatModel("m", num_ctx=100).generate("question", system="be concise")
 
@@ -66,10 +88,7 @@ def test_generate_puts_the_system_prompt_first(monkeypatch):
 
 def test_generate_without_system_sends_a_single_user_message(monkeypatch):
     calls = []
-    monkeypatch.setattr(
-        module.ollama, "chat",
-        lambda **kwargs: calls.append(kwargs) or {"message": {"content": ""}},
-    )
+    _stub_chat(monkeypatch, calls)
 
     OllamaChatModel("m", num_ctx=100).generate("question")
 
@@ -80,10 +99,7 @@ def test_generate_base64_encodes_images(monkeypatch):
     import base64
 
     calls = []
-    monkeypatch.setattr(
-        module.ollama, "chat",
-        lambda **kwargs: calls.append(kwargs) or {"message": {"content": ""}},
-    )
+    _stub_chat(monkeypatch, calls)
 
     OllamaChatModel("m", num_ctx=100).generate("describe this", images=[b"\x89PNG raw bytes"])
 
@@ -92,10 +108,7 @@ def test_generate_base64_encodes_images(monkeypatch):
 
 
 def test_generate_hard_fails_on_ollama_error(monkeypatch):
-    monkeypatch.setattr(
-        module.ollama, "chat",
-        lambda **kwargs: (_ for _ in ()).throw(ConnectionError("ollama down")),
-    )
+    _stub_chat(monkeypatch, [], error=ConnectionError("ollama down"))
 
     with pytest.raises(RuntimeError, match="ollama down"):
         OllamaChatModel("m", num_ctx=100).generate("hello")
@@ -140,6 +153,21 @@ def test_stream_uses_the_injected_model_and_num_ctx(monkeypatch):
     assert calls[0]["json"]["options"]["num_ctx"] == 777
     assert calls[0]["timeout"] == 42
     assert calls[0]["json"]["think"] is False
+
+
+def test_stream_posts_to_the_configured_base_url(monkeypatch):
+    calls = []
+    import json as jsonlib
+
+    def fake_post(url, json, stream, timeout):
+        calls.append(url)
+        return _FakeStreamResponse([jsonlib.dumps({"response": "hi", "done": True}).encode()])
+
+    monkeypatch.setattr(module.requests, "post", fake_post)
+
+    list(OllamaChatModel("m", num_ctx=100, base_url="http://gpu-box:11434").stream("prompt"))
+
+    assert calls == ["http://gpu-box:11434/api/generate"]
 
 
 def test_stream_yields_a_generation_chunk_per_line_including_the_empty_done_line(monkeypatch):

--- a/tests/unit/test_app_config_defaults.py
+++ b/tests/unit/test_app_config_defaults.py
@@ -45,6 +45,7 @@ _FIELD_MAP = [
     ("models.ollama.keep_alive", "OLLAMA_KEEP_ALIVE"),
     ("models.ollama.generate_retries", "OLLAMA_GENERATE_RETRIES"),
     ("models.ollama.generate_retry_delay", "OLLAMA_GENERATE_RETRY_DELAY"),
+    ("models.ollama.base_url", "OLLAMA_BASE_URL"),
     ("chunking.chunk_size", "CHUNK_SIZE"),
     ("chunking.chunk_overlap", "CHUNK_OVERLAP"),
     ("chunking.min_chunk_length", "MIN_CHUNK_LENGTH"),

--- a/tests/unit/test_ollama_endpoint_config.py
+++ b/tests/unit/test_ollama_endpoint_config.py
@@ -1,0 +1,97 @@
+"""Unit tests for the Ollama endpoint resolution shared by every component.
+
+``OLLAMA_BASE_URL`` used to be documented in ``.env.example`` while only the
+CLI's startup health check read it: generation, chat, RECOMP synthesis and
+contextual enrichment all went to a hardcoded ``http://localhost:11434``, so
+pointing the variable at another server moved the diagnostic without moving
+the traffic. These tests pin the single reader that now feeds all of them.
+
+Standard library and ``monkeygrab.config`` only, so the fast CI gate's
+``architecture`` job (which installs no infrastructure) runs them.
+"""
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+for path in (ROOT, ROOT / "src"):
+    if str(path) not in sys.path:
+        sys.path.insert(0, str(path))
+
+import pytest  # noqa: E402
+
+from monkeygrab.config import AppConfig  # noqa: E402
+from monkeygrab.config.env import (  # noqa: E402
+    DEFAULT_OLLAMA_BASE_URL,
+    read_env_ollama_base_url,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_ollama_env(monkeypatch):
+    """Neither variable set, whatever the developer's shell exports."""
+    monkeypatch.delenv("OLLAMA_BASE_URL", raising=False)
+    monkeypatch.delenv("OLLAMA_HOST", raising=False)
+
+
+def test_defaults_to_the_local_server_when_nothing_is_set():
+    assert read_env_ollama_base_url() == "http://localhost:11434"
+    assert DEFAULT_OLLAMA_BASE_URL == "http://localhost:11434"
+
+
+def test_ollama_base_url_is_honoured(monkeypatch):
+    monkeypatch.setenv("OLLAMA_BASE_URL", "http://gpu-box:11434")
+
+    assert read_env_ollama_base_url() == "http://gpu-box:11434"
+
+
+def test_ollama_host_is_the_fallback(monkeypatch):
+    """Ollama's own variable is what the ``ollama`` client and the web control
+    panel honoured before this was wired -- it must not stop working."""
+    monkeypatch.setenv("OLLAMA_HOST", "http://gpu-box:11434")
+
+    assert read_env_ollama_base_url() == "http://gpu-box:11434"
+
+
+def test_ollama_base_url_wins_over_ollama_host(monkeypatch):
+    monkeypatch.setenv("OLLAMA_BASE_URL", "http://explicit:1111")
+    monkeypatch.setenv("OLLAMA_HOST", "http://ambient:2222")
+
+    assert read_env_ollama_base_url() == "http://explicit:1111"
+
+
+def test_a_schemeless_value_gets_http_prepended(monkeypatch):
+    """Ollama documents OLLAMA_HOST as ``127.0.0.1:11434``; the adapters build
+    request URLs by concatenation, which that spelling would break."""
+    monkeypatch.setenv("OLLAMA_HOST", "127.0.0.1:11434")
+
+    assert read_env_ollama_base_url() == "http://127.0.0.1:11434"
+
+
+def test_a_trailing_slash_is_dropped(monkeypatch):
+    monkeypatch.setenv("OLLAMA_BASE_URL", "http://gpu-box:11434/")
+
+    assert read_env_ollama_base_url() == "http://gpu-box:11434"
+
+
+def test_an_empty_value_falls_through_to_the_default(monkeypatch):
+    """``.env`` files routinely carry ``OLLAMA_BASE_URL=`` with nothing after
+    it; that is "unset", not "connect to the empty string"."""
+    monkeypatch.setenv("OLLAMA_BASE_URL", "   ")
+
+    assert read_env_ollama_base_url() == "http://localhost:11434"
+
+
+def test_app_config_carries_the_resolved_endpoint(monkeypatch):
+    """The field the adapters are actually built from."""
+    monkeypatch.setenv("OLLAMA_BASE_URL", "http://gpu-box:11434")
+
+    assert AppConfig.from_env().models.ollama.base_url == "http://gpu-box:11434"
+
+
+def test_app_config_defaults_to_the_local_server():
+    assert AppConfig.from_env().models.ollama.base_url == "http://localhost:11434"
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
Closes #62.

## The defect

`OLLAMA_BASE_URL` was documented but only the CLI's startup health check read it. Generation, `/chat`, RECOMP synthesis, contextual enrichment and the VRAM unloader all pointed at a hardcoded `http://localhost:11434`. Setting the variable moved the diagnostic without moving the traffic — the check reported a server the pipeline never talked to.

Ollama's own `OLLAMA_HOST` was honoured just as partially: the `ollama` client (so `generate()`) and the web control panel's probes read it, while streaming and the unloader did not. **No remote configuration worked end to end under either name.**

## The fix

One reader, `monkeygrab.config.env.read_env_ollama_base_url` — `OLLAMA_BASE_URL`, then `OLLAMA_HOST`, then `http://localhost:11434`. It feeds `AppConfig.models.ollama.base_url` and `rag.chat_pdfs.OLLAMA_BASE_URL`, and from there reaches every consumer the issue lists:

| Consumer | Before | After |
|---|---|---|
| CLI health check | `os.getenv`, then a constant | reads the engine's resolved value |
| Web control panel probes | `OLLAMA_HOST`, own default | same value the pipeline uses |
| RAG generator (`stream`) | literal | `config.models.ollama.base_url` |
| RECOMP / query decomposition / contextual (`generate`) | ambient `OLLAMA_HOST` | client bound to the configured URL |
| Model unloader | literal | `config.models.ollama.base_url` |
| CLI and web `/chat` | ambient `OLLAMA_HOST` | client bound to the configured URL |

Decisions taken against the issue's acceptance list:

- **`OLLAMA_HOST` kept as a documented fallback**, not removed. It is Ollama's own name for the setting and the web panel already honoured it; dropping it would have been a silent removal of working behaviour.
- **`generate()` moved off the module-level `ollama.chat`** onto a client bound to the URL, cached per endpoint. Without that, single-shot roles would still follow the ambient variable and could diverge from streaming. The cache keeps the one-client-per-process behaviour the module-level call had, instead of opening a connection pool per query.
- **A schemeless value gets `http://` prepended.** Ollama documents `OLLAMA_HOST` as `127.0.0.1:11434`, and the adapters build request URLs by concatenation.

## Verification

- `tests/test_ollama_endpoint_wiring.py` covers the issue's "redirects a real request, not just the constant" criterion: it sets the variable, builds the model through `rag.engine.wiring` as the pipeline does, and asserts the URL the adapter POSTs to. Confirmed it fails (`http://localhost:...` != `http://gpu-box:...`) when the wiring is reverted.
- `tests/unit/test_ollama_endpoint_config.py` pins precedence, scheme normalisation, trailing slash and empty-value handling. Standard library only, so the fast gate's `architecture` job runs it.
- `tests/unit/test_app_config_defaults.py` now maps `models.ollama.base_url` to `rag.chat_pdfs.OLLAMA_BASE_URL`, keeping the two in the existing drift guard.
- Full suite: 368 passed, 1 skipped (`test_nothink.py`, opt-in Ollama integration). `ruff check .` clean.
- **Defaults unchanged**: with neither variable set, all seven consumers still resolve to `http://localhost:11434`.

> [!IMPORTANT]
> This touches generation-path wiring, so §5 asks for the full GPU eval gate (`full-eval.yml`) alongside the fast gate. It has not been run — no GPU/Ollama available in the authoring environment. The default path is byte-identical, which is the argument that the gate's result cannot move, but that is an argument, not a measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
