### PR TITLE
Stop settings.json from erasing an env-overridden model pick (#79)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -40,7 +40,7 @@ fine-tuned models and evaluation hooks that had already been deleted.
    - **Support:** context assembly, debug dumps, chat history, `obtener_documentos_indexados`, and the text helpers re-exported from `monkeygrab.application.keywords` (`STOPWORDS`, `extract_keywords`, ...).
    - **Runtime switches (web control panel):** `get_pipeline_flags`, `set_pipeline_flags`, `set_docs_folder_runtime`, `MODEL_ROLE_VARS`, `MODEL_ROLE_ENV_VARS`, `get_model_roles`, `set_model_roles_runtime`, the path derivation helper `_derivar_paths_db`, and the persisted-choice API both interfaces use: `cargar_ajustes_persistidos`, `guardar_ajustes_persistidos`, `resolver_carpeta_store`, `STORE_IDS`.
 
-   The web API adds `/api/ollama[/start|/models]`, `/api/models`, `/api/stores` (GET) and `/api/stores/select` (POST). There are exactly three fixed language stores — `en` (English, default), `es` (Castellano), `ca` (Valencià) — each bound to `rag/docs/<id>/`. They always exist, possibly empty; there is no create/delete/hide/restore and no user-created stores. `settings.json` persists `active_store`, the model roles and the pipeline flags, falling back to the defaults for anything unknown. **Both interfaces read it** (`rag/engine/settings.py`): the web app at import, the CLI in `chat_pdfs.main()`, so a choice made in one is the configuration the other runs under. Precedence is environment > `settings.json` > module defaults, so an exported `OLLAMA_*_MODEL` or `DOCS_FOLDER` still describes the run that declares it. The active store is selectable, and documents can be viewed, added and removed per store.
+   The web API adds `/api/ollama[/start|/models]`, `/api/models`, `/api/stores` (GET) and `/api/stores/select` (POST). There are exactly three fixed language stores — `en` (English, default), `es` (Castellano), `ca` (Valencià) — each bound to `rag/docs/<id>/`. They always exist, possibly empty; there is no create/delete/hide/restore and no user-created stores. `settings.json` persists `active_store`, the model roles and the pipeline flags, falling back to the defaults for anything unknown. **Both interfaces read it** (`rag/engine/settings.py`): the web app at import, the CLI in `chat_pdfs.main()`, so a choice made in one is the configuration the other runs under. Precedence is environment > `settings.json` > module defaults, so an exported `OLLAMA_*_MODEL` or `DOCS_FOLDER` still describes the run that declares it. A save never writes an env-pinned role or store over the stored choice: the override lasts for this run, and unsetting the variable restores what the user picked rather than finding it erased. The active store is selectable, and documents can be viewed, added and removed per store.
 8. **Hard-fail policy, project-wide.** Every adapter under `src/monkeygrab/adapters/` raises on failure instead of degrading — no silent CUDA→CPU fallback, no silent extractor swap, no silent RECOMP-to-raw-context fallback. Do not add a fallback chain inside an adapter; if a caller needs one, it composes two ports explicitly. See `docs/design/2026-07-26-monkeygrab-v2.md` §3 ("Política de fallos").
 9. **Test boundaries are load-bearing, not incidental:**
    - `tests/characterization/` pins the *current* pipeline's observed behavior, including its known bugs. Do not edit these tests to make a change pass — if a change legitimately alters behavior, that's a signal to stop and confirm, not to update the test. The one documented exception is `test_stale_default_config_bug.py`, whose own docstring says exactly when and how it is allowed to change.
@@ -110,8 +110,10 @@ docs/README.md             Documentation standard
 ## 3. Models
 
 Ollama roles are configured via env vars; defaults are the second arg of
-`os.getenv` in `rag/chat_pdfs.py`. The process environment **always** wins over
-the defaults. Jina CLIP v2 and BGE Reranker v2 M3 are fixed.
+`os.getenv` in `rag/chat_pdfs.py`. Precedence is environment > `settings.json`
+> module defaults. The environment wins for this run, including over a
+choice saved in the web UI; a save does not persist that override as if the
+user had picked it (issue #79). Jina CLIP v2 and BGE Reranker v2 M3 are fixed.
 
 | Role | Env var | Notes |
 |------|---------|-------|

--- a/README.md
+++ b/README.md
@@ -245,6 +245,8 @@ saved to `settings.json` in the data directory, and the CLI starts from that
 same file: one configuration per machine, not one per interface. The precedence
 is environment, then saved choices, then defaults, so an exported
 `OLLAMA_*_MODEL` or `DOCS_FOLDER` still describes the run you are starting.
+That override does not overwrite the saved choice: unset the variable and the
+UI pick is still there.
 
 Each corpus has its own Jina CLIP and FAISS index under `rag/vector_db/`. Both
 interfaces detect when a stored index no longer matches the active chunking,

--- a/rag/engine/settings.py
+++ b/rag/engine/settings.py
@@ -12,8 +12,9 @@ Precedence is environment > settings.json > module defaults. A variable exported
 for this run (or read from ``.env``) is an explicit statement about this run and
 outranks a choice saved during an earlier one; everything the environment leaves
 unset falls back to the persisted choice, and only then to the defaults in
-rag/chat_pdfs.py. This is the precedence the README already documents for the
-environment, now applied to persisted state as well.
+rag/chat_pdfs.py. The override is for this run only: a save never writes an
+env-pinned role (or ``DOCS_FOLDER``) over the stored choice, so unsetting the
+variable restores what the user picked rather than destroying it (issue #79).
 
 Best-effort by design: a missing, unreadable or corrupt file leaves the defaults
 standing instead of blocking startup, the same contract rag/engine/history.py
@@ -73,12 +74,57 @@ def resolver_carpeta_store(nombre: str) -> Optional[str]:
     return carpeta if os.path.isdir(carpeta) else None
 
 
+def _leer_ajustes() -> dict:
+    """Return the settings file as a dict, or ``{}`` if it is missing or unusable."""
+    try:
+        # utf-8-sig tolerates a BOM if the file was hand-edited with a Windows tool.
+        with open(ruta_ajustes(), "r", encoding="utf-8-sig") as f:
+            data = json.load(f)
+    except (OSError, ValueError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _roles_a_persistir(on_disk: dict) -> dict:
+    """Effective roles, except any the environment is pinning this run.
+
+    ``get_model_roles`` reports what this process is running, which for an
+    env-pinned role is the override, not the user's stored pick. Writing that
+    back replaces the pick with the override, so the choice is gone when the
+    variable is unset -- issue #79. Keep the on-disk value when there is one;
+    omit the role when there is not, rather than freeze the override as if
+    the user had chosen it.
+    """
+    roles = dict(cfg.get_model_roles())
+    saved = on_disk.get("roles")
+    saved = saved if isinstance(saved, dict) else {}
+    for rol in list(roles):
+        if not _fijado_por_entorno(rol):
+            continue
+        previous = saved.get(rol)
+        if isinstance(previous, str) and previous.strip():
+            roles[rol] = previous
+        else:
+            roles.pop(rol, None)
+    return roles
+
+
+def _store_a_persistir(on_disk: dict) -> str:
+    """Active store, keeping the saved identifier while ``DOCS_FOLDER`` pins this run."""
+    if os.getenv(_DOCS_FOLDER_ENV):
+        saved = on_disk.get("active_store")
+        if isinstance(saved, str) and saved.strip():
+            return saved
+    return _nombre_store_activo()
+
+
 def guardar_ajustes_persistidos() -> None:
     """Write the active model roles, store and pipeline flags to the settings file."""
     try:
+        on_disk = _leer_ajustes()
         data = {
-            "roles": cfg.get_model_roles(),
-            "active_store": _nombre_store_activo(),
+            "roles": _roles_a_persistir(on_disk),
+            "active_store": _store_a_persistir(on_disk),
             "flags": {var: bool(getattr(cfg, var, False)) for var in PERSISTED_FLAGS},
         }
         ruta = ruta_ajustes()
@@ -96,13 +142,8 @@ def cargar_ajustes_persistidos() -> None:
     flags last. Entries the environment pins, and entries naming something this
     build does not have, are skipped.
     """
-    try:
-        # utf-8-sig tolerates a BOM if the file was hand-edited with a Windows tool.
-        with open(ruta_ajustes(), "r", encoding="utf-8-sig") as f:
-            data = json.load(f)
-    except (OSError, ValueError):
-        return
-    if not isinstance(data, dict):
+    data = _leer_ajustes()
+    if not data:
         return
 
     _aplicar_roles(data.get("roles"))

--- a/tests/unit/test_persisted_settings.py
+++ b/tests/unit/test_persisted_settings.py
@@ -132,6 +132,53 @@ def test_the_environment_outranks_a_saved_role(data_dir, monkeypatch):
     assert rag_engine.MODELO_RAG == "saved-rag"
 
 
+def test_save_does_not_erase_a_role_the_environment_is_pinning(data_dir, monkeypatch):
+    """Issue #79: the override is defensible; destroying the stored pick is not.
+
+    Sequence: env pins contextual, settings.json records a different choice,
+    load (runtime follows the env), save (any other control also triggers this).
+    The file must still record the user's pick -- not the override, and not
+    drop the key -- so unsetting the variable restores what they chose.
+    """
+    monkeypatch.setenv("OLLAMA_CONTEXTUAL_MODEL", "pinned-by-env:1b")
+    monkeypatch.setattr(rag_engine, "MODELO_CONTEXTUAL", "pinned-by-env:1b")
+    _save(data_dir, roles={"contextual": "chosen-in-web-ui:9b", "rag": "saved-rag"})
+
+    settings.cargar_ajustes_persistidos()
+    settings.guardar_ajustes_persistidos()
+
+    on_disk = json.loads((Path(data_dir) / "settings.json").read_text(encoding="utf-8"))
+    assert on_disk["roles"]["contextual"] == "chosen-in-web-ui:9b"
+    assert on_disk["roles"]["rag"] == "saved-rag"
+    assert rag_engine.MODELO_CONTEXTUAL == "pinned-by-env:1b"
+
+
+def test_save_does_not_freeze_an_env_override_as_a_stored_choice(data_dir, monkeypatch):
+    """No prior pick for a pinned role: omit it rather than persist the override."""
+    monkeypatch.setenv("OLLAMA_CONTEXTUAL_MODEL", "pinned-by-env:1b")
+    monkeypatch.setattr(rag_engine, "MODELO_CONTEXTUAL", "pinned-by-env:1b")
+    _save(data_dir, roles={"rag": "saved-rag"})
+
+    settings.cargar_ajustes_persistidos()
+    settings.guardar_ajustes_persistidos()
+
+    on_disk = json.loads((Path(data_dir) / "settings.json").read_text(encoding="utf-8"))
+    assert "contextual" not in on_disk["roles"]
+    assert on_disk["roles"]["rag"] == "saved-rag"
+
+
+def test_save_does_not_erase_the_store_while_docs_folder_is_set(data_dir, monkeypatch):
+    monkeypatch.setenv("DOCS_FOLDER", str(DOCS_ROOT / "en"))
+    _save(data_dir, active_store="ca")
+
+    settings.cargar_ajustes_persistidos()
+    settings.guardar_ajustes_persistidos()
+
+    on_disk = json.loads((Path(data_dir) / "settings.json").read_text(encoding="utf-8"))
+    assert on_disk["active_store"] == "ca"
+    assert os.path.basename(rag_engine.CARPETA_DOCS) == "en"
+
+
 def test_docs_folder_pins_the_corpus_over_the_saved_store(data_dir, monkeypatch):
     monkeypatch.setenv("DOCS_FOLDER", str(DOCS_ROOT / "en"))
     _save(data_dir, active_store="ca")


### PR DESCRIPTION
## Summary
- Keep the uniform precedence (environment > `settings.json` > defaults). An exported `OLLAMA_*_MODEL` still wins for this run.
- A save no longer writes that override over the stored pick. Same for `DOCS_FOLDER` vs `active_store`. Unsetting the variable restores what the user chose in the UI, instead of finding it gone.
- If there was no stored pick for a pinned role, the role is omitted rather than freezing the override as if they had chosen it.

This is option 2 from #79: smallest change that removes the data loss, compatible with either precedence rule.

## Test plan
- [x] `pytest tests/unit/test_persisted_settings.py -p no:randomly` -- 15 passed, including the issue's load-then-save sequence
- [x] `ruff check` on the touched files
- [ ] Revert only `guardar_ajustes_persistidos`'s merge-from-disk and confirm `test_save_does_not_erase_a_role_the_environment_is_pinning` fails because the file now records the env value, not a fixture-shape mismatch

Refs #79.

Made with [Cursor](https://cursor.com)