### PR TITLE
Pair regressions against the ledger's earned high water in recovery mode (#92)

### DIFF
--- a/docs/design/2026-07-28-loop-automejorable.md
+++ b/docs/design/2026-07-28-loop-automejorable.md
@@ -517,6 +517,32 @@ Adoptados por defecto; cualquiera es revisable.
   a 4,8 s, ambas holgadamente dentro del 20 %, mientras la recuperación se
   desplomaba. Cada bucket se compara contra su propio techo y basta con que uno
   lo incumpla para descalificar al candidato.
+
+> [!IMPORTANT]
+> **Recuperación contra referencia degradada (decisión del 2026-08-23,
+> issue #92).** El emparejamiento de regresiones contra la referencia del
+> propio run es correcto mientras la referencia sea sana; pero el criterio 5
+> arranca con una referencia saboteada a propósito, y medido en el pipeline
+> real (2026-08-22, issue #89) el sabotaje k=1 tuvo la suerte de pasar
+> `planck-sigma8-es`, caso que toda configuración sana falla. Ese pase de
+> suerte hizo que el filtro de regresión del nivel rápido rechazara a todos
+> los candidatos que restauraban el comportamiento sano: recuperar es fallar
+> de nuevo el caso con el que el sabotaje tuvo fortuna. Decisión: cuando el
+> libro de evidencias contiene un estado **comparable** (mismos modelos,
+> troceado y flags de indexado; ver `_comparable_config_view`) con objetivo
+> estrictamente mayor que la referencia actual, el arnés arranca en **modo
+> recuperación** y las dos comprobaciones de regresión se emparejan contra el
+> vector de pases de esa marca de agua histórica en vez de contra la
+> referencia degradada. Perder un caso que sólo pasó la referencia degradada
+> no es perder terreno ganado. Dos propiedades quedan fijadas: el ratchet
+> sigue arrancando en el objetivo de la referencia, así que aceptar exige
+> superarla; y la latencia sigue emparejada contra la referencia del run,
+> porque es presupuesto duro y no calidad ganada. Sin historia comparable el
+> comportamiento es exactamente el de antes: el límite queda documentado como
+> límite, no se adivina una salida. Procedencia: cada entrada puntuada
+> registra en `regression_baseline_iteration` (schema v2) contra qué iteración
+> del libro se emparejó. Implementación: `harness/loop.py`
+> (`_historical_high_water`, `_comparable_config_view`).
 - **Terminación:** presupuesto de iteraciones, o parada tras varias iteraciones
   seguidas sin superar el suelo de ruido.
 - **Comparación pareada** sobre los mismos casos, nunca entre tasas de runs

--- a/harness/README.md
+++ b/harness/README.md
@@ -401,7 +401,40 @@ boundary checks.
 > the sabotage lucked into it. A paired fast-tier regression check measured
 > against a degraded reference therefore rejects every candidate that restores
 > healthy behaviour, because recovery re-fails the case the sabotage
-> coincidentally fixed. Stage-1 recovery from this sabotage is unreachable on
+> coincidentally fixed. Stage-1 recovery from this sabotage was unreachable on
 > today's search set regardless of proposer. Recorded per issue #89's
-> instruction ("record it, do not weaken `grade.py`"); the loop-level design
-> question this raises is tracked as issue #92.
+> instruction ("record it, do not weaken `grade.py`").
+
+## Recovery mode (issue #92, decided 2026-08-23)
+
+The field note above was the design question; this is the decision, now in
+`loop.py`. When the ledger's prior history contains a **comparable** state
+(`_comparable_config_view`: same model roles, chunking and index-time flags;
+retrieval knobs are excluded because they are exactly what candidates vary)
+whose objective strictly exceeds the in-run reference's, the loop starts in
+**recovery mode**: both regression checks pair against that high-water entry's
+per-case pass vector instead of the degraded reference. Losing a case only a
+degraded reference passed is not losing ground anyone earned.
+
+Fixed alongside:
+
+- The ratchet still starts at the degraded reference's objective — acceptance
+  still requires beating it, so "recovery" means climbing back past health,
+  not rubber-stamping it.
+- Latency stays paired against the in-run reference: a budget, not an earned
+  quality. (Residual limit, documented rather than solved: a sabotage that
+  *slowed* the reference would tighten the ceiling for recovery candidates;
+  no measured sabotage does.)
+- Without comparable history the behaviour is unchanged — the limit stands as
+  a documented limit, not a guessed way around.
+- Provenance: every scored entry records `regression_baseline_iteration`
+  (ledger schema v2; v1 entries read as `None` = paired against the run's own
+  reference), and every report carries a `recovery_mode` block with the
+  baseline iteration, its objective, and how many history entries were
+  eligible.
+- The high water is computed once at start from PRIOR history only; entries
+  written by the current campaign never move the pairing baseline mid-run.
+- Workflow note: because the ledger is meant to span campaigns (see "Running
+  it"), a healthy campaign's entries are what makes a later sabotaged run
+  recoverable. Pointing a criterion-5 campaign at the same `--ledger-dir` as
+  its healthy sibling is what arms recovery mode.

--- a/harness/ledger.py
+++ b/harness/ledger.py
@@ -24,7 +24,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 
 LEDGER_DIR = Path(__file__).resolve().parent / "ledger"
 INDEX_FILE_NAME = "index.jsonl"
@@ -39,7 +39,13 @@ INDEX_FILE_NAME = "index.jsonl"
 # after one real run.
 _ENTRY_FILENAME_RE = re.compile(r"^\d{4}_.*\.json$")
 
-VERDICTS = ("accepted", "rejected_regression", "rejected_latency", "rejected_no_gain", "inconclusive")
+VERDICTS = (
+    "accepted",
+    "rejected_regression",
+    "rejected_latency",
+    "rejected_no_gain",
+    "inconclusive",
+)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -96,6 +102,15 @@ class LedgerEntry:
         reason: Human-readable explanation (which cases regressed, which
             bucket breached the ceiling and by how much, or the gain over the
             ratchet).
+        regression_baseline_iteration: The ledger iteration whose per-case
+            pass vector regressions were paired against, or ``None`` when
+            that was the in-run reference itself (schema v2; absent in v1
+            files, where it is always ``None``). Set to the high-water
+            entry's iteration when the loop ran in recovery mode -- issue
+            #92: against a degraded reference, pairing against the reference
+            would reject every candidate that restores healthy behaviour,
+            because the sabotage can luck into passing a case the healthy
+            pipeline fails. See ``loop._historical_high_water``.
     """
 
     schema_version: int
@@ -121,6 +136,7 @@ class LedgerEntry:
     latency_ceiling_multiplier: float
     verdict: str
     reason: str
+    regression_baseline_iteration: Optional[int] = None
 
     def to_dict(self) -> Dict[str, Any]:
         return dataclasses.asdict(self)
@@ -261,16 +277,21 @@ def write_entry(entry: LedgerEntry, ledger_dir: Path = LEDGER_DIR) -> Path:
     ledger_dir.mkdir(parents=True, exist_ok=True)
     timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     entry_path = ledger_dir / f"{entry.iteration:04d}_{timestamp}.json"
-    entry_path.write_text(json.dumps(entry.to_dict(), indent=2, ensure_ascii=False), encoding="utf-8")
+    entry_path.write_text(
+        json.dumps(entry.to_dict(), indent=2, ensure_ascii=False), encoding="utf-8"
+    )
 
-    index_line = json.dumps({
-        "iteration": entry.iteration,
-        "parent_iteration": entry.parent_iteration,
-        "proposer": entry.proposer,
-        "verdict": entry.verdict,
-        "objective_adjusted": entry.objective_adjusted,
-        "entry_file": entry_path.name,
-    }, ensure_ascii=False)
+    index_line = json.dumps(
+        {
+            "iteration": entry.iteration,
+            "parent_iteration": entry.parent_iteration,
+            "proposer": entry.proposer,
+            "verdict": entry.verdict,
+            "objective_adjusted": entry.objective_adjusted,
+            "entry_file": entry_path.name,
+        },
+        ensure_ascii=False,
+    )
     with (ledger_dir / INDEX_FILE_NAME).open("a", encoding="utf-8") as fh:
         fh.write(index_line + "\n")
 
@@ -305,6 +326,4 @@ def read_entry_by_iteration(ledger_dir: Path, iteration: int) -> LedgerEntry:
     for entry in read_history(ledger_dir):
         if entry.iteration == iteration:
             return entry
-    raise FileNotFoundError(
-        f"no ledger entry for iteration {iteration} under {ledger_dir}"
-    )
+    raise FileNotFoundError(f"no ledger entry for iteration {iteration} under {ledger_dir}")

--- a/harness/loop.py
+++ b/harness/loop.py
@@ -35,19 +35,38 @@ full numbers and why they cannot be re-derived from a fresh clone):
    catch a regression) -- this check runs over all ~9 retrieval-only ids in
    the full search set instead.
 4. **A ``inconclusive`` verdict when any record carries
-   ``infrastructure_error``.** ``tests/eval/run_eval.py`` marks a case this
-   way when it could not be evaluated at all (dead/overloaded Ollama, a
-   retrieval exception) and refuses to compare such a run against the
-   baseline ("this run measured nothing" -- see ``run_eval.main``). Reading
-   those records as ordinary failures would let a dead Ollama read as a
-   quality collapse (fast tier: a good candidate wrongly
-   ``rejected_regression``) or an artificially low reference silently
-   inflate every later candidate into a false ``accepted`` -- exactly the
-   "loop sobre una medida que miente produce basura reproducible" failure
-   the design doc opens with. The reference measurement itself gets no
-   verdict to fall back on: if it carries an infrastructure error,
-   ``run_loop`` raises before entering the loop at all, since no ratchet
-   baseline can be trusted.
+    ``infrastructure_error``.** ``tests/eval/run_eval.py`` marks a case this
+    way when it could not be evaluated at all (dead/overloaded Ollama, a
+    retrieval exception) and refuses to compare such a run against the
+    baseline ("this run measured nothing" -- see ``run_eval.main``). Reading
+    those records as ordinary failures would let a dead Ollama read as a
+    quality collapse (fast tier: a good candidate wrongly
+    ``rejected_regression``) or an artificially low reference silently
+    inflate every later candidate into a false ``accepted`` -- exactly the
+    "loop sobre una medida que miente produce basura reproducible" failure
+    the design doc opens with. The reference measurement itself gets no
+    verdict to fall back on: if it carries an infrastructure error,
+    ``run_loop`` raises before entering the loop at all, since no ratchet
+    baseline can be trusted.
+5. **Recovery mode (issue #92): regressions pair against earned passes, not
+    lucky ones.** The regression filters compare a candidate against the
+    in-run reference -- correct while that reference is healthy, but against
+    a deliberately worsened one (criterion 5's setup) it blocks recovery:
+    measured on the real pipeline 2026-08-22, the ``RAG_TOP_K_FINAL=1``
+    sabotage lucked into passing ``planck-sigma8-es``, a case every healthy
+    configuration fails, so every recovery candidate was
+    ``rejected_regression`` at the fast tier for re-failing exactly that
+    case. When the ledger's prior history contains a *comparable* state
+    (same models, chunking and index-time flags -- see
+    ``_comparable_config_view``) with a strictly higher objective than the
+    in-run reference, the loop starts in recovery mode and pairs both
+    regression checks against that high-water state's per-case pass vector
+    instead: losing a case only a degraded reference passed is not losing
+    ground anyone ever earned. The ratchet itself still starts at the
+    degraded reference's objective, so acceptance still requires beating
+    it; latency stays paired against the in-run reference (a hard budget,
+    not an earned quality). With no comparable history the loop behaves
+    exactly as before -- recovery mode is unavailable then, not guessed.
 
 **Scope, stated plainly (not fixed by this PR): stage 1 is a single-field
 sweep from a fixed reference, not a compounding hill climb.**
@@ -107,7 +126,9 @@ LATENCY_CEILING_MULTIPLIER = 1.20
 SEARCH_SET_AVAILABLE_FAILURES = 5
 DEMONSTRABILITY_FLIP_THRESHOLD = 6
 SEARCH_SET_NET_FLIPS_UNDER_KNOWN_SABOTAGE = 3
-SEARCH_SET_SABOTAGE_DESCRIPTION = "RAG_TOP_K_FINAL=1 (single fragment retrieved; criterion 2, 2026-07-29)"
+SEARCH_SET_SABOTAGE_DESCRIPTION = (
+    "RAG_TOP_K_FINAL=1 (single fragment retrieved; criterion 2, 2026-07-29)"
+)
 
 RESOLUTION_WARNING: Dict[str, Any] = {
     "available_search_set_failures": SEARCH_SET_AVAILABLE_FAILURES,
@@ -162,37 +183,107 @@ def _has_infrastructure_error(records: Sequence[evaluator_mod.CaseRecord]) -> bo
 
 
 def _regressed_ids(
-    reference_records: Sequence[evaluator_mod.CaseRecord],
+    reference_passed_by_id: Dict[str, bool],
     candidate_records: Sequence[evaluator_mod.CaseRecord],
 ) -> List[str]:
-    """Case ids that passed for the reference and failed for the candidate (paired)."""
-    reference_passed = {r.id: r.passed for r in reference_records}
-    return [r.id for r in candidate_records if reference_passed.get(r.id) and not r.passed]
+    """Case ids that passed for the pairing baseline and failed for the candidate (paired).
+
+    ``reference_passed_by_id`` is normally the in-run reference's fast-tier
+    pass vector; in recovery mode it is the high-water entry's instead
+    (module docstring point 5, issue #92).
+    """
+    return [r.id for r in candidate_records if reference_passed_by_id.get(r.id) and not r.passed]
 
 
 def _retrieval_only_net_change(
-    reference_records: Sequence[evaluator_mod.CaseRecord],
+    reference_passed_by_id: Dict[str, bool],
     candidate_records: Sequence[evaluator_mod.CaseRecord],
 ) -> int:
-    """Net change (candidate minus reference) in retrieval-only passing count, paired by id.
+    """Net change (candidate minus baseline) in retrieval-only passing count, paired by id.
 
-    Positive: more retrieval-only cases pass than in the reference. Negative:
+    Positive: more retrieval-only cases pass than in the baseline. Negative:
     fewer do -- what ``run_loop`` refuses to accept regardless of the
-    blended objective (see module docstring point 3).
+    blended objective (see module docstring point 3). The baseline map comes
+    from the in-run reference records, or from the high-water entry while in
+    recovery mode (point 5).
     """
-    reference_passed = {
-        r.id: r.passed for r in reference_records if r.case_type in evaluator_mod.RETRIEVAL_ONLY_CASE_TYPES
-    }
     net = 0
     for r in candidate_records:
         if r.case_type not in evaluator_mod.RETRIEVAL_ONLY_CASE_TYPES:
             continue
-        was_passing = reference_passed.get(r.id, False)
+        was_passing = bool(reference_passed_by_id.get(r.id, False))
         if r.passed and not was_passing:
             net += 1
         elif not r.passed and was_passing:
             net -= 1
     return net
+
+
+def _passed_by_id(records: Sequence[evaluator_mod.CaseRecord]) -> Dict[str, bool]:
+    return {r.id: r.passed for r in records}
+
+
+def _passed_by_id_from_dicts(case_records: Sequence[Dict[str, Any]]) -> Dict[str, bool]:
+    return {r["id"]: bool(r["passed"]) for r in case_records}
+
+
+# RECOVERY MODE (issue #92): what makes two ledger entries comparable.
+
+# Index-time flags decide stored chunk text; retrieval/generation flags are
+# what candidates vary by design and must never affect comparability. Model
+# roles matter (a different generator answers differently); Ollama runtime
+# knobs (num_ctx, timeouts, keep-alive) do not decide case outcomes.
+_INDEX_TIME_FLAG_KEYS = (
+    "usar_contextual_retrieval",
+    "usar_embeddings_imagen",
+    "usar_descripcion_imagen",
+)
+_MODEL_ROLE_KEYS = ("rag", "chat", "contextual", "recomp")
+
+
+def _comparable_config_view(effective_config: Dict[str, Any]) -> Dict[str, Any]:
+    """Reduce an entry's effective config to what decides per-case outcomes.
+
+    Two entries are comparable when this view matches: same models, same
+    chunking, same index-time flags. Everything a proposer searches
+    (retrieval fan-out, fusion weights, reranker threshold) is deliberately
+    excluded -- those differences between historical entries are exactly the
+    evidence recovery mode needs. Test doubles may carry partial configs;
+    missing sections read as ``None`` and compare like-for-like.
+    """
+    models = effective_config.get("models") or {}
+    flags = effective_config.get("flags") or {}
+    return {
+        "models": {key: models.get(key) for key in _MODEL_ROLE_KEYS},
+        "chunking": effective_config.get("chunking"),
+        "index_time_flags": {key: flags.get(key) for key in _INDEX_TIME_FLAG_KEYS},
+    }
+
+
+def _historical_high_water(
+    entries: Sequence[ledger_mod.LedgerEntry],
+    comparable_view: Dict[str, Any],
+) -> Optional[ledger_mod.LedgerEntry]:
+    """The best comparable search-set state in prior ledger history, or ``None``.
+
+    Only complete, non-``inconclusive`` search-set evaluations count: a
+    fast-tier-rejected entry has no full pass vector, and an inconclusive one
+    may be measuring a dead Ollama rather than quality. Ties resolve to the
+    latest iteration so repeated measurements of one configuration converge.
+    Computed once at loop start from PRIOR history only -- entries written by
+    the current run never move the pairing baseline mid-campaign.
+    """
+    best: Optional[ledger_mod.LedgerEntry] = None
+    for entry in entries:
+        if entry.evaluated_case_set != "search_set":
+            continue
+        if entry.verdict == "inconclusive":
+            continue
+        if _comparable_config_view(entry.effective_config) != comparable_view:
+            continue
+        if best is None or entry.objective_adjusted >= best.objective_adjusted:
+            best = entry
+    return best
 
 
 def _latency_breach(
@@ -227,8 +318,39 @@ def _build_entry(
     verdict: str,
     reason: str,
     candidate_latency: Optional[Dict[str, Optional[float]]] = None,
+    regression_baseline_iteration: Optional[int] = None,
 ) -> ledger_mod.LedgerEntry:
-    objective_raw, objective_adjusted = evaluator_mod.compute_objective(result.records, unreachable_ids)
+    objective_raw, objective_adjusted = evaluator_mod.compute_objective(
+        result.records, unreachable_ids
+    )
+    if candidate_latency is None:
+        candidate_latency = evaluator_mod.median_latency_by_bucket(result.records)
+    return ledger_mod.LedgerEntry(
+        schema_version=ledger_mod.SCHEMA_VERSION,
+        iteration=iteration,
+        parent_iteration=parent_iteration,
+        git_commit=git_commit,
+        config_overrides=dict(overrides),
+        effective_config=dict(result.effective_config),
+        proposer=meta.get("proposer", "unknown"),
+        proposer_rationale=meta.get("rationale"),
+        proposer_model=meta.get("model"),
+        proposer_fallback=bool(meta.get("fallback", False)),
+        proposer_fallback_reason=meta.get("fallback_reason"),
+        evaluated_case_set=evaluated_case_set,
+        case_records=[dataclasses.asdict(r) for r in result.records],
+        summary=_summary(result.records),
+        objective_raw=objective_raw,
+        objective_adjusted=objective_adjusted,
+        median_latency_answered_s=candidate_latency.get("answered"),
+        median_latency_retrieval_only_s=candidate_latency.get("retrieval_only"),
+        reference_median_latency_answered_s=reference_latency.get("answered"),
+        reference_median_latency_retrieval_only_s=reference_latency.get("retrieval_only"),
+        latency_ceiling_multiplier=LATENCY_CEILING_MULTIPLIER,
+        verdict=verdict,
+        reason=reason,
+        regression_baseline_iteration=regression_baseline_iteration,
+    )
     if candidate_latency is None:
         candidate_latency = evaluator_mod.median_latency_by_bucket(result.records)
     return ledger_mod.LedgerEntry(
@@ -325,7 +447,9 @@ def run_loop(
 
     reference_full = evaluate({}, tuple(search_set_ids))
     reference_fast = evaluate({}, tuple(fast_tier_ids))
-    if _has_infrastructure_error(reference_full.records) or _has_infrastructure_error(reference_fast.records):
+    if _has_infrastructure_error(reference_full.records) or _has_infrastructure_error(
+        reference_fast.records
+    ):
         raise evaluator_mod.InconclusiveEvaluationError(
             "reference evaluation carries at least one infrastructure_error record -- "
             "no ratchet baseline can be trusted; fix Ollama/the index and retry"
@@ -335,12 +459,43 @@ def run_loop(
     )
     reference_latency = evaluator_mod.median_latency_by_bucket(reference_full.records)
 
-    ratchet = reference_objective_adjusted
-    best_iteration: Optional[int] = None
-
     entries_so_far: List[ledger_mod.LedgerEntry] = list(ledger_mod.read_history(ledger_dir))
     iteration = ledger_mod.next_iteration_number(ledger_dir)
     parent_iteration: Optional[int] = entries_so_far[-1].iteration if entries_so_far else None
+
+    # Recovery mode (issue #92): when prior comparable history measured a
+    # strictly better state than the in-run reference, the reference is
+    # degraded, so regression pairing switches to the high-water pass
+    # vector. Frozen here from PRIOR history; this run's own entries never
+    # move it mid-campaign.
+    high_water = _historical_high_water(
+        entries_so_far, _comparable_config_view(dataclasses.asdict(reference))
+    )
+    if high_water is not None and high_water.objective_adjusted > reference_objective_adjusted:
+        recovery_mode = True
+        # The high-water entry carries the full search-set pass vector, which
+        # covers every fast-tier id (the fast tier is a search-set subset).
+        recovery_pass_vector = _passed_by_id_from_dicts(high_water.case_records)
+        fast_regression_baseline = recovery_pass_vector
+        search_regression_baseline = recovery_pass_vector
+        recovery_baseline_iteration: Optional[int] = high_water.iteration
+        eligible_history_entries = sum(
+            1
+            for e in entries_so_far
+            if e.evaluated_case_set == "search_set"
+            and e.verdict != "inconclusive"
+            and _comparable_config_view(e.effective_config)
+            == _comparable_config_view(dataclasses.asdict(reference))
+        )
+    else:
+        recovery_mode = False
+        fast_regression_baseline = _passed_by_id(reference_fast.records)
+        search_regression_baseline = _passed_by_id(reference_full.records)
+        recovery_baseline_iteration = None
+        eligible_history_entries = 0
+
+    ratchet = reference_objective_adjusted
+    best_iteration: Optional[int] = None
 
     consecutive_non_accepted = 0
     iterations_run = 0
@@ -369,22 +524,40 @@ def run_loop(
 
         if _has_infrastructure_error(fast_result.records):
             entry = _build_entry(
-                iteration=iteration, parent_iteration=parent_iteration, git_commit=git_commit,
-                overrides=overrides, meta=meta, evaluated_case_set="fast_tier",
-                result=fast_result, unreachable_ids=unreachable_ids,
-                reference_latency=reference_latency, verdict="inconclusive",
+                iteration=iteration,
+                parent_iteration=parent_iteration,
+                git_commit=git_commit,
+                overrides=overrides,
+                meta=meta,
+                evaluated_case_set="fast_tier",
+                result=fast_result,
+                unreachable_ids=unreachable_ids,
+                reference_latency=reference_latency,
+                verdict="inconclusive",
                 reason="fast-tier evaluation carries infrastructure_error record(s) -- not scored",
             )
         else:
-            regressed = _regressed_ids(reference_fast.records, fast_result.records)
+            regressed = _regressed_ids(fast_regression_baseline, fast_result.records)
 
             if regressed:
+                baseline_note = (
+                    f" (paired against high-water iteration {recovery_baseline_iteration})"
+                    if recovery_mode
+                    else ""
+                )
                 entry = _build_entry(
-                    iteration=iteration, parent_iteration=parent_iteration, git_commit=git_commit,
-                    overrides=overrides, meta=meta, evaluated_case_set="fast_tier",
-                    result=fast_result, unreachable_ids=unreachable_ids,
-                    reference_latency=reference_latency, verdict="rejected_regression",
-                    reason=f"fast-tier regression on {regressed}",
+                    iteration=iteration,
+                    parent_iteration=parent_iteration,
+                    git_commit=git_commit,
+                    overrides=overrides,
+                    meta=meta,
+                    evaluated_case_set="fast_tier",
+                    result=fast_result,
+                    unreachable_ids=unreachable_ids,
+                    reference_latency=reference_latency,
+                    verdict="rejected_regression",
+                    reason=f"fast-tier regression on {regressed}{baseline_note}",
+                    regression_baseline_iteration=recovery_baseline_iteration,
                 )
             else:
                 full_result = evaluate(overrides, tuple(search_set_ids))
@@ -392,16 +565,24 @@ def run_loop(
 
                 if _has_infrastructure_error(full_result.records):
                     entry = _build_entry(
-                        iteration=iteration, parent_iteration=parent_iteration, git_commit=git_commit,
-                        overrides=overrides, meta=meta, evaluated_case_set="search_set",
-                        result=full_result, unreachable_ids=unreachable_ids,
-                        reference_latency=reference_latency, verdict="inconclusive",
+                        iteration=iteration,
+                        parent_iteration=parent_iteration,
+                        git_commit=git_commit,
+                        overrides=overrides,
+                        meta=meta,
+                        evaluated_case_set="search_set",
+                        result=full_result,
+                        unreachable_ids=unreachable_ids,
+                        reference_latency=reference_latency,
+                        verdict="inconclusive",
                         reason="search-set evaluation carries infrastructure_error record(s) -- not scored",
                     )
                 else:
                     candidate_latency = evaluator_mod.median_latency_by_bucket(full_result.records)
                     breach = _latency_breach(candidate_latency, reference_latency)
-                    retrieval_net = _retrieval_only_net_change(reference_full.records, full_result.records)
+                    retrieval_net = _retrieval_only_net_change(
+                        search_regression_baseline, full_result.records
+                    )
                     _objective_raw, objective_adjusted = evaluator_mod.compute_objective(
                         full_result.records, unreachable_ids
                     )
@@ -410,7 +591,12 @@ def run_loop(
                         verdict, reason = "rejected_latency", breach
                     elif retrieval_net < 0:
                         verdict = "rejected_regression"
-                        reason = f"retrieval-only bucket lost cases net vs reference ({retrieval_net:+d})"
+                        baseline_note = (
+                            f" vs high-water iteration {recovery_baseline_iteration}"
+                            if recovery_mode
+                            else " vs reference"
+                        )
+                        reason = f"retrieval-only bucket lost cases net{baseline_note} ({retrieval_net:+d})"
                     elif objective_adjusted - ratchet <= NOISE_FLOOR_CASES:
                         verdict = "rejected_no_gain"
                         reason = (
@@ -419,23 +605,38 @@ def run_loop(
                         )
                     else:
                         verdict = "accepted"
-                        reason = f"objective_adjusted {objective_adjusted} exceeds ratchet {ratchet}"
+                        reason = (
+                            f"objective_adjusted {objective_adjusted} exceeds ratchet {ratchet}"
+                        )
                         ratchet = objective_adjusted
                         best_iteration = iteration
 
                     entry = _build_entry(
-                        iteration=iteration, parent_iteration=parent_iteration, git_commit=git_commit,
-                        overrides=overrides, meta=meta, evaluated_case_set="search_set",
-                        result=full_result, unreachable_ids=unreachable_ids,
-                        reference_latency=reference_latency, verdict=verdict, reason=reason,
+                        iteration=iteration,
+                        parent_iteration=parent_iteration,
+                        git_commit=git_commit,
+                        overrides=overrides,
+                        meta=meta,
+                        evaluated_case_set="search_set",
+                        result=full_result,
+                        unreachable_ids=unreachable_ids,
+                        reference_latency=reference_latency,
+                        verdict=verdict,
+                        reason=reason,
                         candidate_latency=candidate_latency,
+                        # Provenance on every SCORED entry, accepted ones
+                        # included: which pass vector the regression checks
+                        # paired against is part of the evidence.
+                        regression_baseline_iteration=recovery_baseline_iteration,
                     )
 
         ledger_mod.write_entry(entry, ledger_dir)
         entries_so_far.append(entry)
         new_entries.append(entry)
 
-        consecutive_non_accepted = 0 if entry.verdict == "accepted" else consecutive_non_accepted + 1
+        consecutive_non_accepted = (
+            0 if entry.verdict == "accepted" else consecutive_non_accepted + 1
+        )
         parent_iteration = entry.iteration
         iteration += 1
         iterations_run += 1
@@ -452,6 +653,16 @@ def run_loop(
         "best_iteration": best_iteration,
         "iterations_run": iterations_run,
         "termination_reason": termination_reason,
+        "recovery_mode": {
+            # Issue #92: whether regression pairing ran against the ledger's
+            # historical high-water state instead of the in-run reference.
+            "active": recovery_mode,
+            "baseline_iteration": recovery_baseline_iteration,
+            "baseline_objective_adjusted": (
+                high_water.objective_adjusted if recovery_mode and high_water is not None else None
+            ),
+            "eligible_history_entries": eligible_history_entries,
+        },
         "resolution_warning": RESOLUTION_WARNING,
         "iterations": [e.to_dict() for e in new_entries],
     }

--- a/harness/tests/test_ledger.py
+++ b/harness/tests/test_ledger.py
@@ -34,7 +34,9 @@ def _entry(iteration=1, overrides=None, effective_config=None, verdict="accepted
         proposer_fallback=False,
         proposer_fallback_reason=None,
         evaluated_case_set="search_set",
-        case_records=[{"id": "a", "case_type": "factual_number", "passed": True, "elapsed_seconds": 1.0}],
+        case_records=[
+            {"id": "a", "case_type": "factual_number", "passed": True, "elapsed_seconds": 1.0}
+        ],
         summary={"total": 1, "passed": 1, "pass_rate": 1.0},
         objective_raw=1,
         objective_adjusted=1,
@@ -114,7 +116,9 @@ def test_read_history_on_a_missing_directory_is_empty(tmp_path):
 
 def test_read_entry_by_iteration_returns_that_entry(tmp_path):
     ledger.write_entry(_entry(iteration=1), ledger_dir=tmp_path)
-    ledger.write_entry(_entry(iteration=2, overrides={"retrieval.top_k_final": 4}), ledger_dir=tmp_path)
+    ledger.write_entry(
+        _entry(iteration=2, overrides={"retrieval.top_k_final": 4}), ledger_dir=tmp_path
+    )
     loaded = ledger.read_entry_by_iteration(tmp_path, 2)
     assert loaded.iteration == 2
     assert loaded.config_overrides == {"retrieval.top_k_final": 4}
@@ -151,6 +155,58 @@ def test_read_history_ignores_a_report_json_in_the_same_directory(tmp_path):
 
     assert [e.iteration for e in history] == [1]
     assert ledger.next_iteration_number(tmp_path) == 2
+
+
+def test_schema_v2_entry_records_the_regression_baseline(tmp_path):
+    ledger.write_entry(_entry(iteration=1, verdict="rejected_regression"), ledger_dir=tmp_path)
+    # Simulate loop.py's recovery-mode write (issue #92).
+    entry = ledger._entry_files(tmp_path)[0]
+    data = json.loads(entry.read_text(encoding="utf-8"))
+    data["regression_baseline_iteration"] = 7
+    entry.write_text(json.dumps(data), encoding="utf-8")
+
+    loaded = ledger.read_history(tmp_path)[0]
+    assert loaded.regression_baseline_iteration == 7
+
+
+def test_schema_v1_entry_without_regression_baseline_reads_as_none(tmp_path):
+    """Entries written before schema v2 have no regression_baseline_iteration
+    key; they must keep loading (and read as None = paired against the
+    in-run reference) so an old ledger stays usable across the upgrade."""
+    import dataclasses
+
+    from monkeygrab.config.app_config import AppConfig
+
+    v1_entry = ledger.LedgerEntry(
+        schema_version=1,
+        iteration=1,
+        parent_iteration=None,
+        git_commit=None,
+        config_overrides={},
+        effective_config=dataclasses.asdict(AppConfig()),
+        proposer="grid",
+        proposer_rationale=None,
+        proposer_model=None,
+        proposer_fallback=False,
+        proposer_fallback_reason=None,
+        evaluated_case_set="search_set",
+        case_records=[],
+        summary={"total": 0, "passed": 0, "pass_rate": 0.0},
+        objective_raw=0,
+        objective_adjusted=0,
+        median_latency_answered_s=200.0,
+        median_latency_retrieval_only_s=None,
+        reference_median_latency_answered_s=200.0,
+        reference_median_latency_retrieval_only_s=None,
+        latency_ceiling_multiplier=1.20,
+        verdict="accepted",
+        reason="old campaign",
+    )
+    path = tmp_path / "0001_x.json"
+    path.write_text(json.dumps(v1_entry.to_dict()), encoding="utf-8")
+
+    loaded = ledger.read_history(tmp_path)[0]
+    assert loaded.regression_baseline_iteration is None
 
 
 # GIT COMMIT: no subprocess, best-effort.

--- a/harness/tests/test_loop.py
+++ b/harness/tests/test_loop.py
@@ -25,7 +25,10 @@ from harness import loop
 
 def _rec(case_id, case_type, passed, elapsed, infra_error=False):
     return ev.CaseRecord(
-        id=case_id, case_type=case_type, passed=passed, elapsed_seconds=elapsed,
+        id=case_id,
+        case_type=case_type,
+        passed=passed,
+        elapsed_seconds=elapsed,
         infrastructure_error=infra_error,
     )
 
@@ -36,8 +39,13 @@ class _FixedProposer:
 
     def __init__(self, overrides):
         self._overrides = overrides
-        self.last_meta = {"proposer": "grid", "rationale": None, "model": None,
-                           "fallback": False, "fallback_reason": None}
+        self.last_meta = {
+            "proposer": "grid",
+            "rationale": None,
+            "model": None,
+            "fallback": False,
+            "fallback_reason": None,
+        }
 
     def propose(self, space, ledger_history, last_result):
         return dict(self._overrides)
@@ -46,8 +54,13 @@ class _FixedProposer:
 class _CyclingProposer:
     def __init__(self, options):
         self._it = itertools.cycle(options)
-        self.last_meta = {"proposer": "grid", "rationale": None, "model": None,
-                           "fallback": False, "fallback_reason": None}
+        self.last_meta = {
+            "proposer": "grid",
+            "rationale": None,
+            "model": None,
+            "fallback": False,
+            "fallback_reason": None,
+        }
 
     def propose(self, space, ledger_history, last_result):
         return dict(next(self._it))
@@ -66,23 +79,38 @@ def test_candidate_scoring_higher_but_breaching_latency_is_rejected(tmp_path):
         records = []
         for cid in case_ids:
             if boosted:
-                records.append(_rec(cid, "factual_number", True, 500.0))  # passes everything, but slow
+                records.append(
+                    _rec(cid, "factual_number", True, 500.0)
+                )  # passes everything, but slow
             else:
-                records.append(_rec(cid, "factual_number", cid != "c", 200.0))  # reference fails "c"
+                records.append(
+                    _rec(cid, "factual_number", cid != "c", 200.0)
+                )  # reference fails "c"
         return ev.EvaluationResult(records=tuple(records), effective_config=dict(overrides))
 
     proposer = _FixedProposer({"retrieval.top_k_final": 16})
     report = loop.run_loop(
-        reference=AppConfig(), evaluate=evaluate, proposer=proposer,
-        search_set_ids=search_ids, fast_tier_ids=fast_ids, unreachable_ids=(),
-        max_iterations=1, patience=None, ledger_dir=tmp_path, verify_reachability=False,
+        reference=AppConfig(),
+        evaluate=evaluate,
+        proposer=proposer,
+        search_set_ids=search_ids,
+        fast_tier_ids=fast_ids,
+        unreachable_ids=(),
+        max_iterations=1,
+        patience=None,
+        ledger_dir=tmp_path,
+        verify_reachability=False,
     )
 
     assert len(report["iterations"]) == 1
     entry = report["iterations"][0]
     assert entry["verdict"] == "rejected_latency"
-    assert entry["objective_adjusted"] > report["reference"]["objective_adjusted"]  # scored higher...
-    assert report["ratchet"] == report["reference"]["objective_adjusted"]  # ...but ratchet did not move
+    assert (
+        entry["objective_adjusted"] > report["reference"]["objective_adjusted"]
+    )  # scored higher...
+    assert (
+        report["ratchet"] == report["reference"]["objective_adjusted"]
+    )  # ...but ratchet did not move
     assert report["best_iteration"] is None
 
 
@@ -101,9 +129,16 @@ def test_latency_breach_is_checked_per_bucket_independently(tmp_path):
 
     proposer = _FixedProposer({"retrieval.n_semantic_results": 120})
     report = loop.run_loop(
-        reference=AppConfig(), evaluate=evaluate, proposer=proposer,
-        search_set_ids=search_ids, fast_tier_ids=fast_ids, unreachable_ids=(),
-        max_iterations=1, patience=None, ledger_dir=tmp_path, verify_reachability=False,
+        reference=AppConfig(),
+        evaluate=evaluate,
+        proposer=proposer,
+        search_set_ids=search_ids,
+        fast_tier_ids=fast_ids,
+        unreachable_ids=(),
+        max_iterations=1,
+        patience=None,
+        ledger_dir=tmp_path,
+        verify_reachability=False,
     )
     assert report["iterations"][0]["verdict"] == "rejected_latency"
     assert "retrieval_only" in report["iterations"][0]["reason"]
@@ -121,9 +156,16 @@ def test_termination_fires_on_max_iterations(tmp_path):
         return ev.EvaluationResult(records=tuple(records), effective_config=dict(overrides))
 
     report = loop.run_loop(
-        reference=AppConfig(), evaluate=evaluate, proposer=proposer,
-        search_set_ids=("a", "b"), fast_tier_ids=("a",), unreachable_ids=(),
-        max_iterations=2, patience=None, ledger_dir=tmp_path, verify_reachability=False,
+        reference=AppConfig(),
+        evaluate=evaluate,
+        proposer=proposer,
+        search_set_ids=("a", "b"),
+        fast_tier_ids=("a",),
+        unreachable_ids=(),
+        max_iterations=2,
+        patience=None,
+        ledger_dir=tmp_path,
+        verify_reachability=False,
     )
 
     assert report is not None
@@ -141,9 +183,16 @@ def test_termination_fires_on_patience(tmp_path):
         return ev.EvaluationResult(records=tuple(records), effective_config=dict(overrides))
 
     report = loop.run_loop(
-        reference=AppConfig(), evaluate=evaluate, proposer=proposer,
-        search_set_ids=("a", "b"), fast_tier_ids=("a",), unreachable_ids=(),
-        max_iterations=None, patience=2, ledger_dir=tmp_path, verify_reachability=False,
+        reference=AppConfig(),
+        evaluate=evaluate,
+        proposer=proposer,
+        search_set_ids=("a", "b"),
+        fast_tier_ids=("a",),
+        unreachable_ids=(),
+        max_iterations=None,
+        patience=2,
+        ledger_dir=tmp_path,
+        verify_reachability=False,
     )
 
     assert report is not None
@@ -155,8 +204,13 @@ def test_termination_fires_on_patience(tmp_path):
 def test_run_loop_requires_a_termination_condition():
     with pytest.raises(ValueError):
         loop.run_loop(
-            reference=AppConfig(), evaluate=lambda o, c: None, proposer=_FixedProposer({}),
-            search_set_ids=(), fast_tier_ids=(), max_iterations=None, patience=None,
+            reference=AppConfig(),
+            evaluate=lambda o, c: None,
+            proposer=_FixedProposer({}),
+            search_set_ids=(),
+            fast_tier_ids=(),
+            max_iterations=None,
+            patience=None,
         )
 
 
@@ -173,14 +227,23 @@ def test_fast_tier_regression_is_rejected_before_paying_for_the_full_set(tmp_pat
             full_eval_calls["count"] += 1
         regress = "retrieval.bm25_k1" in overrides
         # Reference: "a" passes. Candidate: "a" now fails -> regression.
-        records = [_rec(cid, "factual_number", not (regress and cid == "a"), 200.0) for cid in case_ids]
+        records = [
+            _rec(cid, "factual_number", not (regress and cid == "a"), 200.0) for cid in case_ids
+        ]
         return ev.EvaluationResult(records=tuple(records), effective_config=dict(overrides))
 
     proposer = _FixedProposer({"retrieval.bm25_k1": 2.0})
     report = loop.run_loop(
-        reference=AppConfig(), evaluate=evaluate, proposer=proposer,
-        search_set_ids=search_ids, fast_tier_ids=fast_ids, unreachable_ids=(),
-        max_iterations=1, patience=None, ledger_dir=tmp_path, verify_reachability=False,
+        reference=AppConfig(),
+        evaluate=evaluate,
+        proposer=proposer,
+        search_set_ids=search_ids,
+        fast_tier_ids=fast_ids,
+        unreachable_ids=(),
+        max_iterations=1,
+        patience=None,
+        ledger_dir=tmp_path,
+        verify_reachability=False,
     )
 
     entry = report["iterations"][0]
@@ -200,14 +263,23 @@ def test_a_real_improvement_is_accepted_and_moves_the_ratchet(tmp_path):
         better = overrides.get("retrieval.top_k_final") == 12
         # Reference passes 6/8; the improved candidate passes all 8 -- a
         # clear gain, well past the noise floor of 0.
-        records = [_rec(cid, "factual_number", better or cid not in ("g", "h"), 200.0) for cid in case_ids]
+        records = [
+            _rec(cid, "factual_number", better or cid not in ("g", "h"), 200.0) for cid in case_ids
+        ]
         return ev.EvaluationResult(records=tuple(records), effective_config=dict(overrides))
 
     proposer = _FixedProposer({"retrieval.top_k_final": 12})
     report = loop.run_loop(
-        reference=AppConfig(), evaluate=evaluate, proposer=proposer,
-        search_set_ids=search_ids, fast_tier_ids=fast_ids, unreachable_ids=(),
-        max_iterations=1, patience=None, ledger_dir=tmp_path, verify_reachability=False,
+        reference=AppConfig(),
+        evaluate=evaluate,
+        proposer=proposer,
+        search_set_ids=search_ids,
+        fast_tier_ids=fast_ids,
+        unreachable_ids=(),
+        max_iterations=1,
+        patience=None,
+        ledger_dir=tmp_path,
+        verify_reachability=False,
     )
 
     entry = report["iterations"][0]
@@ -222,9 +294,15 @@ def test_resolution_warning_is_always_present_in_the_report(tmp_path):
         return ev.EvaluationResult(records=tuple(records), effective_config=dict(overrides))
 
     report = loop.run_loop(
-        reference=AppConfig(), evaluate=evaluate, proposer=_FixedProposer({"retrieval.top_k_final": 4}),
-        search_set_ids=("a",), fast_tier_ids=("a",), max_iterations=1, patience=None,
-        ledger_dir=tmp_path, verify_reachability=False,
+        reference=AppConfig(),
+        evaluate=evaluate,
+        proposer=_FixedProposer({"retrieval.top_k_final": 4}),
+        search_set_ids=("a",),
+        fast_tier_ids=("a",),
+        max_iterations=1,
+        patience=None,
+        ledger_dir=tmp_path,
+        verify_reachability=False,
     )
     assert report["resolution_warning"] == loop.RESOLUTION_WARNING
     assert report["resolution_warning"]["available_search_set_failures"] == 5
@@ -249,15 +327,28 @@ def test_retrieval_only_net_loss_is_rejected_despite_a_higher_blended_objective(
                 passed = not traded  # reference: all 3 figures pass; traded: all 3 fail
             else:
                 passed = traded or cid == "ans1"  # reference: only ans1 passes; traded: all 5 pass
-            records.append(_rec(cid, "figure_retrieval" if is_fig else "factual_number", passed,
-                                 4.0 if is_fig else 200.0))
+            records.append(
+                _rec(
+                    cid,
+                    "figure_retrieval" if is_fig else "factual_number",
+                    passed,
+                    4.0 if is_fig else 200.0,
+                )
+            )
         return ev.EvaluationResult(records=tuple(records), effective_config=dict(overrides))
 
     proposer = _FixedProposer({"retrieval.top_k_final": 16})
     report = loop.run_loop(
-        reference=AppConfig(), evaluate=evaluate, proposer=proposer,
-        search_set_ids=search_ids, fast_tier_ids=("ans1",), unreachable_ids=(),
-        max_iterations=1, patience=None, ledger_dir=tmp_path, verify_reachability=False,
+        reference=AppConfig(),
+        evaluate=evaluate,
+        proposer=proposer,
+        search_set_ids=search_ids,
+        fast_tier_ids=("ans1",),
+        unreachable_ids=(),
+        max_iterations=1,
+        patience=None,
+        ledger_dir=tmp_path,
+        verify_reachability=False,
     )
 
     entry = report["iterations"][0]
@@ -280,12 +371,22 @@ def test_summary_carries_a_per_case_type_breakdown(tmp_path):
         return ev.EvaluationResult(records=tuple(records), effective_config=dict(overrides))
 
     report = loop.run_loop(
-        reference=AppConfig(), evaluate=evaluate, proposer=_FixedProposer({"retrieval.top_k_final": 12}),
-        search_set_ids=("fig", "num"), fast_tier_ids=("fig",), max_iterations=1, patience=None,
-        ledger_dir=tmp_path, verify_reachability=False,
+        reference=AppConfig(),
+        evaluate=evaluate,
+        proposer=_FixedProposer({"retrieval.top_k_final": 12}),
+        search_set_ids=("fig", "num"),
+        fast_tier_ids=("fig",),
+        max_iterations=1,
+        patience=None,
+        ledger_dir=tmp_path,
+        verify_reachability=False,
     )
     summary = report["iterations"][0]["summary"]
-    assert summary["by_case_type"]["figure_retrieval"] == {"total": 1, "passed": 1, "pass_rate": 1.0}
+    assert summary["by_case_type"]["figure_retrieval"] == {
+        "total": 1,
+        "passed": 1,
+        "pass_rate": 1.0,
+    }
     assert summary["by_case_type"]["factual_number"] == {"total": 1, "passed": 1, "pass_rate": 1.0}
 
 
@@ -302,9 +403,15 @@ def test_reference_with_infrastructure_error_raises_before_the_loop_starts(tmp_p
 
     with pytest.raises(ev.InconclusiveEvaluationError):
         loop.run_loop(
-            reference=AppConfig(), evaluate=evaluate, proposer=_FixedProposer({"retrieval.top_k_final": 4}),
-            search_set_ids=("a", "b"), fast_tier_ids=("a",), max_iterations=1, patience=None,
-            ledger_dir=tmp_path, verify_reachability=False,
+            reference=AppConfig(),
+            evaluate=evaluate,
+            proposer=_FixedProposer({"retrieval.top_k_final": 4}),
+            search_set_ids=("a", "b"),
+            fast_tier_ids=("a",),
+            max_iterations=1,
+            patience=None,
+            ledger_dir=tmp_path,
+            verify_reachability=False,
         )
 
 
@@ -317,9 +424,15 @@ def test_fast_tier_infrastructure_error_yields_inconclusive_not_regression(tmp_p
 
     proposer = _FixedProposer({"retrieval.top_k_final": 4})
     report = loop.run_loop(
-        reference=AppConfig(), evaluate=evaluate, proposer=proposer,
-        search_set_ids=("a", "b"), fast_tier_ids=("a",), max_iterations=1, patience=None,
-        ledger_dir=tmp_path, verify_reachability=False,
+        reference=AppConfig(),
+        evaluate=evaluate,
+        proposer=proposer,
+        search_set_ids=("a", "b"),
+        fast_tier_ids=("a",),
+        max_iterations=1,
+        patience=None,
+        ledger_dir=tmp_path,
+        verify_reachability=False,
     )
 
     entry = report["iterations"][0]
@@ -337,9 +450,15 @@ def test_search_set_infrastructure_error_yields_inconclusive_and_no_ratchet_move
 
     proposer = _FixedProposer({"retrieval.top_k_final": 4})
     report = loop.run_loop(
-        reference=AppConfig(), evaluate=evaluate, proposer=proposer,
-        search_set_ids=("a", "b"), fast_tier_ids=("a",), max_iterations=1, patience=None,
-        ledger_dir=tmp_path, verify_reachability=False,
+        reference=AppConfig(),
+        evaluate=evaluate,
+        proposer=proposer,
+        search_set_ids=("a", "b"),
+        fast_tier_ids=("a",),
+        max_iterations=1,
+        patience=None,
+        ledger_dir=tmp_path,
+        verify_reachability=False,
     )
 
     entry = report["iterations"][0]
@@ -351,16 +470,336 @@ def test_search_set_infrastructure_error_yields_inconclusive_and_no_ratchet_move
 
 def test_inconclusive_counts_toward_patience(tmp_path):
     def evaluate(overrides, case_ids):
-        records = [_rec(cid, "factual_number", True, 200.0, infra_error=bool(overrides)) for cid in case_ids]
+        records = [
+            _rec(cid, "factual_number", True, 200.0, infra_error=bool(overrides))
+            for cid in case_ids
+        ]
         return ev.EvaluationResult(records=tuple(records), effective_config=dict(overrides))
 
     proposer = _CyclingProposer([{"retrieval.top_k_final": 4}, {"retrieval.top_k_final": 6}])
     report = loop.run_loop(
-        reference=AppConfig(), evaluate=evaluate, proposer=proposer,
-        search_set_ids=("a",), fast_tier_ids=("a",), max_iterations=None, patience=2,
-        ledger_dir=tmp_path, verify_reachability=False,
+        reference=AppConfig(),
+        evaluate=evaluate,
+        proposer=proposer,
+        search_set_ids=("a",),
+        fast_tier_ids=("a",),
+        max_iterations=None,
+        patience=2,
+        ledger_dir=tmp_path,
+        verify_reachability=False,
     )
 
     assert report["termination_reason"] == "patience"
     assert report["iterations_run"] == 2
     assert all(entry["verdict"] == "inconclusive" for entry in report["iterations"])
+
+
+# RECOVERY MODE (issue #92): against a degraded reference whose extra pass is
+# sabotage luck (it passes a case every healthy configuration fails), pairing
+# regressions against the reference blocks recovery forever. When the ledger's
+# prior history holds a comparable state with a strictly higher objective, the
+# loop pairs against that high-water pass vector instead.
+
+
+def _seed_entry(
+    tmp_path_ledger,
+    iteration,
+    objective,
+    case_records,
+    verdict="accepted",
+    effective_config=None,
+    evaluated_case_set="search_set",
+):
+    import dataclasses
+
+    from harness import ledger as ledger_mod
+
+    entry = ledger_mod.LedgerEntry(
+        schema_version=ledger_mod.SCHEMA_VERSION,
+        iteration=iteration,
+        parent_iteration=None if iteration == 1 else iteration - 1,
+        git_commit=None,
+        config_overrides={},
+        effective_config=effective_config or dataclasses.asdict(AppConfig()),
+        proposer="grid",
+        proposer_rationale=None,
+        proposer_model=None,
+        proposer_fallback=False,
+        proposer_fallback_reason=None,
+        evaluated_case_set=evaluated_case_set,
+        case_records=case_records,
+        summary={
+            "total": len(case_records),
+            "passed": objective,
+            "pass_rate": objective / len(case_records),
+        },
+        objective_raw=objective,
+        objective_adjusted=objective,
+        median_latency_answered_s=200.0,
+        median_latency_retrieval_only_s=None,
+        reference_median_latency_answered_s=200.0,
+        reference_median_latency_retrieval_only_s=None,
+        latency_ceiling_multiplier=loop.LATENCY_CEILING_MULTIPLIER,
+        verdict=verdict,
+        reason="seeded",
+    )
+    ledger_mod.write_entry(entry, tmp_path_ledger)
+
+
+def test_recovery_candidate_reaches_the_search_set_when_reference_is_degraded(tmp_path):
+    """The #92 scenario end to end: a degraded reference passes 'lucky' only
+    because the sabotage lucked into it; the healthy high-water state in the
+    ledger fails it. Recovery pairing must let a candidate that restores
+    health through to acceptance instead of rejecting it at the fast tier."""
+    search_ids = ("lucky", "a", "b", "c", "d")
+    fast_ids = ("lucky",)
+    # High water (healthy): fails 'lucky', passes everything else -> 4.
+    _seed_entry(
+        tmp_path,
+        1,
+        4,
+        [
+            {
+                "id": "lucky",
+                "case_type": "factual_number",
+                "passed": False,
+                "elapsed_seconds": 200.0,
+            },
+            *[
+                {"id": cid, "case_type": "factual_number", "passed": True, "elapsed_seconds": 200.0}
+                for cid in ("a", "b", "c", "d")
+            ],
+        ],
+    )
+
+    def evaluate(overrides, case_ids):
+        healthy = overrides.get("retrieval.top_k_final") == 12
+        records = []
+        for cid in case_ids:
+            if cid == "lucky":
+                passed = not healthy and not overrides  # only the degraded reference passes it
+            else:
+                passed = healthy  # the degraded reference fails these too
+            records.append(_rec(cid, "factual_number", passed, 200.0))
+        return ev.EvaluationResult(records=tuple(records), effective_config=dict(overrides))
+
+    proposer = _FixedProposer({"retrieval.top_k_final": 12})
+    report = loop.run_loop(
+        reference=AppConfig(),
+        evaluate=evaluate,
+        proposer=proposer,
+        search_set_ids=search_ids,
+        fast_tier_ids=fast_ids,
+        unreachable_ids=(),
+        max_iterations=1,
+        patience=None,
+        ledger_dir=tmp_path,
+        verify_reachability=False,
+    )
+
+    assert report["recovery_mode"]["active"] is True
+    assert report["recovery_mode"]["baseline_iteration"] == 1
+    assert report["recovery_mode"]["baseline_objective_adjusted"] == 4
+    entry = report["iterations"][0]
+    assert entry["evaluated_case_set"] == "search_set"  # got past the fast tier
+    assert entry["verdict"] == "accepted"  # restored health: 4 > ratchet 1
+    assert entry["regression_baseline_iteration"] == 1
+
+
+def test_recovery_candidate_losing_earned_fast_tier_cases_is_still_rejected(tmp_path):
+    """Recovery pairs against earned passes, not against nothing: a candidate
+    that re-fails a case the high-water state EARNED is still a regression,
+    even though the degraded reference never passed that case either."""
+    search_ids = ("lucky", "a", "b", "c", "d")
+    fast_ids = ("lucky", "a")
+    _seed_entry(
+        tmp_path,
+        1,
+        4,
+        [
+            {
+                "id": "lucky",
+                "case_type": "factual_number",
+                "passed": False,
+                "elapsed_seconds": 200.0,
+            },
+            *[
+                {"id": cid, "case_type": "factual_number", "passed": True, "elapsed_seconds": 200.0}
+                for cid in ("a", "b", "c", "d")
+            ],
+        ],
+    )
+
+    def evaluate(overrides, case_ids):
+        if not overrides:  # degraded reference: passes only the lucky case -> 1
+            records = [_rec(cid, "factual_number", cid == "lucky", 200.0) for cid in case_ids]
+            return ev.EvaluationResult(records=tuple(records), effective_config=dict(overrides))
+        # Candidate: keeps the lucky case, restores b/c/d, but loses earned 'a' -> 4.
+        records = [_rec(cid, "factual_number", cid != "a", 200.0) for cid in case_ids]
+        return ev.EvaluationResult(records=tuple(records), effective_config=dict(overrides))
+
+    proposer = _FixedProposer({"retrieval.top_k_final": 12})
+    report = loop.run_loop(
+        reference=AppConfig(),
+        evaluate=evaluate,
+        proposer=proposer,
+        search_set_ids=search_ids,
+        fast_tier_ids=fast_ids,
+        unreachable_ids=(),
+        max_iterations=1,
+        patience=None,
+        ledger_dir=tmp_path,
+        verify_reachability=False,
+    )
+
+    entry = report["iterations"][0]
+    assert entry["verdict"] == "rejected_regression"
+    assert "'a'" in entry["reason"]
+    assert entry["regression_baseline_iteration"] == 1
+
+
+def test_without_comparable_history_reference_pairing_is_kept(tmp_path):
+    """A prior entry from a different model is NOT comparable: no recovery
+    mode, so a candidate re-failing the lucky case is rejected exactly as
+    before the fix."""
+    import dataclasses
+
+    search_ids = ("lucky", "a")
+    fast_ids = ("lucky",)
+    other_model = dataclasses.asdict(AppConfig())
+    other_model["models"]["rag"] = "some-other-model"
+    _seed_entry(
+        tmp_path,
+        1,
+        2,
+        [
+            {
+                "id": "lucky",
+                "case_type": "factual_number",
+                "passed": False,
+                "elapsed_seconds": 200.0,
+            },
+            {"id": "a", "case_type": "factual_number", "passed": True, "elapsed_seconds": 200.0},
+        ],
+        effective_config=other_model,
+    )
+
+    def evaluate(overrides, case_ids):
+        healthy = bool(overrides)
+        records = []
+        for cid in case_ids:
+            if cid == "lucky":
+                passed = not healthy  # candidate re-fails what the sabotage lucked into
+            else:
+                passed = healthy
+            records.append(_rec(cid, "factual_number", passed, 200.0))
+        return ev.EvaluationResult(records=tuple(records), effective_config=dict(overrides))
+
+    proposer = _FixedProposer({"retrieval.top_k_final": 12})
+    report = loop.run_loop(
+        reference=AppConfig(),
+        evaluate=evaluate,
+        proposer=proposer,
+        search_set_ids=search_ids,
+        fast_tier_ids=fast_ids,
+        unreachable_ids=(),
+        max_iterations=1,
+        patience=None,
+        ledger_dir=tmp_path,
+        verify_reachability=False,
+    )
+
+    assert report["recovery_mode"]["active"] is False
+    entry = report["iterations"][0]
+    assert entry["verdict"] == "rejected_regression"
+    assert entry["regression_baseline_iteration"] is None
+
+
+def test_inconclusive_history_never_provides_the_high_water(tmp_path):
+    """An inconclusive entry may be measuring a dead Ollama, not quality; its
+    higher objective must not activate recovery mode."""
+    search_ids = ("lucky", "a")
+    fast_ids = ("lucky",)
+    _seed_entry(
+        tmp_path,
+        1,
+        2,
+        [
+            {
+                "id": "lucky",
+                "case_type": "factual_number",
+                "passed": False,
+                "elapsed_seconds": 200.0,
+            },
+            {"id": "a", "case_type": "factual_number", "passed": True, "elapsed_seconds": 200.0},
+        ],
+        verdict="inconclusive",
+    )
+
+    def evaluate(overrides, case_ids):
+        healthy = bool(overrides)
+        records = []
+        for cid in case_ids:
+            passed = healthy if cid != "lucky" else not healthy
+            records.append(_rec(cid, "factual_number", passed, 200.0))
+        return ev.EvaluationResult(records=tuple(records), effective_config=dict(overrides))
+
+    proposer = _FixedProposer({"retrieval.top_k_final": 12})
+    report = loop.run_loop(
+        reference=AppConfig(),
+        evaluate=evaluate,
+        proposer=proposer,
+        search_set_ids=search_ids,
+        fast_tier_ids=fast_ids,
+        unreachable_ids=(),
+        max_iterations=1,
+        patience=None,
+        ledger_dir=tmp_path,
+        verify_reachability=False,
+    )
+
+    assert report["recovery_mode"]["active"] is False
+    assert report["iterations"][0]["verdict"] == "rejected_regression"
+
+
+def test_healthy_reference_at_or_above_high_water_keeps_reference_pairing(tmp_path):
+    """Recovery mode needs the reference STRICTLY below the high water: an
+    equal-or-better reference is healthy, and its own pass vector governs."""
+    search_ids = ("x", "y")
+    fast_ids = ("x",)
+    _seed_entry(
+        tmp_path,
+        1,
+        2,
+        [
+            {"id": "x", "case_type": "factual_number", "passed": False, "elapsed_seconds": 200.0},
+            {"id": "y", "case_type": "factual_number", "passed": True, "elapsed_seconds": 200.0},
+        ],
+    )
+
+    def evaluate(overrides, case_ids):
+        traded = bool(overrides)  # candidate loses 'x' (reference passes it; high water failed it)
+        records = [
+            _rec(cid, "factual_number", not (traded and cid == "x"), 200.0) for cid in case_ids
+        ]
+        return ev.EvaluationResult(records=tuple(records), effective_config=dict(overrides))
+
+    proposer = _FixedProposer({"retrieval.top_k_final": 12})
+    report = loop.run_loop(
+        reference=AppConfig(),
+        evaluate=evaluate,
+        proposer=proposer,
+        search_set_ids=search_ids,
+        fast_tier_ids=fast_ids,
+        unreachable_ids=(),
+        max_iterations=1,
+        patience=None,
+        ledger_dir=tmp_path,
+        verify_reachability=False,
+    )
+
+    assert report["recovery_mode"]["active"] is False
+    entry = report["iterations"][0]
+    # Rejected against the REFERENCE's pass vector ('x' was earned here).
+    assert entry["verdict"] == "rejected_regression"
+    assert entry["regression_baseline_iteration"] is None


### PR DESCRIPTION
## Summary
- Resolves the design question opened by the 2026-08-22 criterion-5 campaign (issue #92): the k=1 sabotage lucked into passing planck-sigma8-es, so the fast-tier regression check paired against the degraded reference rejected every recovery candidate
- Design decision recorded in docs/design/2026-07-28-loop-automejorable.md section 5: when prior ledger history holds a comparable state (same model roles, chunking, index-time flags) with a strictly higher objective than the current reference, the loop starts in recovery mode and pairs both regression checks against that high-water pass vector
- Ratchet still starts at the degraded reference objective; latency still pairs against the in-run reference; without comparable history behaviour is byte-for-byte unchanged
- Provenance: ledger schema v2 adds regression_baseline_iteration per scored entry; reports carry a recovery_mode block; v1 ledgers keep loading

## Test plan
- 6 new loop tests: recovery candidate accepted end to end, earned-case loss still rejected, non-comparable history keeps old pairing, inconclusive history never provides the high water, healthy reference keeps reference pairing, v1 entry compat
- Full harness suite green (149), ruff clean
- Real-pipeline validation (sabotage campaign against a ledger with healthy history) follows as a run report before merge of any product change