### PR TITLE
Print ledger comparability at campaign launch, before any evaluation (#100)

### DIFF
--- a/harness/README.md
+++ b/harness/README.md
@@ -328,6 +328,14 @@ python -m harness.cli --proposer llm --max-iterations 8 --patience 3
 python -m harness.cli --replay 1 --ledger-dir /path/to/ledger
 ```
 
+Every non-dry-run launch first prints what prior ledger history offers under
+this launch's config (model roles, chunking, index-time flags): how many
+entries are comparable search-set states, the historical high water, and --
+when history exists but nothing is comparable -- which concrete fields
+drifted. Recovery mode's arming additionally depends on the measured
+reference objective, so this line can warn about a silently incomparable
+ledger (#100) but never promises arming by itself.
+
 `--dry-run` uses `evaluator.build_demo_evaluator()`: a tiny, deterministic,
 in-process synthetic landscape. It exercises the wiring, not the pipeline —
 it has no opinion about which real configuration is better.

--- a/harness/cli.py
+++ b/harness/cli.py
@@ -125,6 +125,27 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     fast_tier_ids = evaluator_mod.load_fast_tier()
     unreachable_ids = evaluator_mod.load_unreachable_ids()
 
+    # Issue #100: recovery mode pairs against comparable prior history, and a
+    # silently incomparable ledger is how a campaign spends hours fabricating
+    # evidence against its own fix. Say what the ledger offers BEFORE the
+    # reference measurement is paid; arming itself still depends on that
+    # measurement, so nothing here promises it.
+    if ledger_dir.exists():
+        comparability = loop_mod.describe_ledger_comparability(
+            reference, list(ledger_mod.read_history(ledger_dir))
+        )
+        print(
+            f"ledger history: {comparability['history_entries']} entry(ies), "
+            f"{comparability['comparable_search_set_states']} comparable search-set state(s)"
+        )
+        if comparability["high_water_objective_adjusted"] is not None:
+            print(
+                f"  historical high water: {comparability['high_water_objective_adjusted']} "
+                "(recovery mode arms only if the measured reference scores lower)"
+            )
+        for reason in comparability["incomparable_reasons"]:
+            print(f"  WARNING recovery-mode history mismatch -- {reason}")
+
     try:
         report = loop_mod.run_loop(
             reference=reference, evaluate=evaluate, proposer=proposer,

--- a/harness/loop.py
+++ b/harness/loop.py
@@ -265,6 +265,82 @@ def _comparable_config_view(effective_config: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
+def is_comparable_search_set_entry(
+    entry: ledger_mod.LedgerEntry, comparable_view: Dict[str, Any]
+) -> bool:
+    """Whether ``entry`` can serve as a recovery-mode baseline for this view.
+
+    Only complete, non-``inconclusive`` search-set evaluations carry the full
+    pass vector recovery pairing needs; fast-tier-rejected entries do not.
+    """
+    return (
+        entry.evaluated_case_set == "search_set"
+        and entry.verdict != "inconclusive"
+        and _comparable_config_view(entry.effective_config) == comparable_view
+    )
+
+
+def _diff_comparable_views(
+    launch_view: Dict[str, Any], entry_view: Dict[str, Any]
+) -> List[str]:
+    """Human-readable field-level differences between two comparable views."""
+    diffs: List[str] = []
+    for role in _MODEL_ROLE_KEYS:
+        launch_value = launch_view["models"].get(role)
+        entry_value = entry_view["models"].get(role)
+        if launch_value != entry_value:
+            diffs.append(f"models.{role}: this launch {launch_value!r}, ledger {entry_value!r}")
+    if launch_view["chunking"] != entry_view["chunking"]:
+        diffs.append(
+            f"chunking: this launch {launch_view['chunking']!r}, ledger {entry_view['chunking']!r}"
+        )
+    for flag in _INDEX_TIME_FLAG_KEYS:
+        launch_flag = launch_view["index_time_flags"].get(flag)
+        entry_flag = entry_view["index_time_flags"].get(flag)
+        if launch_flag != entry_flag:
+            diffs.append(
+                f"index_time_flags.{flag}: this launch {launch_flag!r}, ledger {entry_flag!r}"
+            )
+    return diffs
+
+
+def describe_ledger_comparability(reference, entries) -> Dict[str, Any]:
+    """What an operator should know about prior history BEFORE paying evaluations.
+
+    Recovery mode's actual arming additionally depends on the reference
+    objective, which only a full search-set evaluation reveals -- so this
+    reports comparability only and never promises arming (issue #100: a
+    silently incomparable ledger is how a campaign spends hours fabricating
+    evidence against its own fix).
+
+    Returns:
+        A dict with ``history_entries``, ``comparable_search_set_states``,
+        ``high_water_objective_adjusted`` (max among comparable states, or
+        ``None``), and ``incomparable_reasons`` -- empty unless entries exist
+        and none of them is comparable, in which case it names the fields
+        that differ against the latest entry.
+    """
+    comparable_view = _comparable_config_view(dataclasses.asdict(reference))
+    comparable = [e for e in entries if is_comparable_search_set_entry(e, comparable_view)]
+    info: Dict[str, Any] = {
+        "history_entries": len(entries),
+        "comparable_search_set_states": len(comparable),
+        "high_water_objective_adjusted": max(
+            (e.objective_adjusted for e in comparable), default=None
+        ),
+        "incomparable_reasons": [],
+    }
+    if entries and not comparable:
+        latest = entries[-1]
+        diffs = _diff_comparable_views(
+            comparable_view, _comparable_config_view(latest.effective_config)
+        )
+        info["incomparable_reasons"] = diffs or [
+            "config matches the latest entry but it carries no complete search-set pass vector"
+        ]
+    return info
+
+
 def _historical_high_water(
     entries: Sequence[ledger_mod.LedgerEntry],
     comparable_view: Dict[str, Any],
@@ -280,14 +356,9 @@ def _historical_high_water(
     """
     best: Optional[ledger_mod.LedgerEntry] = None
     for entry in entries:
-        if entry.evaluated_case_set != "search_set":
-            continue
-        if entry.verdict == "inconclusive":
-            continue
-        if _comparable_config_view(entry.effective_config) != comparable_view:
-            continue
-        if best is None or entry.objective_adjusted >= best.objective_adjusted:
-            best = entry
+        if is_comparable_search_set_entry(entry, comparable_view):
+            if best is None or entry.objective_adjusted >= best.objective_adjusted:
+                best = entry
     return best
 
 
@@ -473,9 +544,8 @@ def run_loop(
     # degraded, so regression pairing switches to the high-water pass
     # vector. Frozen here from PRIOR history; this run's own entries never
     # move it mid-campaign.
-    high_water = _historical_high_water(
-        entries_so_far, _comparable_config_view(dataclasses.asdict(reference))
-    )
+    comparable_view = _comparable_config_view(dataclasses.asdict(reference))
+    high_water = _historical_high_water(entries_so_far, comparable_view)
     if high_water is not None and high_water.objective_adjusted > reference_objective_adjusted:
         recovery_mode = True
         # The high-water entry carries the full search-set pass vector, which
@@ -487,10 +557,7 @@ def run_loop(
         eligible_history_entries = sum(
             1
             for e in entries_so_far
-            if e.evaluated_case_set == "search_set"
-            and e.verdict != "inconclusive"
-            and _comparable_config_view(e.effective_config)
-            == _comparable_config_view(dataclasses.asdict(reference))
+            if is_comparable_search_set_entry(e, comparable_view)
         )
     else:
         recovery_mode = False

--- a/harness/tests/test_loop.py
+++ b/harness/tests/test_loop.py
@@ -839,3 +839,70 @@ def test_healthy_reference_at_or_above_high_water_keeps_reference_pairing(tmp_pa
     # Rejected against the REFERENCE's pass vector ('x' was earned here).
     assert entry["verdict"] == "rejected_regression"
     assert entry["regression_baseline_iteration"] is None
+
+
+# COMPARABILITY AT LAUNCH (issue #100): recovery mode pairs against comparable
+# prior history, and a silently incomparable ledger is how a campaign spends
+# hours fabricating evidence against its own fix. describe_ledger_comparability
+# is what the CLI prints BEFORE any evaluation is paid.
+
+
+def test_describe_comparability_on_an_empty_ledger():
+    info = loop.describe_ledger_comparability(AppConfig(), [])
+    assert info == {
+        "history_entries": 0,
+        "comparable_search_set_states": 0,
+        "high_water_objective_adjusted": None,
+        "incomparable_reasons": [],
+    }
+
+
+def test_describe_comparability_counts_a_matching_search_set_entry(tmp_path):
+    _seed_entry(tmp_path, 1, 27, [{"id": "a", "case_type": "factual_number", "passed": True, "elapsed_seconds": 200.0}])
+    from harness import ledger as ledger_mod
+
+    entries = list(ledger_mod.read_history(tmp_path))
+    info = loop.describe_ledger_comparability(AppConfig(), entries)
+    assert info["history_entries"] == 1
+    assert info["comparable_search_set_states"] == 1
+    assert info["high_water_objective_adjusted"] == 27
+    assert info["incomparable_reasons"] == []
+
+
+def test_describe_comparability_names_the_role_that_drifted(tmp_path):
+    """The 2026-08-23 trap: settings.json moved chat off the code default since
+    the healthy sibling ran; the launch line must name that field before hours
+    are paid."""
+    import dataclasses
+
+    drifted = dataclasses.asdict(AppConfig())
+    drifted["models"]["chat"] = "gemma4:e2b"
+    _seed_entry(
+        tmp_path, 1, 27,
+        [{"id": "a", "case_type": "factual_number", "passed": True, "elapsed_seconds": 200.0}],
+        effective_config=drifted,
+    )
+    from harness import ledger as ledger_mod
+
+    entries = list(ledger_mod.read_history(tmp_path))
+    info = loop.describe_ledger_comparability(AppConfig(), entries)
+    assert info["comparable_search_set_states"] == 0
+    assert info["incomparable_reasons"] == ["models.chat: this launch 'gemma4:e4b', ledger 'gemma4:e2b'"]
+
+
+def test_describe_comparability_explains_fast_tier_only_history(tmp_path):
+    """A config that matches but never produced a full search-set pass vector
+    is not usable as a high water -- say that instead of a config diff."""
+    _seed_entry(
+        tmp_path, 1, 8,
+        [{"id": "a", "case_type": "factual_number", "passed": True, "elapsed_seconds": 200.0}],
+        verdict="rejected_regression",
+        evaluated_case_set="fast_tier",
+    )
+    from harness import ledger as ledger_mod
+
+    info = loop.describe_ledger_comparability(AppConfig(), list(ledger_mod.read_history(tmp_path)))
+    assert info["comparable_search_set_states"] == 0
+    assert info["incomparable_reasons"] == [
+        "config matches the latest entry but it carries no complete search-set pass vector"
+    ]


### PR DESCRIPTION
## Summary
Every non-dry-run harness launch now prints, before the reference measurement is paid:

\\\
ledger history: 7 entry(ies), 0 comparable search-set state(s)
  WARNING recovery-mode history mismatch -- models.chat: this launch 'gemma4:e4b', ledger 'gemma4:e2b'
\\\

Recovery mode pairs regressions against comparable prior history (same model roles, chunking, index-time flags). Until now that comparability only surfaced in the final report -- after every evaluation was paid. The concrete failure this closes: a settings.json role drift would have made the #92 validation campaign silently run without recovery pairing and 'prove' the fix does not work.

The eligibility predicate (\is_comparable_search_set_entry\) is extracted and shared by the high-water search, the report's eligible count, and this line, so they cannot diverge. Arming itself depends on the measured reference objective, so the line reports comparability and never promises arming.

## Issue
Fixes #100

## Test plan
- 4 new tests in \harness/tests/test_loop.py\: empty ledger, comparable entry counted with its high water, role drift named field-by-field (the exact observed trap), and fast-tier-only history explained.
- \pytest harness/tests\: 154 passed. \uff check harness/\: clean.