### PR TITLE
Drop closed-issue leftovers from the README and record the first real harness run

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,10 +281,9 @@ language stores — English, Castellano, Valencià — map to `rag/docs/{en,es,c
 
 The **desktop app** wraps the web interface in a Windows executable with
 [PyInstaller](https://pyinstaller.org/) and [pywebview](https://pywebview.flowrl.com/).
-It needs the isolated MinerU/Jina runtime beside the executable, and the
-packaged build cannot start that worker yet even when the runtime is present
-([#26](https://github.com/iDiagoValeta/localOllamaRAG/issues/26)); use the CLI
-or web app in the meantime. See [`packaging/README.md`](packaging/README.md).
+It needs the isolated MinerU/Jina runtime (`.venv-mineru`) beside the
+executable; without it, indexing and retrieval fail visibly. The jina-clip
+worker ships inside the bundle. See [`packaging/README.md`](packaging/README.md).
 
 ---
 
@@ -297,9 +296,6 @@ or web app in the meantime. See [`packaging/README.md`](packaging/README.md).
 > - **The reranker downloads its model on first use**, a one-time step that needs internet. Everything after runs offline; turn reranking off if you need a fully air-gapped first run.
 > - **Optional stages fail loudly.** If an enabled stage cannot run, the query raises instead of silently returning worse results. Turn the stage off to proceed without it.
 > - **Indexing cost** grows with corpus size, contextual enrichment and the number of extracted images.
-> - **Concurrent web requests can disable the embedder.** Two overlapping queries can desynchronize the Jina CLIP worker's protocol, which permanently disables it until the process restarts ([#24](https://github.com/iDiagoValeta/localOllamaRAG/issues/24)).
-> - **VRAM from the embedder and reranker is not freed before generation.** On memory-constrained GPUs this can make Ollama hang for minutes instead of failing fast ([#25](https://github.com/iDiagoValeta/localOllamaRAG/issues/25)).
-> - **The packaged desktop build cannot start the multimodal worker yet.** Indexing and retrieval fail even with the isolated runtime present ([#26](https://github.com/iDiagoValeta/localOllamaRAG/issues/26)).
 
 ---
 
@@ -318,6 +314,7 @@ retrieval or generation, because the fast gate never exercises a real model.
 ```bash
 pytest                                              # full suite, no GPU required
 python tests/eval/run_eval.py --models <model...>   # full gate; needs Ollama + GPU
+python -m harness.cli --dry-run --max-iterations 3  # config-search wiring; see harness/README.md
 ```
 
 Tests are split by what they protect:

--- a/harness/README.md
+++ b/harness/README.md
@@ -64,12 +64,12 @@ searches without a red test.
 > **The design's original evaluation-time estimate was wrong by a factor of
 > ~6.** Section 4 assumed ~2.8 h/candidate (three or four candidates a
 > night); issue #27's keep-alive fix removed a per-case cold model load
-> that estimate baked in. A full search-set evaluation (32 cases) now costs
-> ~13 min, measured 2026-08-12 against
-> `tests/eval/runs/20260812T194812Z_mineru-jina_clip-faiss.json` (local,
-> gitignored) — a night now fits dozens of candidates, not three or four.
-> This does not change anything about how the space is declared (see
-> above); it does change the case for the LLM proposer, see "Proposers"
+> that estimate baked in. A full search-set evaluation (32 cases) cost
+> ~13 min on 2026-08-12 (before the gate wired query decomposition) and
+> **~20 min** on 2026-08-19 with the product decomposer on — local
+> gitignored artefacts under `tests/eval/runs/`. A night still fits many
+> candidates, not three or four. This does not change how the space is
+> declared; it does change the case for the LLM proposer, see "Proposers"
 > below.
 
 **Index-time keys are excluded and the exclusion is enforced,** not
@@ -379,7 +379,19 @@ boundary checks.
 > `harness/tests/test_criterion5_simulated.py` proves the **search logic**
 > recovers from a deliberately worsened point in a synthetic, fully
 > controlled landscape — for both proposers. It does **not** prove the real
-> pipeline improves. The real criterion-5 run (design doc §2) still needs
-> the GPU and Ollama — now at ~13 min/full-search-set-evaluation rather than
-> the ~2.8 h originally assumed (see "The declared search space" above) —
-> and is pending measurement; nothing in this PR claims it ran.
+> pipeline improves.
+>
+> **Field, 2026-08-19.** First real `GridProposer` loop from healthy
+> defaults (`tests/eval/runs/harness-loop/`, gitignored): 3 iterations
+> (`top_k_final` 4, 6, 12), all `rejected_no_gain`, ratchet 27/32, stopped
+> on `max_iterations`. `top_k_final=12` won `planck-contours-figure` and
+> lost `planck-h0` — net zero. The `resolution_warning` still applies:
+> an accepted improvement on today's search set is a candidate, not a
+> demonstrated result (#30).
+>
+> Criterion 5 on the real pipeline was started the same day
+> (`RAG_TOP_K_FINAL=1`, ledger `tests/eval/runs/harness-loop-c5/`) and
+> aborted after iteration 1. Sabotaged reference: **24/32**. First
+> proposal `top_k_final=4` was `rejected_regression` on the fast tier
+> (`planck-sigma8-es` — the sabotaged reference had passed it). Resume
+> from that ledger; do not delete it. Resume: issue #89.


### PR DESCRIPTION
## Summary
- Root README no longer lists #24, #25 and #26 as live product bugs (#24/#26 are fixed; #25 was closed as not reproduced). Desktop blurb matches the shipped jina-clip worker layout.
- `harness/README.md` records the 2026-08-19 grid loop (ratchet 27/32, no accept) and the aborted criterion-5 run (`RAG_TOP_K_FINAL=1`, iter 1 `rejected_regression`). Resume is #89.

## Test plan
- [ ] Fast CI (lint, architecture, unit, frontend)
- [ ] Skim Known limitations: no links to closed #24/#25/#26 as if they were still open
- [ ] `python -m harness.cli --dry-run --max-iterations 1` still prints usage from the Development section command
