### PR TITLE
Stop treating harness subsets as the 51-case gate (#71)

### DIFF
--- a/harness/README.md
+++ b/harness/README.md
@@ -350,9 +350,12 @@ it has no opinion about which real configuration is better.
 against the sibling PR's contract) — an earlier draft of this adapter
 assumed `{"results": [...], "effective_config": ...}` and would have raised
 `KeyError` on the very first real call, found in the same review before
-`evaluate()` had even landed. `harness/tests/test_evaluator.py` exercises
-the mapping against a stub `run_eval` module carrying the real contract, so
-this stays checked rather than only checked once #56 merges.
+`evaluate()` had even landed. It also passes `write_report=False`: the
+harness ledger is the evidence, and the first real run (issue #71) wrote
+five extra JSONs under `tests/eval/runs/` (including a 0-case reachability
+probe) while the loop ignored `evaluate()`'s `exit_code`. `harness/tests/
+test_evaluator.py` exercises the mapping against a stub `run_eval` module
+carrying the real contract, and pins `write_report=False`.
 
 ## Testing
 

--- a/harness/evaluator.py
+++ b/harness/evaluator.py
@@ -375,7 +375,10 @@ def real_evaluate(config_overrides: Mapping[str, Any], case_ids: Sequence[str]) 
         case_ids=tuple(case_ids),
         config_overrides=search_space.expand_overrides(config_overrides),
         update_baseline=False,
-        write_report=True,
+        # The harness ledger is the evidence; writing tests/eval/runs/*.json
+        # here littered five reports on the first real run (issue #71),
+        # including a 0-case reachability probe.
+        write_report=False,
     )
     records = tuple(
         CaseRecord(

--- a/harness/tests/test_evaluator.py
+++ b/harness/tests/test_evaluator.py
@@ -179,13 +179,15 @@ def test_every_declared_search_space_key_is_honoured_by_the_real_evaluate_contra
 # (this round's constraint: no GPU/Ollama -- the full eval gate owns the card).
 
 
-def _fake_run_eval_module(records, config_dev):
+def _fake_run_eval_module(records, config_dev, seen=None):
     """A stub `run_eval` module whose evaluate() carries #56's real return shape."""
     module = types.ModuleType("run_eval")
     module.DEFAULT_MODELS = ["gemma4:e2b"]
 
     def evaluate(*, models, case_ids=None, config_overrides=None, update_baseline=False, write_report=True):
-        del models, case_ids, config_overrides, update_baseline, write_report
+        del models, case_ids, config_overrides, update_baseline
+        if seen is not None:
+            seen["write_report"] = write_report
         return {"records": records, "config": {"dev": config_dev, "blind": {}}}
 
     module.evaluate = evaluate
@@ -201,7 +203,8 @@ def test_real_evaluate_maps_the_actual_56_contract(monkeypatch):
         },
     ]
     config_dev = {"retrieval": {"top_k_final": 8}}
-    monkeypatch.setitem(sys.modules, "run_eval", _fake_run_eval_module(records, config_dev))
+    seen = {}
+    monkeypatch.setitem(sys.modules, "run_eval", _fake_run_eval_module(records, config_dev, seen))
 
     result = ev.real_evaluate({"retrieval.top_k_final": 8}, ("a", "b"))
 
@@ -210,6 +213,10 @@ def test_real_evaluate_maps_the_actual_56_contract(monkeypatch):
     assert by_id["a"].passed is True
     assert by_id["a"].infrastructure_error is False
     assert by_id["b"].infrastructure_error is True
+    # The harness ledger is the evidence; the first real run (issue #71)
+    # wrote five extra JSONs under tests/eval/runs/ because this defaulted
+    # to True -- including a 0-case reachability probe.
+    assert seen["write_report"] is False
 
 
 def test_real_evaluate_raises_not_implemented_without_an_evaluate_function(monkeypatch):

--- a/tests/eval/README.md
+++ b/tests/eval/README.md
@@ -133,8 +133,10 @@ something is missing:
    nearest 0.01) *after* the gate check, and only if that is higher than the
    current value -- the baseline never moves down automatically.
 
-Infrastructure failures leave the run inconclusive. Only a complete run with
-the calibrated generator model is compared against the baseline.
+Infrastructure failures leave the run inconclusive. Only an unfiltered gold-set
+run (`case_ids is None`, the CLI) is compared against the baseline. A subset
+(the harness search set / fast tier / empty reachability probe) still reports
+`pass_rate` and can raise the baseline when asked, but is not the 51-case gate.
 
 ## Measuring the noise floor and the gate's sensitivity
 

--- a/tests/eval/run_eval.py
+++ b/tests/eval/run_eval.py
@@ -1081,10 +1081,19 @@ def evaluate(
     Args:
         models: Ollama generator models to evaluate.
         case_ids: ``gold_cases.jsonl`` ``"id"`` values to run. ``None`` runs
-            every case (the CLI's behavior). Filtering happens immediately
-            after loading, before any corpus is staged or indexed, so a
-            subset that only touches one corpus (dev or blind) never forces
-            the other one to be staged/indexed.
+            every case (the CLI's behavior) and is the only mode compared
+            against the 51-case floor in ``baseline_min_pass_rate.txt``. A
+            non-empty subset still reports ``pass_rate`` and can raise that
+            file when ``update_baseline`` is True, but never prints FAILED
+            against 0.77 or sets ``exit_code=1`` for that reason -- the
+            first real harness run (issue #71) saw a healthy 8/13 fast tier
+            do exactly that. An empty sequence is the harness reachability
+            probe: ``validate_config_overrides`` still runs, then this
+            returns without preflight, indexing or a report. Filtering of a
+            non-empty subset happens immediately after loading, before any
+            corpus is staged or indexed, so a subset that only touches one
+            corpus (dev or blind) never forces the other one to be
+            staged/indexed.
         config_overrides: Dotted ``"section.field"`` overrides. Only keys in
             ``_APPCONFIG_OVERRIDE_KEYS`` (applied via ``AppConfig.with_overrides``
             to the retrieval/indexing config ``_eval_app_config`` builds) or
@@ -1143,6 +1152,29 @@ def evaluate(
         if unknown:
             raise ValueError(f"unknown gold case id(s): {sorted(unknown)}")
     validate_config_overrides(config_overrides)
+
+    # An empty case_ids tuple is the harness reachability probe: it exists to
+    # trip validate_config_overrides, not to run the pipeline. Falling through
+    # would still preflight Ollama, print 0/0, compare that against the 51-case
+    # floor (0.00 < 0.77) and write a junk report -- measured 2026-08-13 on
+    # the first real harness run (issue #71).
+    if case_ids is not None and not cases:
+        return {
+            "summary": build_summary([]),
+            "records": [],
+            "models": list(models),
+            "aux_model": AUX_MODEL,
+            "num_cases": 0,
+            "num_records": 0,
+            "elapsed_seconds": round(time.perf_counter() - run_started, 1),
+            "pass_rate": 0.0,
+            "baseline": None,
+            "infrastructure_errors": [],
+            "baseline_updated": False,
+            "exit_code": 0,
+            "report_path": None,
+            "config": {"dev": None, "blind": None},
+        }
 
     required_models = set(models) | {AUX_MODEL}
     # An overridden models.contextual is otherwise invisible to preflight:
@@ -1268,14 +1300,29 @@ def evaluate(
         print("        Not compared against the baseline: this run measured nothing.")
         exit_code = 1
     else:
-        if threshold is None:
-            print("\n[gate] no baseline yet (tests/eval/baseline_min_pass_rate.txt missing) -- not gating this run")
-            exit_code = 0
-        elif pass_rate < threshold:
-            print(f"\n[gate] FAILED: pass_rate {pass_rate:.4f} < baseline {threshold:.2f}")
-            exit_code = 1
+        # The floor in baseline_min_pass_rate.txt is for the unfiltered 51-case
+        # gold set. A subset's pass rate is a different statistic -- the first
+        # real harness run (issue #71) saw a healthy 8/13 fast tier print
+        # FAILED against 0.77, and a 0-case reachability probe do the same.
+        # Only case_ids is None (the CLI) is the gate.
+        if case_ids is None:
+            if threshold is None:
+                print("\n[gate] no baseline yet (tests/eval/baseline_min_pass_rate.txt missing) -- not gating this run")
+                exit_code = 0
+            elif pass_rate < threshold:
+                print(f"\n[gate] FAILED: pass_rate {pass_rate:.4f} < baseline {threshold:.2f}")
+                exit_code = 1
+            else:
+                print(f"\n[gate] PASSED: pass_rate {pass_rate:.4f} >= baseline {threshold:.2f}")
+                exit_code = 0
         else:
-            print(f"\n[gate] PASSED: pass_rate {pass_rate:.4f} >= baseline {threshold:.2f}")
+            if threshold is not None:
+                print(
+                    f"\n[gate] subset of {len(cases)} case(s) -- not compared against "
+                    f"the {threshold:.2f} floor, which is calibrated on the full gold set"
+                )
+            else:
+                print("\n[gate] subset run -- not the full-set gate")
             exit_code = 0
 
         if update_baseline:

--- a/tests/eval/test_evaluate_library_api.py
+++ b/tests/eval/test_evaluate_library_api.py
@@ -138,6 +138,106 @@ def test_case_ids_none_selects_every_gold_case(monkeypatch):
     assert result["num_cases"] == len(all_cases)
 
 
+def test_empty_case_ids_is_a_reachability_probe_not_the_gate(monkeypatch, tmp_path):
+    """case_ids=() is verify_reachable's honour-check, not a 0/0 gold run.
+
+    Measured 2026-08-13 on the first real harness run (issue #71): falling
+    through preflighted Ollama, printed FAILED 0.00 < 0.77, and wrote a junk
+    report under tests/eval/runs/.
+    """
+    preflight_calls = []
+    monkeypatch.setattr(
+        run_eval, "preflight_ollama", lambda required: preflight_calls.append(set(required))
+    )
+    ensure_calls = []
+    _capture_ensure_indexed(monkeypatch, ensure_calls)
+    seen = []
+    _capture_run_all_cases(monkeypatch, seen)
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    monkeypatch.setattr(run_eval, "RESULTS_DIR", runs_dir)
+    baseline = tmp_path / "baseline_min_pass_rate.txt"
+    baseline.write_text("0.77\n", encoding="utf-8")
+    monkeypatch.setattr(run_eval, "BASELINE_FILE", baseline)
+
+    result = evaluate(models=["m"], case_ids=(), write_report=True)
+
+    assert result["exit_code"] == 0
+    assert result["num_cases"] == 0
+    assert result["records"] == []
+    assert result["report_path"] is None
+    assert result["baseline_updated"] is False
+    assert preflight_calls == []
+    assert ensure_calls == []
+    assert seen == []
+    assert list(runs_dir.iterdir()) == []
+
+
+def test_empty_case_ids_still_rejects_an_unreachable_override(monkeypatch):
+    ensure_calls = []
+    _capture_ensure_indexed(monkeypatch, ensure_calls)
+
+    with pytest.raises(ValueError, match="models.rag"):
+        evaluate(
+            models=["m"], case_ids=(),
+            config_overrides={"models.rag": "other-model"}, write_report=False,
+        )
+
+    assert ensure_calls == []
+
+
+def _fail_every_case(monkeypatch):
+    def _fake(rag, cases, retrieve_dev, retrieve_blind, evidence_dev, evidence_blind, models):
+        return [
+            {
+                "id": c["id"], "paper": c["paper"], "case_type": c["case_type"],
+                "lang": c["lang"], "model": None, "passed": False, "reason": "stub fail",
+                "elapsed_seconds": 0.0,
+            }
+            for c in cases
+        ]
+
+    monkeypatch.setattr(run_eval, "run_all_cases", _fake)
+
+
+def test_subset_below_the_floor_does_not_fail_the_gate(monkeypatch, capsys, tmp_path):
+    """The 0.77 floor is calibrated on 51 cases; an 8/13 fast tier is not it.
+
+    Measured 2026-08-13 (issue #71): a healthy fast-tier 8/13 = 0.6154 printed
+    [gate] FAILED against that floor. A 0/1 stub here is the same class of
+    mistake, cheaper to pin.
+    """
+    baseline = tmp_path / "baseline_min_pass_rate.txt"
+    baseline.write_text("0.77\n", encoding="utf-8")
+    monkeypatch.setattr(run_eval, "BASELINE_FILE", baseline)
+    _capture_ensure_indexed(monkeypatch, [])
+    _fail_every_case(monkeypatch)
+
+    result = evaluate(models=["m"], case_ids=[_DEV_CASE_ID], write_report=False)
+
+    assert result["pass_rate"] == 0.0
+    assert result["exit_code"] == 0
+    out = capsys.readouterr().out
+    assert "[gate] FAILED" not in out
+    assert "subset" in out
+
+
+def test_full_set_below_the_floor_still_fails_the_gate(monkeypatch, capsys, tmp_path):
+    """The CLI (case_ids is None) is still the 51-case gate -- this must not
+    accidentally disable it while fixing the subset path."""
+    baseline = tmp_path / "baseline_min_pass_rate.txt"
+    baseline.write_text("0.77\n", encoding="utf-8")
+    monkeypatch.setattr(run_eval, "BASELINE_FILE", baseline)
+    _capture_ensure_indexed(monkeypatch, [])
+    _fail_every_case(monkeypatch)
+
+    result = evaluate(models=["m"], write_report=False)
+
+    assert result["pass_rate"] == 0.0
+    assert result["exit_code"] == 1
+    assert "[gate] FAILED" in capsys.readouterr().out
+
+
 def test_unknown_case_id_raises_value_error(monkeypatch):
     _capture_ensure_indexed(monkeypatch, [])
     _capture_run_all_cases(monkeypatch, [])


### PR DESCRIPTION
## Summary
- The first real harness run (issue #71) proved the adapter works (32 CaseRecords, identical pass/fail across three configs, blind set untouched) and then showed three adapter defects the stub could not see.
- `evaluate()` now applies the 0.77 floor only when `case_ids is None` (the CLI). An empty `case_ids=()` reachability probe returns before preflight/index/report. `real_evaluate` writes `write_report=False` so evidence lives in the ledger, not `tests/eval/runs/`.
- `gold_cases.jsonl` / `grade.py` / `baseline_min_pass_rate.txt` are untouched. The CLI full gate still fails a 0/51 run.

## Test plan
- [x] `pytest tests/eval/test_evaluate_library_api.py tests/eval/test_evaluate_cli_wrapper.py` (47 passed, engine job)
- [x] `pytest harness/tests` (132 passed, architecture job)
- [x] `python -m ruff check` on the touched files
- [ ] CI green
- [ ] Optional: one `--max-iterations 0` harness smoke to confirm the probe no longer prints `[gate] FAILED: 0.0000 < 0.77`
