### PR TITLE
Release the embedder worker and reranker weights before RAG generation (#25)

### DIFF
--- a/rag/README.md
+++ b/rag/README.md
@@ -28,6 +28,13 @@ required ports and run `IndexCorpus`, `Retrieve` and `Answer` from
 package's mutable runtime configuration and the immutable `AppConfig` the core
 expects. MinerU, Jina CLIP and FAISS are built by the fixed composition root.
 
+`wiring.py` also owns freeing what it cached: `release_gpu_models()` closes
+the jina-clip worker and drops the reranker's weights, and
+`engine/generation.py` calls it right before every RAG generation call, so
+retrieval's GPU tenants are gone before Ollama is asked to load the
+generator. `/chat` mode never reaches this — it calls Ollama directly — so
+nothing needs to guard the call by mode.
+
 The consequence worth knowing: the CLI, web app, desktop wrapper and evaluation
 gate execute the same indexing, retrieval and generation implementations.
 

--- a/rag/engine/generation.py
+++ b/rag/engine/generation.py
@@ -114,6 +114,21 @@ def generar_tokens_respuesta(mensaje_usuario: str, stats: Optional[Dict[str, Any
     config = wiring.app_config_from_runtime()
     use_case = wiring.answer(_NO_COLLECTION, config)
 
+    # Retrieval (embedder worker, reranker weights) is already done by the
+    # time any caller reaches this point -- preparar_fragmentos_para_generacion
+    # and _preparar_mensaje_usuario_rag only touch the vector store and CPU-side
+    # text assembly. Releasing here, right before the generator's own stream()
+    # call, is what stops the embedder/reranker from still holding VRAM while
+    # Ollama tries to load: Ollama does not fail fast when memory is short, it
+    # blocks until the request times out (#25). Scoped to this function alone
+    # (not the retrieval path) because this is the one place every RAG
+    # generation call funnels through -- CLI and web streaming call this
+    # directly, CLI's non-streaming reply and web's non-streaming reply reach
+    # it via _generar_respuesta_stream below -- while /chat mode never calls
+    # into rag/engine/generation.py at all (it talks to Ollama directly), so
+    # nothing needs to guard this call against firing outside RAG mode.
+    wiring.release_gpu_models()
+
     for chunk in use_case.stream(mensaje_usuario):
         if chunk.text:
             yield chunk.text

--- a/rag/engine/wiring.py
+++ b/rag/engine/wiring.py
@@ -219,6 +219,42 @@ def lexical_index(store: VectorStore, config: AppConfig) -> Bm25LexicalIndex:
     return _lexical_cache["index"]
 
 
+def release_gpu_models() -> None:
+    """Free the cached embedder worker and reranker weights, if either is loaded.
+
+    Called from the generation entry points (rag/engine/generation.py) right
+    before Ollama is asked to load the generator, never from the retrieval
+    path itself: on an 8 GB card, an idle jina-clip worker or a resident
+    Cross-Encoder is enough to keep Ollama from loading at all, and Ollama
+    does not fail fast when memory is short -- it blocks until the request
+    times out (#25). This mirrors tests/eval/run_eval.py's
+    _release_gpu_models, which does the same thing for the embedder/reranker
+    instances its own Retrieve use case holds; this function releases this
+    module's caches instead, since the CLI and the web app get their
+    embedder/reranker through embedder()/reranker() above rather than
+    holding their own references.
+
+    Safe to call with nothing cached (both hooks are then no-ops) and safe
+    to call more than once (a second call finds the slot already cleared).
+    Each cache slot is swapped for ``None`` while holding its own lock --
+    the same lock embedder()/reranker() take to build -- so a build racing
+    this call either wins the swap and gets the live instance back (release
+    then closes the now-orphaned one), or loses it and rebuilds against an
+    empty slot; either way nothing ever calls close()/release() on an
+    instance another thread is mid-build on, or hands out a reference to one
+    that is mid-close.
+    """
+    with _embedder_cache_lock:
+        emb, _embedder_cache["embedder"] = _embedder_cache["embedder"], None
+    if emb is not None:
+        emb.close()
+
+    with _reranker_cache_lock:
+        rer, _reranker_cache["reranker"] = _reranker_cache["reranker"], None
+    if rer is not None:
+        rer.release()
+
+
 def reranker(config: AppConfig) -> CrossEncoderReranker:
     """Return the Cross-Encoder reranker, loading its weights at most once.
 
@@ -432,6 +468,7 @@ __all__ = [
     "query_decomposer",
     "rag_chat_model",
     "recomp_chat_model",
+    "release_gpu_models",
     "reranker",
     "reset_vector_store_cache",
     "retrieval_metrics_to_legacy",

--- a/tests/unit/test_generation_gpu_release.py
+++ b/tests/unit/test_generation_gpu_release.py
@@ -1,0 +1,129 @@
+"""Regression tests for #25: the RAG generation entry points must release the
+GPU-resident embedder/reranker before Ollama is asked to load the generator.
+
+rag/engine/generation.py's generar_tokens_respuesta is the one function every
+RAG generation call funnels through:
+
+- the web app's streaming reply iterates it directly (rag/web/app.py's
+  api_rag);
+- the web app's non-streaming reply and the CLI's generar_respuesta both
+  reach it through _generar_respuesta_stream.
+
+/chat mode (both interfaces) never imports this module at all -- it calls
+Ollama directly -- so it needs no test here; there is nothing for it to call.
+
+Everything below is a double: no real Ollama, embedder or reranker is
+constructed, so this runs without a GPU (it still needs the project's real
+dependencies importable, same as the rest of tests/unit that `import rag`;
+see tests/conftest.py's collect_ignore for why the dependency-free CI job
+skips this file entirely rather than running it against stubs).
+"""
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import rag.chat_pdfs  # noqa: F401 -- import before rag.engine.generation, see wiring's module docstring
+from rag.engine import generation, wiring
+
+
+class _FakeChunk:
+    """Minimal stand-in for monkeygrab.application.answer.GenerationChunk."""
+
+    _STAT_FIELDS = (
+        "model", "done_reason", "total_duration", "load_duration",
+        "prompt_eval_count", "prompt_eval_duration", "eval_count", "eval_duration",
+    )
+
+    def __init__(self, text, done=False):
+        self.text = text
+        self.done = done
+        for field in self._STAT_FIELDS:
+            setattr(self, field, None)
+
+
+class _FakeUseCase:
+    """Stand-in for monkeygrab.application.answer.Answer.
+
+    ``stream`` records that it was entered, so a test can assert
+    release_gpu_models ran strictly before it -- the whole point of #25 is
+    ordering, not just that the hook exists somewhere in the call chain.
+    """
+
+    def __init__(self, events):
+        self._events = events
+
+    def build_user_message(self, pregunta, fragments):
+        del pregunta, fragments
+        return "mensaje", {}
+
+    def stream(self, mensaje_usuario):
+        del mensaje_usuario
+        self._events.append("stream_started")
+        yield _FakeChunk("hola")
+        yield _FakeChunk("", done=True)
+
+
+def _patch_generation(monkeypatch, events):
+    monkeypatch.setattr(wiring, "app_config_from_runtime", lambda: object())
+    monkeypatch.setattr(wiring, "answer", lambda *args, **kwargs: _FakeUseCase(events))
+    monkeypatch.setattr(wiring, "release_gpu_models", lambda: events.append("released"))
+
+
+def test_generar_tokens_respuesta_releases_before_streaming_web_streaming_path(monkeypatch):
+    """api_rag's SSE path: `for token in rag_engine.generar_tokens_respuesta(...)`."""
+    events = []
+    _patch_generation(monkeypatch, events)
+
+    tokens = list(generation.generar_tokens_respuesta("mensaje"))
+
+    assert events == ["released", "stream_started"]
+    assert tokens == ["hola"]
+
+
+def test_generar_respuesta_stream_releases_before_streaming_web_nonstreaming_path(monkeypatch):
+    """api_rag's non-streaming path calls _generar_respuesta_stream directly."""
+    events = []
+    _patch_generation(monkeypatch, events)
+
+    respuesta = generation._generar_respuesta_stream("mensaje")
+
+    assert events == ["released", "stream_started"]
+    assert respuesta == "hola"
+
+
+def test_generar_respuesta_releases_before_streaming_cli_path(monkeypatch):
+    """rag/cli/app.py's _process_rag calls self.rag.generar_respuesta(...)."""
+    events = []
+    _patch_generation(monkeypatch, events)
+    monkeypatch.setattr(generation.cfg, "guardar_debug_rag", lambda *a, **k: None)
+
+    fragmentos = [{"doc": "texto", "metadata": {"source": "a.pdf", "page": 0, "chunk": 0}}]
+    respuesta = generation.generar_respuesta("pregunta", fragmentos)
+
+    assert events == ["released", "stream_started"]
+    assert respuesta == "hola"
+
+
+def test_generar_respuesta_silenciosa_releases_before_streaming_eval_path(monkeypatch):
+    """generar_respuesta_silenciosa is what tests/eval/run_eval.py's
+    run_factual_case calls per case in phase 2 -- confirming it also releases
+    (a no-op there in practice, since the eval runner never populates these
+    caches in the first place, but the ordering contract is the same one)."""
+    events = []
+    _patch_generation(monkeypatch, events)
+
+    fragmentos = [{"doc": "texto", "metadata": {"source": "a.pdf", "page": 0, "chunk": 0}}]
+    respuesta = generation.generar_respuesta_silenciosa("pregunta", fragmentos)
+
+    assert events == ["released", "stream_started"]
+    assert respuesta == "hola"
+
+
+if __name__ == "__main__":
+    import pytest
+
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/unit/test_wiring_gpu_release.py
+++ b/tests/unit/test_wiring_gpu_release.py
@@ -1,0 +1,116 @@
+"""Regression tests for rag/engine/wiring.py's release_gpu_models (#25).
+
+Nothing in rag/ freed the jina-clip worker or the Cross-Encoder weights
+before Ollama loaded the generator, so both stayed resident for the life of
+the process. On an 8 GB card that is enough to keep Ollama from loading at
+all -- it does not fail fast when memory is short, it blocks until the
+request times out. tests/eval/run_eval.py's _release_gpu_models already
+proved the fix (embedder.close() + reranker.release() before generation);
+these tests cover the equivalent hook wired into this module's own caches.
+"""
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import rag.chat_pdfs  # noqa: F401 -- import before rag.engine.wiring, see its module docstring
+from rag.engine import wiring
+
+
+class _RecordingReleasable:
+    """Stand-in for JinaClipEmbedder/CrossEncoderReranker: records release calls."""
+
+    def __init__(self, method_name):
+        self.calls = 0
+        self._method_name = method_name
+        setattr(self, method_name, self._record)
+
+    def _record(self):
+        self.calls += 1
+
+
+def _fake_embedder():
+    return _RecordingReleasable("close")
+
+
+def _fake_reranker():
+    return _RecordingReleasable("release")
+
+
+def setup_function(_func):
+    wiring._embedder_cache.update(embedder=None)
+    wiring._reranker_cache.update(reranker=None)
+
+
+def teardown_function(_func):
+    wiring._embedder_cache.update(embedder=None)
+    wiring._reranker_cache.update(reranker=None)
+
+
+def test_release_gpu_models_closes_cached_embedder_and_clears_the_slot():
+    embedder = _fake_embedder()
+    wiring._embedder_cache.update(embedder=embedder)
+
+    wiring.release_gpu_models()
+
+    assert embedder.calls == 1
+    assert wiring._embedder_cache["embedder"] is None
+
+
+def test_release_gpu_models_releases_cached_reranker_and_clears_the_slot():
+    reranker = _fake_reranker()
+    wiring._reranker_cache.update(reranker=reranker)
+
+    wiring.release_gpu_models()
+
+    assert reranker.calls == 1
+    assert wiring._reranker_cache["reranker"] is None
+
+
+def test_release_gpu_models_releases_both_caches_in_one_call():
+    embedder = _fake_embedder()
+    reranker = _fake_reranker()
+    wiring._embedder_cache.update(embedder=embedder)
+    wiring._reranker_cache.update(reranker=reranker)
+
+    wiring.release_gpu_models()
+
+    assert embedder.calls == 1
+    assert reranker.calls == 1
+    assert wiring._embedder_cache["embedder"] is None
+    assert wiring._reranker_cache["reranker"] is None
+
+
+def test_release_gpu_models_is_a_no_op_when_nothing_is_cached():
+    # Neither cache populated -- must not raise (e.g. on a /chat-only session
+    # that never triggered a RAG retrieval).
+    wiring.release_gpu_models()
+
+    assert wiring._embedder_cache["embedder"] is None
+    assert wiring._reranker_cache["reranker"] is None
+
+
+def test_release_gpu_models_does_not_double_release_on_a_second_call():
+    """A second call must find the slot already cleared, not re-release the
+    same instance -- CrossEncoderReranker.release()/JinaClipEmbedder.close()
+    already tolerate that themselves, but release_gpu_models should not even
+    attempt it once the cache has been swapped to None."""
+    embedder = _fake_embedder()
+    reranker = _fake_reranker()
+    wiring._embedder_cache.update(embedder=embedder)
+    wiring._reranker_cache.update(reranker=reranker)
+
+    wiring.release_gpu_models()
+    wiring.release_gpu_models()
+
+    assert embedder.calls == 1
+    assert reranker.calls == 1
+
+
+if __name__ == "__main__":
+    import pytest
+
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

- `rag/engine/wiring.py` cached the jina-clip worker and the Cross-Encoder reranker for the life of the process; nothing released either before Ollama loaded the generator. `tests/eval/run_eval.py`'s `_release_gpu_models` already proved the fix (`embedder.close()` + `reranker.release()` between its retrieval and generation phases). This wires the same pair of calls into the product's own generation path.
- New `wiring.release_gpu_models()` swaps both cache slots to `None` under the same locks `embedder()`/`reranker()` build under (#53), then closes/releases outside the lock.
- `rag/engine/generation.py`'s `generar_tokens_respuesta` calls it once, right before `use_case.stream()`. That function is the single place every RAG generation call funnels through — web's streaming reply iterates it directly; CLI's `generar_respuesta` and web's non-streaming reply both reach it via `_generar_respuesta_stream`. `/chat` mode (both interfaces) calls Ollama directly and never imports this module, so it can never trigger the release — no flag needed, the scoping is structural.

## Design decision (answering the review questions directly)

1. **Unconditional or only before generation?** Scoped to RAG generation by construction, not a runtime flag: the one call site is inside `generar_tokens_respuesta`, which `/chat` never reaches.
2. **Does the embedder worker have to die, or is the reranker enough?** Both have to go, reasoned from measured VRAM (not a guess — see below): jina-clip ≈2.80 GB, reranker ≈1.23 GB, `gemma4:e4b` ≈3.95 GB alone. Releasing only the reranker leaves embedder + generator ≈6.75 GB, already over an 8 GB budget once this machine's ~1.6 GB OS/desktop overhead is added back in.
3. **What does the next query pay?** Retrieval on the *next* RAG query pays the reload — `JinaClipEmbedder` has no partial-unload API, only `close()` (whole process), so that's a real ~29–36 s cold start; the reranker's reload is a few seconds. This repeats on every RAG query after the first in a session. It is not eliminated, only pushed to where the 8 GB budget forces it — the measured alternative is not "a bit slower," it's the generator silently split across GPU and CPU on *every* generation call (see measurement below). Removing the trade-off entirely (bigger card, smaller models, partial-unload scheme) is out of scope for this issue.
4. **Interaction with PR #53's double-checked locks?** `release_gpu_models()` takes the exact same lock each builder takes, swaps the slot to `None` before calling `close()`/`release()`, outside the lock. A build racing a release fully completes before the other proceeds — never a torn-down instance handed to a caller, never a release running on a half-built one. `JinaClipEmbedder.close()` additionally holds its own internal request lock, so it can't race an in-flight `embed()` call either. No lock is held across both cache sections, so there's no lock-ordering cycle.
5. **Both interfaces?** Yes — one mechanism, one call site, reached by both the CLI and the web app (streaming and non-streaming).

## Real-VRAM verification

Measured directly on this machine's RTX 4060 (8 GB) — `nvidia-smi` before/after real loads, no doubles — **before** GPU work on this task was put on hold pending an unrelated evaluation-gate run on the same machine. Baseline was confirmed clean throughout (no other GPU tenant resident), so these are not readings taken under contention:

| Component | VRAM | Cold start |
|---|---|---|
| jina-clip-v2 worker | ~2.80 GB | ~30–36 s |
| BGE reranker v2 m3 | ~1.23 GB | ~7 s |
| `gemma4:e4b` (alone) | ~3.95 GB | — |

Reproduced the bug directly: with jina-clip + reranker left resident (pre-fix behavior) and `gemma4:e4b` then asked to generate, Ollama's own `/api/ps` showed it placed only ~1.68 GB of the model on GPU instead of its normal ~3.95 GB — roughly half silently pushed to CPU RAM for that call. With the fix applied (`embedder.close()` + `reranker.release()` called first), the generator got its full ~3.95 GB every time.

**No further live-GPU measurement has been taken since being asked to hold off pending a concurrent evaluation-gate run on this machine, and none is planned until that's confirmed clear.** Flagging this plainly rather than claiming a fresher reading I don't have.

## Note for review: overlap with #69

PR #69 ("Route every Ollama call through the configured base URL") is open concurrently and also touches `rag/engine/generation.py` and `rag/engine/wiring.py`. The overlapping hunks are in different regions of both files (#69 touches the `OLLAMA_BASE_URL` constant and the `rag_chat_model`/`recomp_chat_model`/`query_decomposer` builders; this PR adds `release_gpu_models()` after `lexical_index()` and one call site inside `generar_tokens_respuesta`). This branch is already rebased onto every commit currently on `main` (through `ee3758b`), and the two changes applied cleanly with no textual conflict.

## Test plan

- [x] `tests/unit/test_wiring_gpu_release.py` — `release_gpu_models()` closes/releases what's cached, clears the slot, is a no-op with nothing cached, and doesn't double-release on a second call.
- [x] `tests/unit/test_generation_gpu_release.py` — asserts the release happens *before* `use_case.stream()` is entered, exercised through `generar_tokens_respuesta` (web streaming), `_generar_respuesta_stream` (web non-streaming), `generar_respuesta` (CLI) and `generar_respuesta_silenciosa` (the eval runner's own path — a no-op there since that runner never populates these caches). All via doubles, no GPU or live Ollama required.
- [x] `pytest -q -p no:randomly`: 405 passed, 1 skipped (baseline on `main`: 396 passed, 1 skipped — the +9 is exactly the new tests above).
- [x] `ruff check .`: clean.
- [x] `tests/characterization/` and `tests/eval/` untouched.

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)
