### PR TITLE
Refuse --update-baseline when measuring more than one generator (#28)

### DIFF
--- a/tests/eval/README.md
+++ b/tests/eval/README.md
@@ -131,7 +131,9 @@ something is missing:
    exits non-zero if it dropped -- that comparison is the gate. `--update-baseline`
    additionally raises the file to `pass_rate - 0.05` (rounded down to the
    nearest 0.01) *after* the gate check, and only if that is higher than the
-   current value -- the baseline never moves down automatically.
+   current value -- the baseline never moves down automatically. It also
+   refuses more than one `--models` entry: the file holds one number,
+   calibrated on the default generator.
 
 Infrastructure failures leave the run inconclusive. Only an unfiltered gold-set
 run (`case_ids is None`, the CLI) is compared against the baseline. A subset

--- a/tests/eval/run_eval.py
+++ b/tests/eval/run_eval.py
@@ -1111,7 +1111,8 @@ def evaluate(
             pass rate minus ``BASELINE_MARGIN``, same as ``--update-baseline``
             -- only when the run is conclusive (no infrastructure errors);
             an inconclusive run leaves the baseline untouched regardless of
-            this flag, exactly like the CLI.
+            this flag, exactly like the CLI. Refuses more than one model:
+            the file holds one number, calibrated on ``DEFAULT_MODELS``.
         write_report: Write the timestamped JSON report under
             ``tests/eval/runs/``. ``False`` writes nothing to disk, so a
             caller can decide where its own evidence lives.
@@ -1140,9 +1141,18 @@ def evaluate(
             is missing. Raised before any case runs, same as the CLI.
         ValueError: ``case_ids`` names an id that is not in
             ``gold_cases.jsonl``, or ``config_overrides`` names a key
-            evaluate() cannot honour end to end.
+            evaluate() cannot honour end to end, or ``update_baseline``
+            is True with more than one model (the ratchet is one number;
+            mixing generators into it is what issue #28 exists to prevent).
     """
     run_started = time.perf_counter()
+
+    if update_baseline and len(models) != 1:
+        raise ValueError(
+            "refusing update_baseline with multiple models "
+            f"({list(models)}): the ratchet is one number and mixing "
+            "generators into it is what issue #28 exists to prevent"
+        )
 
     cases = load_gold_cases()
     if case_ids is not None:

--- a/tests/eval/test_evaluate_library_api.py
+++ b/tests/eval/test_evaluate_library_api.py
@@ -331,6 +331,27 @@ def test_update_baseline_true_raises_it_when_the_run_is_conclusive(monkeypatch, 
     assert baseline_file.read_text(encoding="utf-8").strip() != "0.10"
 
 
+def test_update_baseline_with_multiple_models_raises_before_any_work(monkeypatch):
+    """The ratchet is one number; mixing generators into it is the hole
+    issue #28 named. Fail before preflight/index so an exploratory sweep
+    cannot pollute the file by accident."""
+    ensure_calls = []
+    _capture_ensure_indexed(monkeypatch, ensure_calls)
+    seen = []
+    _capture_run_all_cases(monkeypatch, seen)
+
+    with pytest.raises(ValueError, match="multiple models"):
+        evaluate(
+            models=["gemma4:e2b", "gemma4:e4b"],
+            case_ids=[_DEV_CASE_ID],
+            write_report=False,
+            update_baseline=True,
+        )
+
+    assert ensure_calls == []
+    assert seen == []
+
+
 def test_config_overrides_reach_the_appconfig_and_ensure_indexed(monkeypatch):
     ensure_calls = []
     _capture_ensure_indexed(monkeypatch, ensure_calls)


### PR DESCRIPTION
## Summary
- `baseline_min_pass_rate.txt` is one number, calibrated on `gemma4:e2b`. `run_eval.py` already said other models must not be mixed into the same ratchet, but `--update-baseline --models a b` would have written the aggregate.
- `evaluate()` now raises `ValueError` before preflight/index when `update_baseline` is True and `len(models) != 1`. The exploratory sweep in #28 is not blocked: omit `--update-baseline`.
- `gold_cases.jsonl` / `grade.py` / the baseline file itself are untouched.

## Test plan
- [x] `test_update_baseline_with_multiple_models_raises_before_any_work` (no ensure_indexed / run_all_cases)
- [x] existing `test_update_baseline_true_raises_it_when_the_run_is_conclusive` still passes
- [x] CLI wrapper still forwards argv (it stubs `evaluate`)
- [ ] CI green
