### PR TITLE
Raise OLLAMA_KEEP_ALIVE default and align recomp_num_ctx (issue #25)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,10 +47,10 @@
 # Requested per call; the model/Modelfile can still cap the effective window.
 #OLLAMA_RAG_NUM_CTX=16384                       # final RAG generator
 #OLLAMA_QUERY_NUM_CTX=2048                      # LLM query decomposition
-#OLLAMA_RECOMP_NUM_CTX=8192                     # RECOMP synthesis
+#OLLAMA_RECOMP_NUM_CTX=16384                    # RECOMP synthesis; matches OLLAMA_RAG_NUM_CTX so both calls reuse one loaded runner instead of reloading between them (issue #25)
 #OLLAMA_CONTEXTUAL_NUM_CTX=32768                # contextual retrieval at indexing time
 #OLLAMA_REQUEST_TIMEOUT=900                     # HTTP timeout in seconds for long generations
-#OLLAMA_KEEP_ALIVE=0                            # seconds in VRAM after each call; 0 unloads immediately
+#OLLAMA_KEEP_ALIVE=120                          # seconds in VRAM after each call; 0 unloads immediately. Model load is 93-95% of query wall time (issue #25), so this is what makes back-to-back queries fast -- but it also holds VRAM that long after every call. Lower it (or set 0) on a small/shared GPU, e.g. the packaged desktop app.
 #OLLAMA_GENERATE_RETRIES=2                      # retry RAG /generate on HTTP 5xx after unloading models
 #OLLAMA_GENERATE_RETRY_DELAY=3                  # seconds between generate retries
 

--- a/README.md
+++ b/README.md
@@ -246,6 +246,11 @@ same file: one configuration per machine, not one per interface. The precedence
 is environment, then saved choices, then defaults, so an exported
 `OLLAMA_*_MODEL` or `DOCS_FOLDER` still describes the run you are starting.
 
+`OLLAMA_KEEP_ALIVE` keeps the generator's weights in VRAM for that many seconds
+after each call, since loading them back is most of a query's latency — on a
+small or shared GPU that also means the model squats on VRAM for that long
+afterward, so lower it (or set it to `0`) there.
+
 Each corpus has its own Jina CLIP and FAISS index under `rag/vector_db/`. Both
 interfaces detect when a stored index no longer matches the active chunking,
 extraction or index-time flags and warn about it, but never reindex on their
@@ -291,7 +296,7 @@ or web app in the meantime. See [`packaging/README.md`](packaging/README.md).
 > - **Optional stages fail loudly.** If an enabled stage cannot run, the query raises instead of silently returning worse results. Turn the stage off to proceed without it.
 > - **Indexing cost** grows with corpus size, contextual enrichment and the number of extracted images.
 > - **Concurrent web requests can disable the embedder.** Two overlapping queries can desynchronize the Jina CLIP worker's protocol, which permanently disables it until the process restarts ([#24](https://github.com/iDiagoValeta/localOllamaRAG/issues/24)).
-> - **VRAM from the embedder and reranker is not freed before generation.** On memory-constrained GPUs this can make Ollama hang for minutes instead of failing fast ([#25](https://github.com/iDiagoValeta/localOllamaRAG/issues/25)).
+> - **VRAM from the embedder and reranker is not freed before generation**, but measurement found Ollama offloads rather than blocking: contention cost single-digit seconds, not the multi-minute hang once suspected ([#25](https://github.com/iDiagoValeta/localOllamaRAG/issues/25)).
 > - **The packaged desktop build cannot start the multimodal worker yet.** Indexing and retrieval fail even with the isolated runtime present ([#26](https://github.com/iDiagoValeta/localOllamaRAG/issues/26)).
 
 ---

--- a/rag/chat_pdfs.py
+++ b/rag/chat_pdfs.py
@@ -153,11 +153,24 @@ MODELO_DESC = os.getenv("MODELO_DESC", _inferir_descripcion_modelo(MODELO_RAG))
 
 OLLAMA_RAG_NUM_CTX = _leer_env_int("OLLAMA_RAG_NUM_CTX", 16384)
 OLLAMA_QUERY_NUM_CTX = _leer_env_int("OLLAMA_QUERY_NUM_CTX", 2048)
-OLLAMA_RECOMP_NUM_CTX = _leer_env_int("OLLAMA_RECOMP_NUM_CTX", 8192)
+# Matches OLLAMA_RAG_NUM_CTX on purpose: RECOMP and the final generation both
+# run on the same model (see MODELO_RECOMP/MODELO_RAG), and Ollama keys a
+# resident runner by model AND num_ctx, so a mismatch here forces a second
+# cold load per query even with OLLAMA_KEEP_ALIVE set. Measured in issue #25
+# (2026-07-29): a num_ctx change alone reloads a 1 GB model in ~82s. Verified
+# with a paired gate run (tests/eval/runs/): this alignment alone is what
+# turns a 20.4 min run into 16.4 min -- reverting only this (keep_alive
+# unchanged) reproduced the reference run exactly, 44/51 with zero flips.
+OLLAMA_RECOMP_NUM_CTX = _leer_env_int("OLLAMA_RECOMP_NUM_CTX", 16384)
 OLLAMA_CONTEXTUAL_NUM_CTX = _leer_env_int("OLLAMA_CONTEXTUAL_NUM_CTX", 32768)
 OLLAMA_REQUEST_TIMEOUT = _leer_env_int("OLLAMA_REQUEST_TIMEOUT", 900)
 # Seconds to keep weights in VRAM after each Ollama call; 0 unloads immediately.
-OLLAMA_KEEP_ALIVE = _leer_env_int("OLLAMA_KEEP_ALIVE", 0)
+# Model load is 93-95% of query wall time (issue #25, 2026-07-29): at 120s,
+# queries within that window of each other reuse the resident weights instead
+# of paying a ~170s cold load again. Costs VRAM residency for that long after
+# every call -- lower it (or set 0) on a card that needs the headroom back
+# sooner, e.g. the packaged desktop app on an unknown GPU.
+OLLAMA_KEEP_ALIVE = _leer_env_int("OLLAMA_KEEP_ALIVE", 120)
 OLLAMA_GENERATE_RETRIES = _leer_env_int("OLLAMA_GENERATE_RETRIES", 2)
 OLLAMA_GENERATE_RETRY_DELAY = _leer_env_int("OLLAMA_GENERATE_RETRY_DELAY", 3)
 

--- a/src/monkeygrab/config/app_config.py
+++ b/src/monkeygrab/config/app_config.py
@@ -103,10 +103,15 @@ class AppConfig:
             ollama=OllamaRuntimeConfig(
                 rag_num_ctx=env.read_env_int("OLLAMA_RAG_NUM_CTX", 16384),
                 query_num_ctx=env.read_env_int("OLLAMA_QUERY_NUM_CTX", 2048),
-                recomp_num_ctx=env.read_env_int("OLLAMA_RECOMP_NUM_CTX", 8192),
+                # Matches rag_num_ctx on purpose -- see rag/chat_pdfs.py's
+                # OLLAMA_RECOMP_NUM_CTX comment (issue #25): a mismatch here
+                # forces Ollama to reload the generator a second time per query.
+                recomp_num_ctx=env.read_env_int("OLLAMA_RECOMP_NUM_CTX", 16384),
                 contextual_num_ctx=env.read_env_int("OLLAMA_CONTEXTUAL_NUM_CTX", 32768),
                 request_timeout=env.read_env_int("OLLAMA_REQUEST_TIMEOUT", 900),
-                keep_alive=env.read_env_int("OLLAMA_KEEP_ALIVE", 0),
+                # See rag/chat_pdfs.py's OLLAMA_KEEP_ALIVE comment (issue #25)
+                # for the measurement behind 120 and the VRAM residency trade-off.
+                keep_alive=env.read_env_int("OLLAMA_KEEP_ALIVE", 120),
                 generate_retries=env.read_env_int("OLLAMA_GENERATE_RETRIES", 2),
                 generate_retry_delay=env.read_env_int("OLLAMA_GENERATE_RETRY_DELAY", 3),
                 base_url=env.read_env_ollama_base_url(),

--- a/src/monkeygrab/config/models.py
+++ b/src/monkeygrab/config/models.py
@@ -9,10 +9,10 @@ from monkeygrab.config.env import DEFAULT_OLLAMA_BASE_URL
 class OllamaRuntimeConfig:
     rag_num_ctx: int = 16384
     query_num_ctx: int = 2048
-    recomp_num_ctx: int = 8192
+    recomp_num_ctx: int = 16384  # matches rag_num_ctx -- see AppConfig.from_env()
     contextual_num_ctx: int = 32768
     request_timeout: int = 900
-    keep_alive: int = 0
+    keep_alive: int = 120
     generate_retries: int = 2
     generate_retry_delay: int = 3
     base_url: str = DEFAULT_OLLAMA_BASE_URL

--- a/tests/eval/run_eval.py
+++ b/tests/eval/run_eval.py
@@ -614,10 +614,23 @@ def _generation_keep_alive(models_used: Iterable[str]):
     below to free Ollama's own 120s hold on them) rather than the whole run:
     phase 1 never touches Ollama, so it cannot benefit, and leaving it set
     past main() would let a non-zero keep-alive leak into anything else
-    importing rag.chat_pdfs afterwards. Does not touch the product default --
-    see issue #27: keep_alive=0 exists because the embedder and reranker
-    contend for the same 8 GB (issue #25), and raising it globally would
-    make that contention worse.
+    importing rag.chat_pdfs afterwards.
+
+    Independent of what the product default is: this scoping still matters
+    on its own terms (phase 1 shouldn't hold a keep-alive it can never use),
+    which is why it stays even now that OLLAMA_KEEP_ALIVE's product default
+    is also 120 (rag/chat_pdfs.py). That default used to be 0, on the theory
+    that the embedder and reranker contend for the same 8 GB (issue #27).
+    Issue #25's 2026-07-29 measurement found that contention costs 5.0s on
+    e4b and 2.0s on e2b, not the multi-minute stall once feared, with all
+    three tenants coexisting at 7514 of 8188 MiB; #25 was closed as not
+    reproduced on that basis and the product default was raised separately.
+    A consequence worth being explicit about: because this context manager
+    already forced 120 for phase 2's generation calls regardless of the
+    product default, raising the product default does not change what this
+    harness measures here -- any speedup phase 2 shows across a keep-alive
+    change has to come from somewhere else (e.g. recomp_num_ctx no longer
+    forcing a reload between RECOMP and the final generation call).
 
     Args:
         models_used: Every Ollama model name this phase may have loaded


### PR DESCRIPTION
## Summary

- Raise `OLLAMA_KEEP_ALIVE` default from `0` to `120` seconds and align `OLLAMA_RECOMP_NUM_CTX` (8192) with `OLLAMA_RAG_NUM_CTX` (16384), per issue #25's 2026-07-29 measurement: model load is 93-95% of query wall time, and Ollama keys a resident runner by model **and** `num_ctx`, so RECOMP and the final generation calling the same model at different context sizes forced a second cold load every query.
- Both are numeric pipeline parameters under CLAUDE.md rule 6 (affect latency/cost/eval results). **The repo owner explicitly approved this change and its scope.**
- Updates `.env.example`, `README.md`, and `tests/eval/run_eval.py`'s `_generation_keep_alive` docstring, which asserted a now-disproven rationale ("keep_alive=0 exists because the embedder and reranker contend for the same 8GB" — issue #25 measured that contention at 5.0s/2.0s, not a multi-minute stall, and closed #25 as not reproduced).

## Verification

**Ollama reload on `num_ctx` change — verified directly against the running server, not inferred from wall time.** With `gemma4:e2b`: a same-`num_ctx` call has `load_duration` ~0.45-0.47s; alternating `num_ctx` (2048↔8192) reloads it in 8.4-8.7s every single time, and `/api/ps` confirms `context_length` actually changes between calls. This is a real reload, not a cache artifact.

**Direction of the num_ctx alignment.** Raised RECOMP (not lowered the generator): `gemma4:e4b` is already ~66% offloaded to system RAM at `num_ctx=16384` on the reference 8188 MiB card, so the extra VRAM cost of raising RECOMP from 8192→16384 is marginal (measured 3.50 GB → 3.65 GB resident). Lowering the generator's context to 8192 instead would truncate the evidence it sees and change answers — that needs its own gate run to justify and is out of scope here.

**keep_alive value: 120, not the measured 300.** The speedup only depends on whether the next call lands inside the keep-alive window, not the window's size — 120s covers the intra-query RECOMP→generation gap and typical inter-question think time at half the VRAM-residency exposure of 300s, which matters for the packaged desktop app running on unknown-GPU machines. 120 is also the value `tests/eval/run_eval.py` already uses for its own generation phase.

**Full test suite**, measured on both `origin/main` and this branch (not assumed):
- `origin/main` baseline: `542 passed, 1 skipped` in 69.23s
- This branch: `542 passed, 1 skipped` in 61-70s (run-to-run variance, no regressions)

**`ruff check .`**: clean on both.

**Evaluation gate** (`tests/eval/run_eval.py --models gemma4:e2b`), both corpora registered a cache hit — no reindex triggered:

| Run | Config | Pass rate | Total wall time | Answered median | Retrieval-only median |
|---|---|---|---|---|---|
| Reference | `main` (keep_alive=0, recomp=8192) | 44/51 (86.3%) | 20.4 min | 28.5s | 4.1s |
| **This branch** | keep_alive=120, recomp=16384 | 43/51 (84.3%) | **16.4 min** | **17.5s** | 6.2s |
| Isolation control | keep_alive=120, recomp reverted to 8192 | 44/51 (86.3%) | 24.0 min | — | — |

`compare_runs.py`, this branch vs reference:
```
0 flipped to PASS, 1 flipped to FAIL, 50 unchanged
  - planck-h0 / gemma4:e2b
pass rate delta: -0.0196
```

`compare_runs.py`, isolation control vs reference:
```
identical: 51 case(s) unchanged
pass rate delta: +0.0000
```

**The isolation run pins the cause of both the speedup and the flip on `recomp_num_ctx`, not `keep_alive`.** Reverting only `recomp_num_ctx` back to 8192 (keeping `keep_alive=120`) reproduces the reference run byte-for-byte (44/51, zero flips) and loses the entire speedup (24.0 min, back near the 20.4 min reference). This also confirms the `keep_alive` product-default change is invisible to this gate specifically: `run_eval.py`'s `_generation_keep_alive` context manager already forces `OLLAMA_KEEP_ALIVE=120` for phase 2's generation calls regardless of the product default, so the gate ran phase 2 at keep_alive=120 even on `main`. `keep_alive`'s actual payoff is the product's own query-to-query latency (the 173.8s → 12.7s issue #25 measured directly), which this gate does not exercise.

**The one flip** (`planck-h0`/`gemma4:e2b`, PASS→FAIL, pass rate still comfortably above the 0.77 floor): the model's answer cites `H0 = 67.27 ± 0.60`, a real value reported elsewhere in the same Planck cosmology paper, instead of the gold case's expected `67.4`. Raising `recomp_num_ctx` changes what RECOMP synthesis retains from the evidence, which changed which of the paper's several H0 values reached the final answer. This is a real, reportable side effect of the alignment — not sampling noise (the isolation run's exact byte-for-byte match to the reference rules that out) — and is disclosed here for the reviewer's judgment rather than hidden.

## Test plan

- [x] `pytest -q -p no:randomly` — 542 passed, 1 skipped (measured on both `origin/main` and this branch)
- [x] `ruff check .` — clean
- [x] `tests/eval/run_eval.py --models gemma4:e2b` — 43/51 (84.3%), above the 0.77 baseline floor; both corpora cache-hit, no reindex
- [x] Isolation run confirms `recomp_num_ctx` (not `keep_alive`) is the cause of both the speedup and the one flip
- [x] `.env.example`, `README.md`, `tests/unit/test_app_config_defaults.py`-covered equivalence all reflect the new defaults

Refs #25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
