### PR TITLE
Close the wiring cache read race that could return the wrong corpus (#57)

### DIFF
--- a/rag/engine/wiring.py
+++ b/rag/engine/wiring.py
@@ -82,19 +82,23 @@ def vector_store(config: AppConfig) -> VectorStore:
     once the lock is held. The cheap, unlocked check outside the lock keeps
     the common case (cache already valid) lock-free.
 
-    The key and the store live in one ``(key, store)`` tuple under a single
-    dict slot, read with one subscript rather than two (#57). Under
-    CPython's GIL, a dict lookup by an immutable, C-hashable key -- our key
-    is a tuple of strings -- runs to completion without releasing the GIL,
-    so that single read is atomic: no other thread's write can be
-    interleaved partway through it. Two separate reads (key, then store)
-    would not have that guarantee -- a thread could validate the key,
-    lose the GIL to a concurrent corpus switch that republishes the slot,
-    and then read back a store belonging to the *new* key. The result
-    would look like a normal answer while silently citing the wrong
-    corpus, with nothing to log or raise. Splitting the read into "check"
-    and "return" of a local variable, rather than reading the dict twice,
-    closes the window entirely instead of narrowing it.
+    The key and the store live in one ``(key, store)`` tuple under a
+    single dict slot (``_store_cache["entry"]``), read with one subscript
+    instead of two (#57). That subscript is not itself atomic -- on this
+    interpreter it compiles to a dict lookup followed by a separate tuple
+    unpack, and a thread switch can land between them. What makes the
+    read safe is that it yields an *immutable* ``(key, store)`` pair,
+    which from then on lives only in this thread's own locals: a
+    concurrent corpus switch can swap which pair the slot holds next, but
+    it cannot reach into the pair this thread already pulled off the slot
+    and change it. The old two-slot cache had no such guarantee -- with
+    the key and the store as separate dict entries, a thread could
+    validate its key against one slot, get preempted, have a second
+    thread republish both slots for a different corpus, and then read the
+    *other* slot back holding the new corpus's store, silently
+    disagreeing with the key this thread already checked. The result was
+    a well-formed answer retrieved from the wrong corpus, with nothing to
+    log or raise.
     """
     key = (config.paths.path_db, config.paths.collection_name)
     cached_key, store = _store_cache["entry"]
@@ -120,6 +124,20 @@ def embedder(config: AppConfig):
     subprocess and loads jina-clip on first use (~29s), and the losing
     instance is unreachable yet pinned alive by its own stdout/stderr pump
     threads once its worker has started, so nothing ever closes it (#46).
+
+    Unlike ``vector_store``/``lexical_index``, this slot is never re-keyed
+    or republished -- there is no corpus- or config-dependent identity to
+    switch, and nothing today ever resets it, so once built it holds the
+    one instance that will ever exist for the process's life. The #57
+    read race (validate one value, return another) has nothing to attach
+    to here. That reasoning is conditional on there staying no
+    invalidation path: a future GPU-release routine that swaps this slot
+    back to ``None`` to free VRAM would reopen the window, and the
+    ``(key, value)`` tuple trick used above would not close it here --
+    returning a locally-captured reference cannot stop a concurrent
+    ``close()`` on the very object it points to. That would need an
+    ownership rule (e.g. refcounting callers, or not invalidating the
+    slot until nothing still holds it), not just an atomic-looking read.
     """
     if _embedder_cache["embedder"] is None:
         with _embedder_cache_lock:
@@ -220,10 +238,12 @@ def lexical_index(store: VectorStore, config: AppConfig) -> Bm25LexicalIndex:
     concurrent callers racing the same new key build only one index (#46).
 
     The key and the index live in one ``(key, index)`` tuple under a single
-    dict slot instead of two separate slots, so the check and the value a
-    caller ultimately returns come from the same atomic read rather than
-    two -- see ``vector_store`` above for why the two-read version could
-    hand a caller an index that belongs to a BM25 retune racing it (#57).
+    dict slot instead of two separate slots, unpacked into this thread's
+    own locals in one subscript. The pair is immutable once read, so a
+    concurrent BM25 retune republishing the slot cannot alter the pair
+    this thread already has -- see ``vector_store`` above for the exact
+    reasoning, and for why the old two-slot cache could hand a caller an
+    index that belonged to a retune racing it (#57).
 
     Args:
         collection: Collection whose chunks form the BM25 corpus.
@@ -257,6 +277,11 @@ def reranker(config: AppConfig) -> CrossEncoderReranker:
     construct one, since each duplicate would separately load hundreds of
     megabytes of weights on first ``rerank()`` call, competing for the same
     GPU (#46).
+
+    Like ``embedder``, this slot is a singleton with no reset path today,
+    so the #57 read race does not apply -- see that function's docstring
+    for why, and for what adding an invalidation path here would require
+    instead of the tuple trick used by ``vector_store``/``lexical_index``.
 
     Args:
         config: Current pipeline configuration.

--- a/rag/engine/wiring.py
+++ b/rag/engine/wiring.py
@@ -68,7 +68,7 @@ def app_config_from_runtime() -> AppConfig:
     )
 
 
-_store_cache: Dict[str, Any] = {"key": None, "store": None}
+_store_cache: Dict[str, Any] = {"entry": (None, None)}
 _store_cache_lock = threading.Lock()
 _embedder_cache: Dict[str, Any] = {"embedder": None}
 _embedder_cache_lock = threading.Lock()
@@ -81,18 +81,35 @@ def vector_store(config: AppConfig) -> VectorStore:
     must not both open the same FAISS index, so the key check is repeated
     once the lock is held. The cheap, unlocked check outside the lock keeps
     the common case (cache already valid) lock-free.
+
+    The key and the store live in one ``(key, store)`` tuple under a single
+    dict slot, read with one subscript rather than two (#57). Under
+    CPython's GIL, a dict lookup by an immutable, C-hashable key -- our key
+    is a tuple of strings -- runs to completion without releasing the GIL,
+    so that single read is atomic: no other thread's write can be
+    interleaved partway through it. Two separate reads (key, then store)
+    would not have that guarantee -- a thread could validate the key,
+    lose the GIL to a concurrent corpus switch that republishes the slot,
+    and then read back a store belonging to the *new* key. The result
+    would look like a normal answer while silently citing the wrong
+    corpus, with nothing to log or raise. Splitting the read into "check"
+    and "return" of a local variable, rather than reading the dict twice,
+    closes the window entirely instead of narrowing it.
     """
     key = (config.paths.path_db, config.paths.collection_name)
-    if _store_cache["key"] != key:
+    cached_key, store = _store_cache["entry"]
+    if cached_key != key:
         with _store_cache_lock:
-            if _store_cache["key"] != key:
-                _store_cache.update(key=key, store=build_vector_store(config))
-    return _store_cache["store"]
+            cached_key, store = _store_cache["entry"]
+            if cached_key != key:
+                store = build_vector_store(config)
+                _store_cache["entry"] = (key, store)
+    return store
 
 
 def reset_vector_store_cache() -> None:
     with _store_cache_lock:
-        _store_cache.update(key=None, store=None)
+        _store_cache["entry"] = (None, None)
 
 
 def embedder(config: AppConfig):
@@ -185,7 +202,7 @@ def query_decomposer(config: AppConfig) -> OllamaChatModel:
 # Expensive, reusable components keyed by what would invalidate them. Held at
 # module level because the interfaces call the pipeline as free functions and
 # have nowhere else to keep them for the life of the process.
-_lexical_cache: Dict[str, Any] = {"key": None, "index": None}
+_lexical_cache: Dict[str, Any] = {"entry": (None, None)}
 _lexical_cache_lock = threading.Lock()
 _reranker_cache: Dict[str, Any] = {"reranker": None}
 _reranker_cache_lock = threading.Lock()
@@ -202,6 +219,12 @@ def lexical_index(store: VectorStore, config: AppConfig) -> Bm25LexicalIndex:
     Double-checked locking: the key is re-read once the lock is held so two
     concurrent callers racing the same new key build only one index (#46).
 
+    The key and the index live in one ``(key, index)`` tuple under a single
+    dict slot instead of two separate slots, so the check and the value a
+    caller ultimately returns come from the same atomic read rather than
+    two -- see ``vector_store`` above for why the two-read version could
+    hand a caller an index that belongs to a BM25 retune racing it (#57).
+
     Args:
         collection: Collection whose chunks form the BM25 corpus.
         config: Current config; the BM25 parameters are read from it.
@@ -213,13 +236,14 @@ def lexical_index(store: VectorStore, config: AppConfig) -> Bm25LexicalIndex:
     # unnamed collections (test doubles, typically) never share a cache entry.
     key = (id(store), config.retrieval.bm25_k1, config.retrieval.bm25_b)
 
-    if _lexical_cache["key"] != key:
+    cached_key, index = _lexical_cache["entry"]
+    if cached_key != key:
         with _lexical_cache_lock:
-            if _lexical_cache["key"] != key:
-                _lexical_cache.update(
-                    key=key, index=Bm25LexicalIndex(store, config.retrieval)
-                )
-    return _lexical_cache["index"]
+            cached_key, index = _lexical_cache["entry"]
+            if cached_key != key:
+                index = Bm25LexicalIndex(store, config.retrieval)
+                _lexical_cache["entry"] = (key, index)
+    return index
 
 
 def reranker(config: AppConfig) -> CrossEncoderReranker:

--- a/tests/unit/test_wiring_cache_concurrency.py
+++ b/tests/unit/test_wiring_cache_concurrency.py
@@ -93,13 +93,13 @@ def _race_two_callers(target, args, builder):
 def _reset_wiring_caches():
     """Isolate each test from cache state left by others in the same process."""
     wiring._embedder_cache.update(embedder=None)
-    wiring._store_cache.update(key=None, store=None)
-    wiring._lexical_cache.update(key=None, index=None)
+    wiring._store_cache.update(entry=(None, None))
+    wiring._lexical_cache.update(entry=(None, None))
     wiring._reranker_cache.update(reranker=None)
     yield
     wiring._embedder_cache.update(embedder=None)
-    wiring._store_cache.update(key=None, store=None)
-    wiring._lexical_cache.update(key=None, index=None)
+    wiring._store_cache.update(entry=(None, None))
+    wiring._lexical_cache.update(entry=(None, None))
     wiring._reranker_cache.update(reranker=None)
 
 

--- a/tests/unit/test_wiring_cache_read_race.py
+++ b/tests/unit/test_wiring_cache_read_race.py
@@ -1,0 +1,217 @@
+"""Regression tests for the cache-read race in rag/engine/wiring.py (#57).
+
+PR #53 put double-checked locking around the check-then-*build* half of
+``vector_store``/``lexical_index``, so two concurrent first callers can no
+longer both construct the cached object. But the *read* that follows a
+cache hit was left outside any lock: the key comparison and the value
+fetch are two separate dict lookups, so a thread can validate its own key,
+lose the CPU, have a second thread republish the cache slot under a
+*different* key, and then hand back the wrong key's value on resume.
+
+For ``vector_store`` this means a query answered against one corpus can be
+served the FAISS store of whatever corpus a concurrent
+``POST /api/stores/select`` (or BM25 retune, for ``lexical_index``) just
+switched to -- a well-formed answer sourced from the wrong documents, with
+no error and no log line.
+
+``PausingDict`` below forces this interleaving deterministically without
+assuming which internal keys wiring.py's cache reads: it pauses a chosen
+thread the first time it subscripts the dict (whatever key that read
+happens to be), after the value has already been fetched but before
+control returns to the caller. That reproduces the exact race regardless
+of whether the cache stores a key and a value as two separate slots or as
+one atomically-read tuple, so the same test is valid both before and after
+the fix.
+"""
+
+import os
+import sys
+import threading
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import pytest
+
+import rag.chat_pdfs  # noqa: F401 -- import before rag.engine.wiring, see its module docstring
+from monkeygrab.config.app_config import AppConfig
+from monkeygrab.config.paths import RAG_BASE_DIR
+from rag.engine import wiring
+
+
+class PausingDict(dict):
+    """Dict whose chosen thread pauses mid-lookup on its first subscript read.
+
+    The value is fetched from the underlying storage (mirroring exactly
+    what a real, uninstrumented read would already have captured) and only
+    then does the thread block on ``resume_event`` -- so a second thread is
+    free to overwrite this dict's contents before the first thread resumes
+    and finishes using the value it already fetched.
+    """
+
+    def __init__(self, *args, thread_name, ready_event, resume_event, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._thread_name = thread_name
+        self._ready_event = ready_event
+        self._resume_event = resume_event
+        self._paused = False
+
+    def __getitem__(self, item):
+        value = super().__getitem__(item)
+        if not self._paused and threading.current_thread().name == self._thread_name:
+            self._paused = True
+            self._ready_event.set()
+            assert self._resume_event.wait(timeout=5), "test never resumed the paused thread"
+        return value
+
+
+@pytest.fixture(autouse=True)
+def _isolate_wiring_caches():
+    """Snapshot/restore the module-level caches around each test.
+
+    A plain content copy rather than a hardcoded shape, so this keeps
+    working whether a cache is two separate key/value slots or a single
+    atomically-read tuple slot (see #57).
+    """
+    store_snapshot = dict(wiring._store_cache)
+    lexical_snapshot = dict(wiring._lexical_cache)
+    yield
+    wiring._store_cache.clear()
+    wiring._store_cache.update(store_snapshot)
+    wiring._lexical_cache.clear()
+    wiring._lexical_cache.update(lexical_snapshot)
+
+
+def test_vector_store_read_does_not_return_a_different_keys_store(monkeypatch):
+    """T1 validates the 'en' store is still cached, then a corpus switch to
+    'es' republishes the slot before T1's own read finishes -- T1 must get
+    back the 'en' store it checked for, never the 'es' store T2 published.
+    """
+    store_en = object()
+    store_es = object()
+    config_en = AppConfig()
+    config_es = config_en.with_overrides(
+        **{"paths.docs_folder": os.path.join(RAG_BASE_DIR, "docs", "es")}
+    )
+
+    # Warm the cache through the public API so priming matches whatever
+    # internal shape wiring.py currently uses -- the test does not assume it.
+    monkeypatch.setattr(wiring, "build_vector_store", lambda cfg: store_en)
+    wiring.vector_store(config_en)
+
+    ready = threading.Event()
+    resume = threading.Event()
+    paused = PausingDict(
+        wiring._store_cache, thread_name="T1", ready_event=ready, resume_event=resume
+    )
+    monkeypatch.setattr(wiring, "_store_cache", paused)
+
+    result = {}
+    t1 = threading.Thread(
+        target=lambda: result.__setitem__("t1", wiring.vector_store(config_en)), name="T1"
+    )
+    t1.start()
+    assert ready.wait(timeout=5), "T1 never reached its cache read"
+
+    # T2 switches the active store to 'es' while T1 is paused mid-read.
+    monkeypatch.setattr(wiring, "build_vector_store", lambda cfg: store_es)
+    t2 = threading.Thread(target=wiring.vector_store, args=(config_es,), name="T2")
+    t2.start()
+    t2.join(timeout=5)
+    assert not t2.is_alive(), "T2 never completed the corpus switch"
+
+    resume.set()
+    t1.join(timeout=5)
+    assert not t1.is_alive(), "T1 hung after resuming"
+
+    assert result["t1"] is store_en, (
+        "T1 asked for the 'en' store but got back the 'es' store T2 "
+        "published after T1's own key check -- wrong-corpus answer (#57)"
+    )
+
+
+def test_lexical_index_read_does_not_return_a_different_keys_index(monkeypatch):
+    """Same race for the BM25 cache: T1's collection check must not be
+    answered with the index a concurrent BM25 retune just published.
+    """
+    store_a = object()
+    store_b = object()
+    index_a = object()
+    index_b = object()
+    config = AppConfig()
+
+    monkeypatch.setattr(wiring, "Bm25LexicalIndex", lambda store, retrieval: index_a)
+    wiring.lexical_index(store_a, config)
+
+    ready = threading.Event()
+    resume = threading.Event()
+    paused = PausingDict(
+        wiring._lexical_cache, thread_name="T1", ready_event=ready, resume_event=resume
+    )
+    monkeypatch.setattr(wiring, "_lexical_cache", paused)
+
+    result = {}
+    t1 = threading.Thread(
+        target=lambda: result.__setitem__("t1", wiring.lexical_index(store_a, config)),
+        name="T1",
+    )
+    t1.start()
+    assert ready.wait(timeout=5), "T1 never reached its cache read"
+
+    # T2 retunes BM25 for a different collection while T1 is paused mid-read.
+    monkeypatch.setattr(wiring, "Bm25LexicalIndex", lambda store, retrieval: index_b)
+    t2 = threading.Thread(target=wiring.lexical_index, args=(store_b, config), name="T2")
+    t2.start()
+    t2.join(timeout=5)
+    assert not t2.is_alive(), "T2 never completed the retune"
+
+    resume.set()
+    t1.join(timeout=5)
+    assert not t1.is_alive(), "T1 hung after resuming"
+
+    assert result["t1"] is index_a, (
+        "T1 asked for store_a's lexical index but got back store_b's index "
+        "that T2 published after T1's own key check (#57)"
+    )
+
+
+def test_reset_during_in_flight_build_serializes_on_the_lock(monkeypatch):
+    """Coverage gap noted in #57: reset_vector_store_cache() shares
+    _store_cache_lock with vector_store(), so a reset racing an in-flight
+    build cannot observe (or interleave with) a half-published slot -- it
+    runs entirely before the build starts or entirely after it publishes.
+    Started once the build is already in progress, it must run after
+    publication and leave the cache empty.
+    """
+    calls = {"count": 0}
+    release = threading.Event()
+
+    def blocking_build(config):
+        calls["count"] += 1
+        release.wait(timeout=5)
+        return object()
+
+    monkeypatch.setattr(wiring, "build_vector_store", blocking_build)
+    config = AppConfig()
+
+    t_build = threading.Thread(target=wiring.vector_store, args=(config,))
+    t_build.start()
+
+    deadline = time.time() + 5
+    while calls["count"] < 1 and time.time() < deadline:
+        time.sleep(0.001)
+    assert calls["count"] == 1, "builder never entered construction"
+
+    t_reset = threading.Thread(target=wiring.reset_vector_store_cache)
+    t_reset.start()
+
+    release.set()
+    t_build.join(timeout=5)
+    t_reset.join(timeout=5)
+    assert not t_build.is_alive() and not t_reset.is_alive(), "a thread hung"
+
+    cached_key, cached_store = wiring._store_cache["entry"]
+    assert cached_key is None and cached_store is None


### PR DESCRIPTION
## Summary

PR #53 locked the check-then-*build* half of `vector_store()`/`lexical_index()` in `rag/engine/wiring.py`, so two concurrent first callers can no longer both construct the cached object. It left the **read** that follows a cache hit unlocked: the key comparison and the value fetch were two separate dict lookups, so a thread could validate its own key, get preempted, have a second thread republish the cache slot under a *different* key (a corpus switch via `POST /api/stores/select`, or a BM25 retune from the control panel), and then hand back a value belonging to that other key on resume.

Unlike #46's duplicate-construction race, this doesn't crash or waste VRAM — it returns a well-formed answer retrieved from the wrong corpus, with nothing to log or raise.

## Fix

Store the key and the value as one `(key, value)` tuple under a single dict slot, read with one subscript instead of two, and use the unpacked local variable for the eventual `return` instead of reading the dict a second time. This is the issue's preferred option: it removes the window entirely rather than serializing around it, and the hot path stays lock-free.

Correctness does not rest on that subscript being atomic — on CPython 3.13.5 it compiles to a dict lookup followed by a separate tuple unpack, so a thread switch can land between them. What makes it safe is that the subscript returns an *immutable* `(key, value)` pair that only this thread's own locals hold from then on: a concurrent republish swaps which pair lives in the slot next, but cannot reach into the pair this thread already read and change it. That property holds independent of the GIL, including under a free-threaded build.

`reset_vector_store_cache()` already held the lock — only the slot-shape update was needed there.

`_embedder_cache` and `_reranker_cache` were checked and left untouched: they are unkeyed singletons with no republish path (no reset function ever invalidates them today), so their two-read pattern can only ever return the one object that was ever built — no wrong-object window to close. That reasoning is conditional on there staying no invalidation path: if one is ever added (e.g. a GPU-release routine that swaps a slot back to `None`), the same race reopens, and the tuple trick used here would not be enough to close it — a locally-captured reference can't stop a concurrent `close()` on the object it points to. That direction needs an ownership rule, not just an atomic-looking read. (A prior draft of such a routine, #70, has since been closed, so there's no open conflict today.)

## Testing

- Added `tests/unit/test_wiring_cache_read_race.py`: two regression tests force the exact interleaving deterministically via a `PausingDict` that pauses a chosen thread's *first* cache read (whatever key it happens to read) after the value is fetched but before control returns to the caller — giving a second thread a real window to swap the cache contents first. This works unchanged against both the old two-slot cache and the new single-tuple slot, so the same test demonstrates the bug before the fix and its absence after. A third test closes the coverage gap the review flagged — `reset_vector_store_cache()` racing an in-flight build — but is written against the new slot shape and isn't a pre-fix demonstration: run against `origin/main`'s `wiring.py` it fails with `KeyError: 'entry'` (a fixture-shape mismatch), not the wrong-object assertion the other two produce.
- Updated `tests/unit/test_wiring_cache_concurrency.py` (PR #53's tests) for the new cache slot shape — no behavioral changes to those tests.
- Full suite: 542 passed / 1 skipped on `origin/main` baseline → 545 passed / 1 skipped after (the 3 new tests, no regressions).
- `ruff check .`: clean.

## Test plan

- [x] The two race-interleaving regression tests fail against pre-fix code with the wrong-object assertion, pass against post-fix code
- [x] Existing `tests/unit/test_wiring_cache_concurrency.py` (#46) still green
- [x] Full suite green, no `tests/characterization/` changes
- [x] `ruff check .` clean

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)
