### PR TITLE
Pre-serialize FAISS sidecar rows instead of re-dumping them every add

### DIFF
--- a/src/monkeygrab/adapters/vectorstore/faiss_store.py
+++ b/src/monkeygrab/adapters/vectorstore/faiss_store.py
@@ -28,17 +28,22 @@ class _Row(NamedTuple):
 
     ``line`` is cached here, not recomputed from ``doc``/``metadata`` on every
     write, because re-running ``json.dumps`` over every previously stored row
-    on every ``add`` is exactly the redundant cost issue #55 measured (~90%
-    of the sidecar's write time). Caching it on the row itself rather than in
-    a side list keyed by position makes staleness structurally impossible
-    instead of a convention to maintain: a ``_Row`` is only ever constructed
-    once, at the single point where a chunk is either freshly added
-    (``add``, which serializes it) or loaded from disk (``_load_or_init``,
-    which keeps the exact bytes already on disk instead of re-serializing
-    them). Nothing ever mutates a field in place or rebuilds ``line`` from
-    the other three after the fact, so ``line`` and (``chunk_id``, ``doc``,
-    ``metadata``) can never drift apart -- there is no code path that could
-    change one without the other.
+    on every ``add`` was the redundant cost issue #55 measured. Caching it on
+    the row itself, set once at construction and never rebuilt in place, means
+    ``line`` always decodes to a row that reproduces these fields -- but that
+    is not the same as "``line`` equals ``_serialize_row(chunk_id, doc,
+    metadata)``". For a row loaded from a legacy file (``_load_or_init``
+    caches the on-disk bytes verbatim; ``_metadata_from_dict`` fills in
+    defaults for keys that row never had), those two can legitimately differ
+    while still describing the same content. One side effect worth knowing:
+    the sidecar no longer self-normalizes a legacy row to the current key set
+    on rewrite -- ``_FORMAT_VERSION`` is the only lever left for that.
+
+    Trade-off: carrying ``line`` roughly doubles ``self._rows``'s resident
+    memory over a version without it (single-digit MB at the corpus sizes
+    this product plausibly sees), and ``_write_meta_file`` now builds the
+    whole sidecar as one string before writing it, so its peak memory is the
+    full file rather than one line at a time.
     """
 
     chunk_id: str
@@ -290,7 +295,7 @@ class FaissVectorStore:
         self._fingerprint_path = os.path.join(self._dir, _FINGERPRINT_FILENAME)
 
         self._index, self._rows = _load_or_init(self._dir)
-        self._id_to_pos: Dict[str, int] = {row[0]: i for i, row in enumerate(self._rows)}
+        self._id_to_pos: Dict[str, int] = {row.chunk_id: i for i, row in enumerate(self._rows)}
 
     def add(self, chunk: Chunk, embedding: Sequence[float]) -> None:
         if chunk.id in self._id_to_pos:
@@ -310,14 +315,17 @@ class FaissVectorStore:
             )
 
         faiss.normalize_L2(vector)
-        self._index.add(vector)
-        position = len(self._rows)
+        # Serialize before mutating the index: if this ever raised, an index
+        # already grown by one with no matching row would be a desync that
+        # _load_or_init's count check rejects forever on the next reopen.
         row = _Row(
             chunk_id=chunk.id,
             doc=chunk.text,
             metadata=chunk.metadata,
             line=_serialize_row(chunk.id, chunk.text, chunk.metadata),
         )
+        self._index.add(vector)
+        position = len(self._rows)
         self._rows.append(row)
         self._id_to_pos[chunk.id] = position
         self._save()
@@ -340,7 +348,7 @@ class FaissVectorStore:
         k = self._index.ntotal
         scores, positions = self._index.search(vector, k)
         candidates = [
-            (float(scores[0][j]), self._rows[positions[0][j]][0], int(positions[0][j]))
+            (float(scores[0][j]), self._rows[positions[0][j]].chunk_id, int(positions[0][j]))
             for j in range(k)
         ]
         candidates.sort(key=lambda c: (-c[0], c[1]))
@@ -432,7 +440,7 @@ class FaissVectorStore:
         else:
             self._index = None
         self._rows = kept_rows
-        self._id_to_pos = {row[0]: i for i, row in enumerate(self._rows)}
+        self._id_to_pos = {row.chunk_id: i for i, row in enumerate(self._rows)}
         self._rewrite()
         return removed
 

--- a/src/monkeygrab/adapters/vectorstore/faiss_store.py
+++ b/src/monkeygrab/adapters/vectorstore/faiss_store.py
@@ -2,7 +2,7 @@
 
 import json
 import os
-from typing import Any, Dict, List, Optional, Sequence, Tuple
+from typing import Any, Dict, List, NamedTuple, Optional, Sequence, Tuple
 
 import faiss
 import numpy as np
@@ -16,11 +16,35 @@ from monkeygrab.domain.fragment import Fragment
 # conformance here is structural (duck typing), the same contract every other
 # adapter in this package satisfies without inheriting its port.
 
-# A row kept in memory per stored chunk: (id, doc text, metadata). Position in
-# this list is always the FAISS vector's position in the index -- both grow by
-# one, together, on every add() -- so no separate id<->position table needs
-# its own persistence; it is rebuilt from this list on load (see SECTION 3).
-_Row = Tuple[str, str, ChunkMetadata]
+
+class _Row(NamedTuple):
+    """One stored chunk: id, doc text, metadata, plus its pre-serialized
+    ``meta.jsonl`` line (including the trailing newline).
+
+    Position in the owning list is always the FAISS vector's position in the
+    index -- both grow by one, together, on every add() -- so no separate
+    id<->position table needs its own persistence; it is rebuilt from this
+    list on load (see ``_load_or_init``).
+
+    ``line`` is cached here, not recomputed from ``doc``/``metadata`` on every
+    write, because re-running ``json.dumps`` over every previously stored row
+    on every ``add`` is exactly the redundant cost issue #55 measured (~90%
+    of the sidecar's write time). Caching it on the row itself rather than in
+    a side list keyed by position makes staleness structurally impossible
+    instead of a convention to maintain: a ``_Row`` is only ever constructed
+    once, at the single point where a chunk is either freshly added
+    (``add``, which serializes it) or loaded from disk (``_load_or_init``,
+    which keeps the exact bytes already on disk instead of re-serializing
+    them). Nothing ever mutates a field in place or rebuilds ``line`` from
+    the other three after the fact, so ``line`` and (``chunk_id``, ``doc``,
+    ``metadata``) can never drift apart -- there is no code path that could
+    change one without the other.
+    """
+
+    chunk_id: str
+    doc: str
+    metadata: ChunkMetadata
+    line: str
 
 
 # PERSISTENCE FORMAT
@@ -74,21 +98,40 @@ def _metadata_from_dict(meta: Dict[str, Any]) -> ChunkMetadata:
     )
 
 
+def _serialize_row(chunk_id: str, doc: str, metadata: ChunkMetadata) -> str:
+    """Build the on-disk JSONL line for one row, including its trailing newline.
+
+    ``ensure_ascii=False``: the default (``True``) escapes every non-ASCII
+    character (e.g. accented Castilian/Valencian text) to a ``\\uXXXX``
+    sequence, which roughly doubles the sidecar's size on those corpora for
+    no benefit -- ``json.loads`` parses both forms identically, so this is
+    safe on the read path. It only changes bytes written from here forward:
+    rows already on disk keep whatever form they were written in (see
+    ``_load_or_init``, which caches the original line instead of
+    re-serializing it), so one file can legitimately hold a mix of both --
+    each line is decoded independently, and the index fingerprint
+    (``monkeygrab.application.index_fingerprint.index_recipe``) never reads
+    ``meta.jsonl`` content, so this has no effect on fingerprint comparability
+    either.
+    """
+    return json.dumps(
+        {"id": chunk_id, "doc": doc, "metadata": _metadata_to_dict(metadata)},
+        ensure_ascii=False,
+    ) + "\n"
+
+
 def _write_meta_file(path: str, rows: List[_Row]) -> None:
     """Write every row in ``rows`` to ``path`` as JSONL, one object per line.
 
     Shared by ``_save`` and ``_rewrite``: both stage a full sidecar snapshot
     to a temp path before any ``os.replace``, rather than mutating
-    ``meta.jsonl`` in place.
+    ``meta.jsonl`` in place. Each row's line is already serialized (see
+    ``_Row``), so this is one string join and one write -- no per-row
+    ``json.dumps`` on rows that were already serialized on an earlier
+    ``add`` (issue #55).
     """
     with open(path, "w", encoding="utf-8") as f:
-        for chunk_id, doc, metadata in rows:
-            f.write(json.dumps({
-                "id": chunk_id,
-                "doc": doc,
-                "metadata": _metadata_to_dict(metadata),
-            }))
-            f.write("\n")
+        f.write("".join(row.line for row in rows))
 
 
 # DISK I/O
@@ -144,11 +187,21 @@ def _load_or_init(store_dir: str) -> Tuple[Optional["faiss.Index"], List[_Row]]:
     try:
         with open(meta_path, "r", encoding="utf-8") as f:
             for line in f:
-                line = line.strip()
-                if not line:
+                stripped = line.strip()
+                if not stripped:
                     continue
-                row = json.loads(line)
-                rows.append((row["id"], row["doc"], _metadata_from_dict(row["metadata"])))
+                row = json.loads(stripped)
+                # Cache the exact line already on disk rather than
+                # re-serializing the parsed dict: cheaper (no json.dumps for
+                # rows nothing has changed about), and it preserves whatever
+                # ensure_ascii form this row was originally written in --
+                # see _serialize_row's docstring.
+                rows.append(_Row(
+                    chunk_id=row["id"],
+                    doc=row["doc"],
+                    metadata=_metadata_from_dict(row["metadata"]),
+                    line=stripped + "\n",
+                ))
     except (json.JSONDecodeError, KeyError) as e:
         raise _corrupt(store_dir, f"{_META_FILENAME} could not be parsed: {e}") from e
 
@@ -259,7 +312,12 @@ class FaissVectorStore:
         faiss.normalize_L2(vector)
         self._index.add(vector)
         position = len(self._rows)
-        row: _Row = (chunk.id, chunk.text, chunk.metadata)
+        row = _Row(
+            chunk_id=chunk.id,
+            doc=chunk.text,
+            metadata=chunk.metadata,
+            line=_serialize_row(chunk.id, chunk.text, chunk.metadata),
+        )
         self._rows.append(row)
         self._id_to_pos[chunk.id] = position
         self._save()
@@ -289,12 +347,12 @@ class FaissVectorStore:
 
         fragments = []
         for score, _chunk_id, position in candidates[:n_results]:
-            _, doc, metadata = self._rows[position]
+            row = self._rows[position]
             # Cosine distance (1 - cosine similarity) on the normalized
             # vectors this store indexes -- not a literal L2 magnitude like
             # "Smaller is nearer", matching the Fragment.distancia contract; ordering is
             # what downstream ranking (RRF, min/max/mean debug stats) uses.
-            fragments.append(Fragment(doc=doc, metadata=metadata, distancia=1.0 - score))
+            fragments.append(Fragment(doc=row.doc, metadata=row.metadata, distancia=1.0 - score))
         return fragments
 
     def get_by_ids(self, ids: Sequence[str]) -> List[Fragment]:
@@ -303,13 +361,13 @@ class FaissVectorStore:
             position = self._id_to_pos.get(chunk_id)
             if position is None:
                 continue
-            _, doc, metadata = self._rows[position]
-            fragments.append(Fragment(doc=doc, metadata=metadata))
+            row = self._rows[position]
+            fragments.append(Fragment(doc=row.doc, metadata=row.metadata))
         return fragments
 
     def get_page(self, limit: Optional[int], offset: int) -> List[Fragment]:
         rows = self._rows[offset:] if limit is None else self._rows[offset : offset + limit]
-        return [Fragment(doc=doc, metadata=metadata) for _, doc, metadata in rows]
+        return [Fragment(doc=row.doc, metadata=row.metadata) for row in rows]
 
     def count(self) -> int:
         return len(self._rows)
@@ -358,8 +416,8 @@ class FaissVectorStore:
     def delete_source(self, source: str) -> int:
         positions = [
             position
-            for position, (_, _, metadata) in enumerate(self._rows)
-            if metadata.source != source
+            for position, row in enumerate(self._rows)
+            if row.metadata.source != source
         ]
         removed = len(self._rows) - len(positions)
         if removed == 0:

--- a/tests/unit/adapters/test_faiss_store.py
+++ b/tests/unit/adapters/test_faiss_store.py
@@ -5,6 +5,7 @@ exception is test_add_hard_fails_when_persistence_write_fails, which injects
 a write failure that cannot be reliably reproduced with a real disk.
 """
 
+import json
 import math
 import os
 import sys
@@ -129,6 +130,65 @@ def test_persists_to_disk_and_reopening_matches(tmp_path):
     assert reopened.count() == store.count() == 2
     assert reopened.get_page(limit=None, offset=0) == store.get_page(limit=None, offset=0)
     assert reopened.query(_unit([1.0, 0.0]), n_results=1) == store.query(_unit([1.0, 0.0]), n_results=1)
+
+
+def test_accented_text_and_non_ascii_filename_round_trip_without_escapes(tmp_path):
+    """Regression test for #55/#75: rows are now serialized with
+    ensure_ascii=False, so accented text is written as raw UTF-8 rather than
+    \\uXXXX escapes. A plain field-equality check would pass either way
+    (json.loads parses both forms identically) -- the point of this test is
+    inspecting the actual bytes on disk, not just what comes back out."""
+    paths = _paths(tmp_path, "accented")
+    store = FaissVectorStore(paths)
+    chunk = _chunk(
+        "informe_técnico_año_2026.pdf", 0, 0, "Texto con áéíóúñ y ¿preguntas?"
+    )
+    store.add(chunk, _unit([1.0, 0.0]))
+
+    meta_path = Path(paths.path_db) / paths.collection_name / "meta.jsonl"
+    raw = meta_path.read_text(encoding="utf-8")
+    assert "\\u" not in raw
+    assert "informe_técnico_año_2026.pdf" in raw
+    assert "áéíóúñ" in raw
+
+    reopened = FaissVectorStore(paths)
+    fragment = reopened.get_by_ids([chunk.id])[0]
+    assert fragment.doc == "Texto con áéíóúñ y ¿preguntas?"
+    assert fragment.metadata.source == "informe_técnico_año_2026.pdf"
+
+
+def test_reopening_a_legacy_ascii_escaped_sidecar_alongside_a_new_utf8_row(tmp_path):
+    """Every store already on a user's disk was written pre-#75, with every
+    row \\uXXXX-escaped (ensure_ascii=True). This simulates reopening one:
+    a legacy line is rewritten into its escaped form by hand, a new chunk is
+    then added through the normal API (raw UTF-8, per #75), and both lines
+    must still decode to identical text -- the mixed-encoding file the
+    ensure_ascii=False decision explicitly allows, since _load_or_init caches
+    each row's on-disk bytes verbatim instead of re-encoding them."""
+    paths = _paths(tmp_path, "legacy")
+    store = FaissVectorStore(paths)
+    legacy_chunk = _chunk("legacy.pdf", 0, 0, "café con leche")
+    store.add(legacy_chunk, _unit([1.0, 0.0]))
+
+    meta_path = Path(paths.path_db) / paths.collection_name / "meta.jsonl"
+    row = json.loads(meta_path.read_text(encoding="utf-8"))
+    legacy_line = json.dumps(row, ensure_ascii=True) + "\n"
+    assert "\\u" in legacy_line  # sanity: café's accent actually gets escaped
+    meta_path.write_text(legacy_line, encoding="utf-8")
+
+    reopened = FaissVectorStore(paths)
+    new_chunk = _chunk("new.pdf", 0, 0, "nouvelle ligne UTF-8 : 日本語")
+    reopened.add(new_chunk, _unit([0.0, 1.0]))
+
+    lines = [line for line in meta_path.read_text(encoding="utf-8").splitlines() if line]
+    assert len(lines) == 2
+    assert "\\u" in lines[0]  # legacy row untouched -- still escaped
+    assert "\\u" not in lines[1]  # freshly added row -- raw UTF-8
+
+    healed = FaissVectorStore(paths)
+    fragments = {f.id: f for f in healed.get_by_ids([legacy_chunk.id, new_chunk.id])}
+    assert fragments[legacy_chunk.id].doc == "café con leche"
+    assert fragments[new_chunk.id].doc == "nouvelle ligne UTF-8 : 日本語"
 
 
 def test_version_mismatch_hard_fails_on_reopen(tmp_path):


### PR DESCRIPTION
## Summary

#52's atomicity fix (staging `index.faiss`/`meta.jsonl`/`version.txt` to temp paths before any `os.replace`) is correct and stays untouched by this PR. Its measured side effect, tracked as #55: `_save`/`_rewrite` now rewrite `meta.jsonl` in full on every `add`, and the rewrite re-ran `json.dumps` over every row already stored on an earlier `add`, not just the new one.

`_Row` now carries its own pre-serialized JSONL line alongside `(chunk_id, doc, metadata)`, built once at the single point a row is created — `add()` serializes a freshly added chunk before touching the index (so a serialization failure can't desync `index.ntotal` from `len(self._rows)`), `_load_or_init` caches the exact bytes already on disk instead of re-encoding them. `_write_meta_file` becomes a single `"".join(row.line for row in rows)` plus one `write()` call.

A second, independent change: newly serialized rows now use `ensure_ascii=False`, avoiding `\uXXXX`-escaping of accented Castilian/Valencian text. Rows already on disk are never re-encoded — they're cached as their original bytes — so one store's `meta.jsonl` can legitimately hold both forms. Safe because `json.loads` parses each line independently regardless of which form it used, and `monkeygrab.application.index_fingerprint.index_recipe` never reads `meta.jsonl` content, so this has no effect on fingerprint comparability.

## Measured (this machine, Windows/NTFS, dim 512, ~2200-char chunks, summed over a synthetic indexing run)

| n | sidecar rewrite, before | sidecar rewrite, after (combined) |
|---|---|---|
| 884 | 20.3-20.7s | 6.9-7.9s (~2.7-3.0x) |
| 3000 | 230.1s | 73.9s (~3.1x) |

**Correction from an earlier revision of this PR:** isolating the pre-serialization change alone (holding `ensure_ascii=True` constant) measures 20.3s -> 6.65s at n=884 — statistically the same as the combined 6.9-7.9s above. `ensure_ascii=False`'s own contribution to wall time is roughly 3%, inside run-to-run noise. An Opus review of this PR independently reproduced the win (2.70x at n=884, 2.85x at n=3000) and decomposed it further: with the encoding held constant, `json.dumps` was ~62% of the old per-add cost and the whole-file write is the other ~38% — that floor is what caps the combined win at ~2.7-3x, not the ~7.9x originally estimated in #55 (its "~90% redundant" was too high). `ensure_ascii=False`'s real, measured payoff is file size, not speed: 4834.5 KiB -> 2637.7 KiB at n=884.

`faiss.write_index` summed over the same 884 adds is ~1s, so post-fix the sidecar goes from ~12x the index write to ~4x — still real, still worth having, at a size the desktop app's uncapped per-document indexing can reach.

## Why the atomicity property is unchanged

`_save`/`_rewrite` still stage all three files to temp paths before any `os.replace`, in the same order, with the same `OSError` handling — only what `_write_meta_file` does *internally* changed (pre-serialized join instead of a per-row `json.dumps` loop). `tests/unit/adapters/test_faiss_store.py::test_reopening_after_sidecar_write_failure_loads_consistently` (the #52 regression test, including its third-`add` recovery assertion) passes **unmodified**, along with the rest of `test_faiss_store*.py`.

## Addressed in review

- **Test gap (the real finding):** neither FAISS store test file exercised non-ASCII content, so `ensure_ascii=False` had zero coverage — a silently-dropped `encoding="utf-8"` on `_write_meta_file`'s `open()` would have broken every accented corpus on Windows/cp1252 while the full suite stayed green. Added `test_accented_text_and_non_ascii_filename_round_trip_without_escapes` (asserts no `\u` escapes in the actual bytes on disk, not just that fields round-trip) and `test_reopening_a_legacy_ascii_escaped_sidecar_alongside_a_new_utf8_row` (a pre-#75 escaped row plus a freshly added raw-UTF-8 row, both surviving reopen). Both verified to actually fail when the behavior they target is reverted.
- `add()` now serializes the row (`_serialize_row`, which runs `json.dumps`) *before* `self._index.add(vector)`, not after — closes a window where a serialization failure could leave the index one vector ahead of `self._rows`, which `_load_or_init`'s count check would then reject forever on the next open.
- Replaced the three remaining positional `_Row` accesses (`row[0]`, `self._rows[...][0]`) with `.chunk_id` — the exact pattern that made the old 3-tuple brittle.
- Tightened `_Row`'s docstring: "line can never drift from the row's fields" overstated it for the legacy-load path (`_load_or_init` caches on-disk bytes verbatim while `_metadata_from_dict` fills in defaults for keys a legacy row never had, so `line` and `_serialize_row(...)` can legitimately differ while decoding to the same fields). Also now records that the sidecar no longer self-normalizes a legacy row's key set on rewrite, and the memory trade-off: `self._rows` roughly doubles in size for carrying the cached line, and `_write_meta_file`'s peak is the whole file as one string rather than one line at a time (negligible at any corpus size this product plausibly sees).

## Test plan

- [x] `tests/unit/adapters/test_faiss_store.py` + `test_faiss_store_fingerprint.py`: 29/29 pass (27 existing, unmodified, + 2 new)
- [x] Full suite (`pytest -q -p no:randomly`), rebased on current `origin/main`: 563 passed, 1 skipped, both before and after this change — no regressions
- [x] `ruff check .`: clean
- [x] No `tests/characterization/` test touched or broken

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)