### PR TITLE
Add a repeatable --set KEY=VALUE flag to pin the campaign's reference config (#101)

### DIFF
--- a/harness/README.md
+++ b/harness/README.md
@@ -323,6 +323,14 @@ python -m harness.cli --dry-run --max-iterations 3
 # Ollama, and a GPU -- fails with an actionable message otherwise):
 python -m harness.cli --proposer llm --max-iterations 8 --patience 3
 
+# Real campaign pinned to be comparable with prior ledger history -- e.g. a
+# criterion-5 recovery run against a sabotaged reference (--set is
+# repeatable; unknown keys abort at launch before any evaluation):
+RAG_TOP_K_FINAL=1 python -m harness.cli \
+    --ledger-dir tests/eval/runs/harness-loop \
+    --set models.rag=gemma4:e4b --set models.chat=gemma4:e2b \
+    --set models.contextual=gemma4:e2b --set models.recomp=gemma4:e2b
+
 # Criterion 7: reconstruct one ledger iteration and re-run its exact
 # overrides and case ids. Exit 0 iff the pass/fail vector matches.
 python -m harness.cli --replay 1 --ledger-dir /path/to/ledger

--- a/harness/cli.py
+++ b/harness/cli.py
@@ -4,6 +4,14 @@ Usage:
     python -m harness.cli --dry-run --max-iterations 3
     python -m harness.cli --proposer llm --max-iterations 8 --patience 3
     python -m harness.cli --replay 1 --ledger-dir /path/to/ledger
+    python -m harness.cli --set retrieval.top_k_final=1 --ledger-dir tests/eval/runs/harness-loop
+
+``--set KEY=VALUE`` (repeatable) pins fields of the reference config the
+ratchet measures against, so a campaign that must be comparable with prior
+ledger history -- a criterion-5 recovery run, say -- does not need
+environment variables or a hand-written wrapper script. Unknown keys fail
+at launch (the repo's hard-fail policy); values are JSON-decoded when they
+parse as JSON and kept as raw strings otherwise.
 
 ``--dry-run`` always works: it wires in a small deterministic in-process
 evaluator (``evaluator.build_demo_evaluator``) so the whole loop -- proposer,
@@ -23,7 +31,7 @@ import json
 import sys
 import tempfile
 from pathlib import Path
-from typing import Optional, Sequence
+from typing import Any, Dict, Optional, Sequence
 
 from harness import evaluator as evaluator_mod
 from harness import ledger as ledger_mod
@@ -42,6 +50,29 @@ def _build_reference():
     from monkeygrab.config.app_config import AppConfig
 
     return AppConfig.from_env()
+
+
+def parse_set_overrides(pairs: Sequence[str]) -> Dict[str, Any]:
+    """Parse repeated ``KEY=VALUE`` strings into a dotted-key overrides dict.
+
+    Values are JSON-decoded so integers, floats and booleans survive the
+    command line; anything that is not valid JSON stays a raw string (which
+    is what every model-role pin needs).
+
+    Raises:
+        ValueError: A pair carries no ``=`` or an empty key.
+    """
+    overrides: Dict[str, Any] = {}
+    for pair in pairs:
+        key, sep, raw = pair.partition("=")
+        if not sep or not key.strip():
+            raise ValueError(f"--set expects KEY=VALUE, got {pair!r}")
+        try:
+            value: Any = json.loads(raw)
+        except json.JSONDecodeError:
+            value = raw
+        overrides[key.strip()] = value
+    return overrides
 
 
 def _build_proposer(name: str, reference, *, model: str):
@@ -71,6 +102,13 @@ def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
                              "Re-run ledger iteration ITERATION's overrides and case ids "
                              "(criterion 7). Skips the search loop. Needs --ledger-dir "
                              "pointing at the ledger that holds that entry."
+                         ))
+    parser.add_argument("--set", action="append", default=[], metavar="KEY=VALUE",
+                         help=(
+                             "Pin a reference-config field for this campaign (repeatable), "
+                             "e.g. --set retrieval.top_k_final=1 --set models.chat=gemma4:e2b. "
+                             "Applied to the reference the ratchet measures against; unknown "
+                             "keys fail at launch."
                          ))
     return parser.parse_args(argv)
 
@@ -108,7 +146,22 @@ def _run_replay(iteration: int, evaluate, ledger_dir: Path) -> int:
 def main(argv: Optional[Sequence[str]] = None) -> int:
     args = parse_args(argv)
 
+    try:
+        set_overrides = parse_set_overrides(args.set)
+    except ValueError as exc:
+        print(f"USAGE: {exc}", file=sys.stderr)
+        return 2
+
     reference = _build_reference()
+    if set_overrides:
+        # with_overrides raises ValueError on an unknown section or field:
+        # a mistyped --set key must abort the campaign before any evaluation
+        # is paid, never silently measure a config that ignores it.
+        try:
+            reference = reference.with_overrides(**set_overrides)
+        except ValueError as exc:
+            print(f"SET FAILED: {exc}", file=sys.stderr)
+            return 2
     proposer = _build_proposer(args.proposer, reference, model=args.llm_model)
 
     if args.dry_run:

--- a/harness/tests/test_cli.py
+++ b/harness/tests/test_cli.py
@@ -56,6 +56,45 @@ def test_parse_args_replay():
     assert args.ledger_dir == Path("somewhere")
 
 
+def test_parse_set_overrides_decodes_json_and_keeps_raw_strings():
+    """Ints and bools must survive the CLI; model pins stay strings."""
+    overrides = cli.parse_set_overrides([
+        "retrieval.top_k_final=1", "flags.usar_reranker=false", "models.rag=gemma4:e4b",
+    ])
+    assert overrides == {
+        "retrieval.top_k_final": 1,
+        "flags.usar_reranker": False,
+        "models.rag": "gemma4:e4b",
+    }
+
+
+def test_parse_set_overrides_rejects_a_pair_without_equals():
+    import pytest
+
+    for bad in ("retrieval.top_k_final", "=1"):
+        with pytest.raises(ValueError, match="KEY=VALUE"):
+            cli.parse_set_overrides([bad])
+
+
+def test_set_overrides_reach_the_reference_and_unknown_keys_fail_hard(tmp_path, capsys):
+    """--set feeds AppConfig.with_overrides: a known key changes the campaign's
+    reference, an unknown key aborts before any evaluation is paid."""
+    code = cli.main([
+        "--dry-run", "--max-iterations", "1", "--ledger-dir", str(tmp_path),
+        "--set", "retrieval.top_k_final=6",
+    ])
+    assert code == 0
+    report = (tmp_path / "report.json")
+    assert report.exists()
+
+    code = cli.main([
+        "--dry-run", "--max-iterations", "1", "--ledger-dir", str(tmp_path),
+        "--set", "retrieval.no_such_field=6",
+    ])
+    assert code == 2
+    assert "no_such_field" in capsys.readouterr().err
+
+
 def test_cli_replay_exits_zero_when_the_demo_evaluator_matches(tmp_path):
     """End-to-end criterion 7 against the in-process demo landscape.
 


### PR DESCRIPTION
## Summary
Agents (and humans) can now launch a real harness campaign with pinned reference fields directly from the CLI:

\\\
python -m harness.cli --set retrieval.top_k_final=1 --set models.chat=gemma4:e2b ...
\\\

The flag feeds \AppConfig.with_overrides\ on the reference the ratchet, feasibility and latency ceiling measure against. Values are JSON-decoded (integers and booleans survive the CLI; anything non-JSON stays a raw string, which is what model-role pins need). Unknown sections or fields abort at launch with exit code 2 before any evaluation is paid: the repo's hard-fail policy applied to the new surface.

## Issue
Fixes #101

## Test plan
- \pytest harness/tests/test_cli.py\: 6 passed, including an end-to-end dry-run asserting a known key reaches the reference and an unknown key exits 2 with the offending field named.
- \pytest harness/tests\: 153 passed. \uff check harness/\: clean.
- The criterion-5 validation campaign currently running on this machine's GPU used today's env-var workaround; this flag is its replacement, exercised here via the demo evaluator.