### PR TITLE
Add --replay to reconstruct and re-run a ledger entry (#71)

### DIFF
--- a/harness/README.md
+++ b/harness/README.md
@@ -324,6 +324,10 @@ python -m harness.cli --dry-run --max-iterations 3
 # Real run (needs the sibling PR's tests/eval/run_eval.evaluate() on main,
 # Ollama, and a GPU -- fails with an actionable message otherwise):
 python -m harness.cli --proposer llm --max-iterations 8 --patience 3
+
+# Criterion 7: reconstruct one ledger iteration and re-run its exact
+# overrides and case ids. Exit 0 iff the pass/fail vector matches.
+python -m harness.cli --replay 1 --ledger-dir /path/to/ledger
 ```
 
 `--dry-run` uses `evaluator.build_demo_evaluator()`: a tiny, deterministic,

--- a/harness/cli.py
+++ b/harness/cli.py
@@ -3,6 +3,7 @@
 Usage:
     python -m harness.cli --dry-run --max-iterations 3
     python -m harness.cli --proposer llm --max-iterations 8 --patience 3
+    python -m harness.cli --replay 1 --ledger-dir /path/to/ledger
 
 ``--dry-run`` always works: it wires in a small deterministic in-process
 evaluator (``evaluator.build_demo_evaluator``) so the whole loop -- proposer,
@@ -65,7 +66,43 @@ def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
                          help="Use the deterministic in-process demo evaluator instead of the real gate.")
     parser.add_argument("--llm-model", default=proposers_mod.LlmProposer.DEFAULT_MODEL,
                          help=f"Ollama model for --proposer llm. Default: {proposers_mod.LlmProposer.DEFAULT_MODEL}.")
+    parser.add_argument("--replay", type=int, metavar="ITERATION", default=None,
+                         help=(
+                             "Re-run ledger iteration ITERATION's overrides and case ids "
+                             "(criterion 7). Skips the search loop. Needs --ledger-dir "
+                             "pointing at the ledger that holds that entry."
+                         ))
     return parser.parse_args(argv)
+
+
+def _run_replay(iteration: int, evaluate, ledger_dir: Path) -> int:
+    """Criterion 7: reconstruct one ledger entry and compare the pass vector."""
+    try:
+        entry = ledger_mod.read_entry_by_iteration(ledger_dir, iteration)
+    except FileNotFoundError as exc:
+        print(f"REPLAY FAILED: {exc}", file=sys.stderr)
+        return 1
+    try:
+        result = evaluator_mod.replay(evaluate, entry.config_overrides, entry.case_records)
+    except NotImplementedError as exc:
+        print(f"NOT AVAILABLE: {exc}", file=sys.stderr)
+        return 1
+    except evaluator_mod.ReachabilityError as exc:
+        print(f"REACHABILITY GATE FAILED: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"replay iteration {entry.iteration} ({entry.evaluated_case_set}, {len(entry.case_records)} cases)")
+    print(f"overrides: {entry.config_overrides}")
+    print(f"identical: {result.identical}")
+    if result.flips:
+        print(f"flips: {list(result.flips)}")
+    if result.missing:
+        print(f"missing from replay: {list(result.missing)}")
+    if result.extra:
+        print(f"extra in replay: {list(result.extra)}")
+    if result.infrastructure_errors:
+        print(f"infrastructure errors: {list(result.infrastructure_errors)}")
+    return 0 if result.identical else 1
 
 
 def main(argv: Optional[Sequence[str]] = None) -> int:
@@ -80,6 +117,9 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     else:
         evaluate = evaluator_mod.real_evaluate
         ledger_dir = args.ledger_dir or ledger_mod.LEDGER_DIR
+
+    if args.replay is not None:
+        return _run_replay(args.replay, evaluate, ledger_dir)
 
     search_set_ids = evaluator_mod.search_set_case_ids()
     fast_tier_ids = evaluator_mod.load_fast_tier()

--- a/harness/evaluator.py
+++ b/harness/evaluator.py
@@ -159,6 +159,59 @@ def compute_objective(records: Sequence[CaseRecord], unreachable_ids: Iterable[s
     return raw, adjusted
 
 
+@dataclass(frozen=True)
+class ReplayResult:
+    """Pass/fail comparison of a ledger entry against a fresh evaluation.
+
+    Criterion 7 (design doc section 2): reconstruct the configuration from
+    the entry, re-run the same case ids, get the same classification within
+    the one-case noise floor. Latency and generated text are not compared
+    -- criterion 1 measured that the grader absorbs generator wording
+    changes; the bit that has to match is ``passed``.
+    """
+
+    flips: Tuple[str, ...]
+    missing: Tuple[str, ...]
+    extra: Tuple[str, ...]
+    infrastructure_errors: Tuple[str, ...]
+
+    @property
+    def identical(self) -> bool:
+        return not (
+            self.flips or self.missing or self.extra or self.infrastructure_errors
+        )
+
+
+def replay(
+    evaluate: EvaluatorFn,
+    config_overrides: Mapping[str, Any],
+    stored_records: Sequence[Mapping[str, Any]],
+) -> ReplayResult:
+    """Re-run ``evaluate`` on a ledger entry's overrides and case ids.
+
+    Args:
+        evaluate: Same adapter the loop uses (demo or real).
+        config_overrides: The entry's raw proposer deltas, not expanded.
+        stored_records: The entry's ``case_records`` (``id`` / ``passed``).
+
+    Returns:
+        The pass/fail diff. ``identical`` is True only when every stored
+        id came back with the same ``passed`` bit, no extras, and no
+        infrastructure errors.
+    """
+    case_ids = tuple(r["id"] for r in stored_records)
+    result = evaluate(config_overrides, case_ids)
+    stored = {r["id"]: bool(r["passed"]) for r in stored_records}
+    got = {r.id: r.passed for r in result.records}
+    flips = tuple(sorted(cid for cid in stored if cid in got and stored[cid] != got[cid]))
+    missing = tuple(sorted(set(stored) - set(got)))
+    extra = tuple(sorted(set(got) - set(stored)))
+    infra = tuple(sorted(r.id for r in result.records if r.infrastructure_error))
+    return ReplayResult(
+        flips=flips, missing=missing, extra=extra, infrastructure_errors=infra,
+    )
+
+
 # GOLD CASES / CASE SETS
 
 _gold_cases_cache: Optional[List[Dict[str, Any]]] = None

--- a/harness/ledger.py
+++ b/harness/ledger.py
@@ -292,3 +292,19 @@ def read_history(ledger_dir: Path = LEDGER_DIR) -> List[LedgerEntry]:
     """
     entries = [read_entry(p) for p in _entry_files(ledger_dir)]
     return sorted(entries, key=lambda e: e.iteration)
+
+
+def read_entry_by_iteration(ledger_dir: Path, iteration: int) -> LedgerEntry:
+    """The entry whose ``iteration`` matches, or ``FileNotFoundError``.
+
+    Criterion 7's reconstruct-and-rerun path (``harness.cli --replay``)
+    looks an entry up this way rather than by filename: the filename's
+    timestamp is incidental, the iteration number is what the index and
+    ``parent_iteration`` links use.
+    """
+    for entry in read_history(ledger_dir):
+        if entry.iteration == iteration:
+            return entry
+    raise FileNotFoundError(
+        f"no ledger entry for iteration {iteration} under {ledger_dir}"
+    )

--- a/harness/tests/test_cli.py
+++ b/harness/tests/test_cli.py
@@ -1,0 +1,80 @@
+"""Tests for harness.cli -- --replay (criterion 7) wiring."""
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+if str(REPO_ROOT / "src") not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from harness import cli
+from harness import evaluator as ev
+from harness import ledger
+
+
+def _entry_from_result(result, *, iteration=1, overrides=None):
+    records = [
+        {
+            "id": r.id, "case_type": r.case_type,
+            "passed": r.passed, "elapsed_seconds": r.elapsed_seconds,
+        }
+        for r in result.records
+    ]
+    passed = sum(1 for r in result.records if r.passed)
+    return ledger.LedgerEntry(
+        schema_version=ledger.SCHEMA_VERSION,
+        iteration=iteration,
+        parent_iteration=None,
+        git_commit="deadbeef",
+        config_overrides=overrides or {},
+        effective_config=result.effective_config,
+        proposer="grid",
+        proposer_rationale=None,
+        proposer_model=None,
+        proposer_fallback=False,
+        proposer_fallback_reason=None,
+        evaluated_case_set="search_set",
+        case_records=records,
+        summary={"total": len(records), "passed": passed, "pass_rate": 0.0},
+        objective_raw=passed,
+        objective_adjusted=passed,
+        median_latency_answered_s=None,
+        median_latency_retrieval_only_s=None,
+        reference_median_latency_answered_s=None,
+        reference_median_latency_retrieval_only_s=None,
+        latency_ceiling_multiplier=1.20,
+        verdict="rejected_no_gain",
+        reason="test",
+    )
+
+
+def test_parse_args_replay():
+    args = cli.parse_args(["--replay", "2", "--ledger-dir", "somewhere"])
+    assert args.replay == 2
+    assert args.ledger_dir == Path("somewhere")
+
+
+def test_cli_replay_exits_zero_when_the_demo_evaluator_matches(tmp_path):
+    """End-to-end criterion 7 against the in-process demo landscape.
+
+    Write a ledger entry from a demo evaluation, then ``--replay`` that
+    iteration with the same demo evaluator -- the pass vector must match,
+    which is the reconstruct-and-rerun path the first real #71 run never
+    had as a command.
+    """
+    evaluate = ev.build_demo_evaluator()
+    ids = ev.search_set_case_ids()[:3]
+    overrides = {"retrieval.top_k_final": 8}
+    result = evaluate(overrides, ids)
+    ledger.write_entry(_entry_from_result(result, overrides=overrides), ledger_dir=tmp_path)
+
+    code = cli.main(["--dry-run", "--replay", "1", "--ledger-dir", str(tmp_path)])
+    assert code == 0
+
+
+def test_cli_replay_exits_nonzero_when_the_iteration_is_missing(tmp_path, capsys):
+    code = cli.main(["--dry-run", "--replay", "9", "--ledger-dir", str(tmp_path)])
+    assert code == 1
+    assert "iteration 9" in capsys.readouterr().err

--- a/harness/tests/test_evaluator.py
+++ b/harness/tests/test_evaluator.py
@@ -225,3 +225,79 @@ def test_real_evaluate_raises_not_implemented_without_an_evaluate_function(monke
 
     with pytest.raises(NotImplementedError):
         ev.real_evaluate({}, ())
+
+
+# CRITERION 7 -- reconstruct-and-rerun pass vector.
+
+
+def test_replay_identical_when_every_passed_bit_matches():
+    stored = [
+        {"id": "a", "passed": True},
+        {"id": "b", "passed": False},
+    ]
+
+    def evaluate(overrides, case_ids):
+        assert list(case_ids) == ["a", "b"]
+        assert dict(overrides) == {"retrieval.top_k_final": 4}
+        return ev.EvaluationResult(
+            records=(
+                _rec("a", passed=True),
+                _rec("b", passed=False),
+            ),
+            effective_config={},
+        )
+
+    result = ev.replay(evaluate, {"retrieval.top_k_final": 4}, stored)
+    assert result.identical is True
+    assert result.flips == ()
+    assert result.missing == ()
+    assert result.extra == ()
+    assert result.infrastructure_errors == ()
+
+
+def test_replay_reports_a_classification_flip():
+    stored = [{"id": "a", "passed": True}, {"id": "b", "passed": False}]
+
+    def evaluate(overrides, case_ids):
+        del overrides, case_ids
+        return ev.EvaluationResult(
+            records=(_rec("a", passed=True), _rec("b", passed=True)),
+            effective_config={},
+        )
+
+    result = ev.replay(evaluate, {}, stored)
+    assert result.identical is False
+    assert result.flips == ("b",)
+
+
+def test_replay_reports_missing_and_extra_ids():
+    stored = [{"id": "a", "passed": True}]
+
+    def evaluate(overrides, case_ids):
+        del overrides, case_ids
+        return ev.EvaluationResult(records=(_rec("b", passed=True),), effective_config={})
+
+    result = ev.replay(evaluate, {}, stored)
+    assert result.missing == ("a",)
+    assert result.extra == ("b",)
+    assert result.identical is False
+
+
+def test_replay_treats_an_infrastructure_error_as_not_identical():
+    stored = [{"id": "a", "passed": True}]
+
+    def evaluate_broken(overrides, case_ids):
+        del overrides, case_ids
+        return ev.EvaluationResult(
+            records=(
+                ev.CaseRecord(
+                    id="a", case_type="factual_number", passed=True,
+                    elapsed_seconds=1.0, infrastructure_error=True,
+                ),
+            ),
+            effective_config={},
+        )
+
+    result = ev.replay(evaluate_broken, {}, stored)
+    assert result.identical is False
+    assert result.infrastructure_errors == ("a",)

--- a/harness/tests/test_ledger.py
+++ b/harness/tests/test_ledger.py
@@ -13,6 +13,8 @@ if str(REPO_ROOT) not in sys.path:
 if str(REPO_ROOT / "src") not in sys.path:
     sys.path.insert(0, str(REPO_ROOT / "src"))
 
+import pytest
+
 from monkeygrab.config.app_config import AppConfig
 from harness import ledger, search_space
 
@@ -108,6 +110,20 @@ def test_read_history_is_sorted_by_iteration(tmp_path):
 
 def test_read_history_on_a_missing_directory_is_empty(tmp_path):
     assert ledger.read_history(tmp_path / "does_not_exist") == []
+
+
+def test_read_entry_by_iteration_returns_that_entry(tmp_path):
+    ledger.write_entry(_entry(iteration=1), ledger_dir=tmp_path)
+    ledger.write_entry(_entry(iteration=2, overrides={"retrieval.top_k_final": 4}), ledger_dir=tmp_path)
+    loaded = ledger.read_entry_by_iteration(tmp_path, 2)
+    assert loaded.iteration == 2
+    assert loaded.config_overrides == {"retrieval.top_k_final": 4}
+
+
+def test_read_entry_by_iteration_raises_when_missing(tmp_path):
+    ledger.write_entry(_entry(iteration=1), ledger_dir=tmp_path)
+    with pytest.raises(FileNotFoundError, match="iteration 9"):
+        ledger.read_entry_by_iteration(tmp_path, 9)
 
 
 def test_read_history_ignores_a_report_json_in_the_same_directory(tmp_path):


### PR DESCRIPTION
## Summary
- Criterion 7 is why the evidence ledger exists. The first real harness run (#71) proved the adapter and got 0 flips across three configs, but never reconstructed one entry and re-ran it.
- `python -m harness.cli --replay N --ledger-dir ...` loads that iteration, calls the same evaluator with its overrides and case ids, and exits 0 iff the pass/fail vector matches. Compares `passed`, not generated text (the measured noise floor).
- Demo-evaluator end-to-end test in `harness/tests/test_cli.py`. `gold_cases.jsonl` / `grade.py` / baseline untouched.

## Test plan
- [x] `pytest harness/tests` (142 passed)
- [x] `python -m ruff check` on the touched files
- [ ] CI green
- [ ] Real replay of the 2026-08-13 ledger iteration 1 (`top_k_final=4`, 32 search-set cases) against current main -- running locally
