### PR TITLE
Ship jina_clip_worker.py as PyInstaller data so the frozen worker can start

### DIFF
--- a/packaging/MonkeyGrab.spec
+++ b/packaging/MonkeyGrab.spec
@@ -43,6 +43,23 @@ if _SRC not in sys.path:
 hiddenimports += collect_submodules("rag")
 hiddenimports += collect_submodules("monkeygrab")
 
+# jina_clip_worker.py is never imported by the frozen app -- JinaClipEmbedder
+# launches it as a SCRIPT with the external .venv-mineru interpreter (see
+# src/monkeygrab/adapters/embedding/jina_clip_embedder.py). collect_submodules
+# above only bundles it as compiled bytecode inside the PYZ archive, which an
+# external interpreter cannot run as `python jina_clip_worker.py`. Ship it as
+# a literal data file at the same path it already has relative to its package
+# in the source tree (monkeygrab/adapters/embedding/), so JinaClipEmbedder's
+# existing Path(__file__).with_name("jina_clip_worker.py") lookup finds it
+# under sys._MEIPASS at runtime, exactly as it finds it beside the source
+# file in dev -- verified with a standalone PyInstaller onedir build that
+# __file__ for an archived module resolves to a real path mirroring the
+# source tree under sys._MEIPASS. No frozen/dev branch needed in the adapter,
+# same shape as composition._isolated_python() (#26).
+_worker_script = os.path.join(_SRC, "monkeygrab", "adapters", "embedding", "jina_clip_worker.py")
+if os.path.isfile(_worker_script):
+    datas.append((_worker_script, os.path.join("monkeygrab", "adapters", "embedding")))
+
 # --- Heavy third-party packages: collect data + binaries + submodules --------
 _collect = [
     "faiss", "sentence_transformers", "transformers", "tokenizers",

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -61,7 +61,10 @@ in source/dev runs the variable is unset and everything stays repo-relative.
   (one-time, needs internet) into the user cache.
 - A desktop bundle without `.venv-mineru` starts, but indexing and retrieval
   fail visibly because the fixed multimodal stack has no fallback.
-- The packaged build fails the same way even with `.venv-mineru` present:
-  the worker script never leaves the PyInstaller archive, so it cannot start
-  ([#26](https://github.com/iDiagoValeta/localOllamaRAG/issues/26)). Use the
-  CLI or web app until that is fixed.
+- `jina_clip_worker.py` ships as a PyInstaller data file (see the spec's
+  comment next to its `datas` entry), landing beside the frozen
+  `jina_clip_embedder` module under `_internal/`. `JinaClipEmbedder` resolves
+  it with the same `Path(__file__).with_name(...)` lookup it uses in a source
+  checkout, so no dev/frozen branch is needed — the two layouts mirror each
+  other by construction, the same way `_isolated_python()` already resolves
+  `.venv-mineru` in both ([#26](https://github.com/iDiagoValeta/localOllamaRAG/issues/26)).

--- a/src/monkeygrab/adapters/embedding/jina_clip_embedder.py
+++ b/src/monkeygrab/adapters/embedding/jina_clip_embedder.py
@@ -28,6 +28,7 @@ import math
 import os
 import queue
 import subprocess
+import sys
 import threading
 from pathlib import Path
 from typing import Dict, List, Optional
@@ -149,6 +150,18 @@ class JinaClipEmbedder:
         return self._process
 
     def _start_worker(self) -> None:
+        # Checked explicitly, before ever spawning the process: without this,
+        # a missing worker_script (e.g. packaging/MonkeyGrab.spec forgetting
+        # to ship it as a data file, see #26) surfaces as the *external*
+        # interpreter dying immediately with its own "can't open file"
+        # message on stderr -- technically diagnosable, but easy to miss
+        # since nothing about it names this adapter or the path it resolved.
+        if not os.path.isfile(self._worker_script):
+            raise RuntimeError(
+                f"jina-clip worker script not found at {self._worker_script!r} "
+                f"(frozen={getattr(sys, 'frozen', False)}); packaging/MonkeyGrab.spec "
+                "must ship jina_clip_worker.py as a data file next to this module"
+            )
         try:
             process = subprocess.Popen(
                 [self._python_executable, self._worker_script],

--- a/tests/unit/adapters/test_jina_clip_embedder.py
+++ b/tests/unit/adapters/test_jina_clip_embedder.py
@@ -143,6 +143,14 @@ def _make_popen(behavior=_echo_ok, *, startup_message="ready"):
 def _embedder(monkeypatch, behavior=_echo_ok, *, startup_message="ready", **kwargs):
     fake_popen, calls = _make_popen(behavior, startup_message=startup_message)
     monkeypatch.setattr(module.subprocess, "Popen", fake_popen)
+    # worker_script="fake-worker.py" never exists on disk -- these tests are
+    # about the wire protocol against a doubled Popen, not about the worker
+    # script existence check (see the dedicated tests for that), so the
+    # existence check is patched to pass by default. embed_image's own
+    # image-file existence check uses the same os.path.isfile and is
+    # re-patched by the individual tests that care about it, which override
+    # this default.
+    monkeypatch.setattr(module.os.path, "isfile", lambda path: True)
     embedder = JinaClipEmbedder("fake-python", worker_script="fake-worker.py", **kwargs)
     return embedder, calls
 
@@ -174,6 +182,37 @@ def test_worker_is_not_started_at_construction(monkeypatch):
     JinaClipEmbedder("fake-python", worker_script="fake-worker.py")
 
     assert calls == []
+
+
+def test_default_worker_script_constant_resolves_to_the_real_dev_file():
+    """_WORKER_SCRIPT is Path(__file__).with_name("jina_clip_worker.py"), computed
+    once at import time -- the same shape as composition._isolated_python(), with
+    no sys.frozen/sys._MEIPASS branch. In dev that must land on the real sibling
+    file; a PyInstaller onedir experiment (see packaging/MonkeyGrab.spec's comment
+    on the jina_clip_worker.py datas entry, #26) confirmed the identical expression
+    also lands on the real file once it is shipped as bundled data, which is why
+    no frozen-specific code path exists here to test in isolation.
+    """
+    assert module._WORKER_SCRIPT.endswith("jina_clip_worker.py")
+    assert Path(module._WORKER_SCRIPT).is_file()
+
+
+def test_missing_worker_script_raises_naming_the_path_and_frozen_state(monkeypatch, tmp_path):
+    """Regression test for #26: a missing worker script must fail loudly and
+    specifically, not as an opaque "external interpreter died immediately"
+    error diagnosable only by reading foreign stderr.
+    """
+    missing_script = str(tmp_path / "jina_clip_worker.py")
+    fake_popen, calls = _make_popen()
+    monkeypatch.setattr(module.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(module.sys, "frozen", True, raising=False)
+    embedder = JinaClipEmbedder("fake-python", worker_script=missing_script)
+
+    with pytest.raises(RuntimeError, match=r"frozen=True") as excinfo:
+        embedder.embed("hello")
+
+    assert repr(missing_script) in str(excinfo.value)  # message embeds the path via !r
+    assert calls == []  # never even tried to spawn a process for a script that isn't there
 
 
 def test_worker_starts_once_and_is_reused_across_calls(monkeypatch):


### PR DESCRIPTION
## Summary

- `JinaClipEmbedder` launches `jina_clip_worker.py` as a script with the external `.venv-mineru` interpreter, resolving the path via `Path(__file__).with_name("jina_clip_worker.py")`. `MonkeyGrab.spec`'s `collect_submodules("monkeygrab")` only bundled that file as compiled bytecode inside the PYZ archive, which the external interpreter cannot execute — so a frozen build's indexing/retrieval failed even with `.venv-mineru` correctly in place, the subprocess dying immediately with an unhelpful "can't open file" from the foreign interpreter's own stderr.
- Fix: ship `jina_clip_worker.py` as a literal PyInstaller `datas` entry, at the same relative path it already has in the source tree (`monkeygrab/adapters/embedding/`). A standalone PyInstaller onedir experiment (throwaway package, not committed) confirmed `__file__` for an archived pure-Python module resolves to a real path mirroring the source tree under `sys._MEIPASS`, so the adapter's existing `Path(__file__).with_name(...)` lookup already finds the shipped file correctly in both dev and frozen — **no `sys.frozen` branch needed**, matching the shape `composition._isolated_python()` already uses to resolve `.venv-mineru` in both layouts (this repo has twice before invented a second convention for an already-solved problem — PRs #60 and #52 — this fix deliberately does not).
- Added an explicit hard-fail in `_start_worker()`: if the worker script is missing, raise immediately with the resolved path and frozen state, instead of relying on an opaque subprocess death (project hard-fail policy, CLAUDE.md §1 rule 8).
- Updated `packaging/README.md`'s note on this bug to describe the fix instead of the failure.
- Checked every other `__file__`-relative path in `src/monkeygrab/` and `rag/` for the same defect shape (script/data resolved via `__file__` but not shipped as `datas`): none found. `mineru_extractor.py` and `composition.py` resolve an *external* sibling directory (`.venv-mineru`) the same way `_isolated_python()` does, which is correct by construction since it's outside the archive. `rag/web/app.py`'s `_react_dist` resolves to `rag/web/frontend/dist`, which the spec already ships as `datas`. `rag/chat_pdfs.py` / `rag/web/desktop.py` only use `__file__` for dev-only `sys.path` bootstrapping, explicitly skipped when frozen.

## Verification

- **Tier reached: tier 1 (real built bundle), confirmed in a follow-up comment below.** `python packaging/build_exe.py` completed in 37m39s; `jina_clip_worker.py` is physically present, byte-identical to source, at `dist/MonkeyGrab/_internal/monkeygrab/adapters/embedding/jina_clip_worker.py` — exactly the path `Path(__file__).with_name(...)` resolves to at runtime. `jina_clip_embedder.py` itself is correctly absent as a raw file there (stays compiled in the PYZ, since it's only ever imported). The full end-to-end "indexes a PDF and answers a query" run was not exercised (no `.venv-mineru` on this machine, and the GPU/Ollama were kept free for another agent's evaluation gate run) — but the specific defect (worker script never leaving the archive) is verified fixed on disk in a real build, not just simulated.
- Unit tests added to `tests/unit/adapters/test_jina_clip_embedder.py`:
  - `test_default_worker_script_constant_resolves_to_the_real_dev_file` — the dev-mode resolution still finds the real sibling file (unmocked).
  - `test_missing_worker_script_raises_naming_the_path_and_frozen_state` — a missing script raises `RuntimeError` naming the resolved path and `frozen=True/False`, instead of failing silently or via foreign stderr.
  - (Plus a small harness change: the existing `_embedder()` test helper now defaults `os.path.isfile` to `True`, since the new existence check would otherwise reject the pre-existing tests' non-existent `worker_script="fake-worker.py"` fixture path — the two new tests above cover the check itself.)
- Full suite measured locally (CPU only, no GPU/Ollama touched — both busy with an evaluation gate run elsewhere):
  - `origin/main` (f5573b0): **547 passed, 1 skipped**, 85.5s
  - this branch: **549 passed, 1 skipped** (+2 new tests), 87.8s — no regressions
- `python -m ruff check .` — clean.
- Changed files: `packaging/MonkeyGrab.spec`, `packaging/README.md`, `src/monkeygrab/adapters/embedding/jina_clip_embedder.py`, `tests/unit/adapters/test_jina_clip_embedder.py`. No overlap with PR #75 (`faiss_store.py`) or PR #73 (`rag/chat_pdfs.py`, `rag/web/app.py`).

## Test plan

- [x] `python -m pytest -q -p no:randomly` — 549 passed, 1 skipped
- [x] `python -m ruff check .` — clean
- [ ] Built bundle indexes a PDF and answers a query on a machine with `.venv-mineru` prepared (issue's full acceptance bar — needs a machine with `.venv-mineru` set up; not run here)
- [x] Confirm `jina_clip_worker.py` physically present at `dist/MonkeyGrab/_internal/monkeygrab/adapters/embedding/jina_clip_worker.py` after the build completes — done, byte-identical to source

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)
