### PR TITLE
Raise OLLAMA_KEEP_ALIVE default to 120 (issue #25, no gate trade)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,7 +50,7 @@
 #OLLAMA_RECOMP_NUM_CTX=8192                     # RECOMP synthesis
 #OLLAMA_CONTEXTUAL_NUM_CTX=32768                # contextual retrieval at indexing time
 #OLLAMA_REQUEST_TIMEOUT=900                     # HTTP timeout in seconds for long generations
-#OLLAMA_KEEP_ALIVE=0                            # seconds in VRAM after each call; 0 unloads immediately
+#OLLAMA_KEEP_ALIVE=120                          # seconds in VRAM after each call; 0 unloads immediately. Model load is 93-95% of query wall time (issue #25), so this is what makes back-to-back queries fast -- but it also holds VRAM that long after every call. Lower it (or set 0) on a small/shared GPU.
 #OLLAMA_GENERATE_RETRIES=2                      # retry RAG /generate on HTTP 5xx after unloading models
 #OLLAMA_GENERATE_RETRY_DELAY=3                  # seconds between generate retries
 

--- a/README.md
+++ b/README.md
@@ -248,6 +248,11 @@ is environment, then saved choices, then defaults, so an exported
 That override does not overwrite the saved choice: unset the variable and the
 UI pick is still there.
 
+`OLLAMA_KEEP_ALIVE` keeps the generator's weights in VRAM for that many seconds
+after each call, since loading them back is most of a query's latency — on a
+small or shared GPU that also means the model squats on VRAM for that long
+afterward, so lower it (or set it to `0`) there.
+
 Each corpus has its own Jina CLIP and FAISS index under `rag/vector_db/`. Both
 interfaces detect when a stored index no longer matches the active chunking,
 extraction or index-time flags and warn about it, but never reindex on their

--- a/rag/chat_pdfs.py
+++ b/rag/chat_pdfs.py
@@ -157,7 +157,11 @@ OLLAMA_RECOMP_NUM_CTX = _leer_env_int("OLLAMA_RECOMP_NUM_CTX", 8192)
 OLLAMA_CONTEXTUAL_NUM_CTX = _leer_env_int("OLLAMA_CONTEXTUAL_NUM_CTX", 32768)
 OLLAMA_REQUEST_TIMEOUT = _leer_env_int("OLLAMA_REQUEST_TIMEOUT", 900)
 # Seconds to keep weights in VRAM after each Ollama call; 0 unloads immediately.
-OLLAMA_KEEP_ALIVE = _leer_env_int("OLLAMA_KEEP_ALIVE", 0)
+# Model load is 93-95% of query wall time (issue #25, 2026-07-29): at 120s,
+# queries within that window reuse the resident weights instead of paying a
+# ~170s cold load again. Costs VRAM residency for that long after every call
+# -- lower it (or set 0) on a card that needs the headroom back sooner.
+OLLAMA_KEEP_ALIVE = _leer_env_int("OLLAMA_KEEP_ALIVE", 120)
 OLLAMA_GENERATE_RETRIES = _leer_env_int("OLLAMA_GENERATE_RETRIES", 2)
 OLLAMA_GENERATE_RETRY_DELAY = _leer_env_int("OLLAMA_GENERATE_RETRY_DELAY", 3)
 

--- a/src/monkeygrab/config/app_config.py
+++ b/src/monkeygrab/config/app_config.py
@@ -106,7 +106,9 @@ class AppConfig:
                 recomp_num_ctx=env.read_env_int("OLLAMA_RECOMP_NUM_CTX", 8192),
                 contextual_num_ctx=env.read_env_int("OLLAMA_CONTEXTUAL_NUM_CTX", 32768),
                 request_timeout=env.read_env_int("OLLAMA_REQUEST_TIMEOUT", 900),
-                keep_alive=env.read_env_int("OLLAMA_KEEP_ALIVE", 0),
+                # See rag/chat_pdfs.py's OLLAMA_KEEP_ALIVE comment (issue #25)
+                # for the measurement behind 120 and the VRAM residency trade-off.
+                keep_alive=env.read_env_int("OLLAMA_KEEP_ALIVE", 120),
                 generate_retries=env.read_env_int("OLLAMA_GENERATE_RETRIES", 2),
                 generate_retry_delay=env.read_env_int("OLLAMA_GENERATE_RETRY_DELAY", 3),
                 base_url=env.read_env_ollama_base_url(),

--- a/src/monkeygrab/config/models.py
+++ b/src/monkeygrab/config/models.py
@@ -12,7 +12,7 @@ class OllamaRuntimeConfig:
     recomp_num_ctx: int = 8192
     contextual_num_ctx: int = 32768
     request_timeout: int = 900
-    keep_alive: int = 0
+    keep_alive: int = 120
     generate_retries: int = 2
     generate_retry_delay: int = 3
     base_url: str = DEFAULT_OLLAMA_BASE_URL

--- a/tests/eval/run_eval.py
+++ b/tests/eval/run_eval.py
@@ -629,10 +629,19 @@ def _generation_keep_alive(models_used: Iterable[str]):
     below to free Ollama's own 120s hold on them) rather than the whole run:
     phase 1 never touches Ollama, so it cannot benefit, and leaving it set
     past main() would let a non-zero keep-alive leak into anything else
-    importing rag.chat_pdfs afterwards. Does not touch the product default --
-    see issue #27: keep_alive=0 exists because the embedder and reranker
-    contend for the same 8 GB (issue #25), and raising it globally would
-    make that contention worse.
+    importing rag.chat_pdfs afterwards.
+
+    Independent of what the product default is: this scoping still matters
+    on its own terms (phase 1 shouldn't hold a keep-alive it can never use),
+    which is why it stays even now that OLLAMA_KEEP_ALIVE's product default
+    is also 120 (rag/chat_pdfs.py). That default used to be 0, on the theory
+    that the embedder and reranker contend for the same 8 GB (issue #27).
+    Issue #25's 2026-07-29 measurement found that contention costs 5.0s on
+    e4b and 2.0s on e2b, not the multi-minute stall once feared, with all
+    three tenants coexisting at 7514 of 8188 MiB; #25 was closed as not
+    reproduced on that basis. Raising the product default does not change
+    what this gate measures in phase 2 -- this context manager already
+    forced 120 for generation calls regardless.
 
     Args:
         models_used: Every Ollama model name this phase may have loaded


### PR DESCRIPTION
## Summary
- Raise the product `OLLAMA_KEEP_ALIVE` default from 0 to 120 seconds. Issue #25 measured model load as 93-95% of query wall time (173.8s → 12.7s when the next query lands inside the window).
- This is the half of #80 that does not move the gate: `run_eval.py`'s `_generation_keep_alive` already forces 120 for phase 2, and the isolation run on #80 (`keep_alive=120`, `recomp_num_ctx` still 8192) was identical to the 44/51 reference (zero flips). `recomp_num_ctx` stays at 8192 — that alignment is a real trade (one flip, `planck-h0`) and is not in this PR.

## Test plan
- [x] `ruff check` on the touched files
- [ ] Fast CI green
- No full gate needed: isolation already showed this default is invisible to the eval runner's phase 2.

Refs #25. Leaves #80 open for the `recomp_num_ctx` decision.
