### PR TITLE
Make --set pins reach every measured evaluation, not just the bookkeeping (#101)

### DIFF
--- a/harness/README.md
+++ b/harness/README.md
@@ -325,7 +325,9 @@ python -m harness.cli --proposer llm --max-iterations 8 --patience 3
 
 # Real campaign pinned to be comparable with prior ledger history -- e.g. a
 # criterion-5 recovery run against a sabotaged reference (--set is
-# repeatable; unknown keys abort at launch before any evaluation):
+# repeatable; unknown keys abort at launch; pins reach EVERY measured
+# evaluation, the reference's included -- not just the harness's bookkeeping
+# config):
 RAG_TOP_K_FINAL=1 python -m harness.cli \
     --ledger-dir tests/eval/runs/harness-loop \
     --set models.rag=gemma4:e4b --set models.chat=gemma4:e2b \

--- a/harness/cli.py
+++ b/harness/cli.py
@@ -206,6 +206,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             unreachable_ids=unreachable_ids,
             max_iterations=args.max_iterations, patience=args.patience,
             ledger_dir=ledger_dir,
+            reference_overrides=set_overrides,
         )
     except evaluator_mod.ReachabilityError as exc:
         print(f"REACHABILITY GATE FAILED: {exc}", file=sys.stderr)

--- a/harness/loop.py
+++ b/harness/loop.py
@@ -469,6 +469,7 @@ def run_loop(
     ledger_dir=ledger_mod.LEDGER_DIR,
     verify_reachability: bool = True,
     reachability_probe_case_ids: Sequence[str] = (),
+    reference_overrides: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Run the search until termination, writing one ledger entry per iteration.
 
@@ -500,6 +501,15 @@ def run_loop(
             intentionally use an evaluator too narrow to answer the probe
             (e.g. one that only ever sees a fixed, tiny case set).
         reachability_probe_case_ids: Forwarded to ``evaluator.verify_reachable``.
+        reference_overrides: Dotted-key pins (e.g. from ``cli --set``) applied
+            to EVERY evaluation this run makes, the reference's included, and
+            merged under each candidate's own overrides. Without them the
+            reference measurement would silently re-derive its config from
+            environment and settings.json while the harness's ``reference``
+            object claims otherwise -- a pin that never reaches the measured
+            pipeline is how a campaign fabricates a baseline (issue #101,
+            caught live 2026-08-23: the sabotaged reference scored healthy-27
+            because only the bookkeeping object saw the sabotage).
 
     Returns:
         The final report: reference stats, ratchet, best iteration, iteration
@@ -518,11 +528,13 @@ def run_loop(
     if max_iterations is None and patience is None:
         raise ValueError("run_loop needs max_iterations and/or patience to guarantee termination")
 
+    reference_overrides = dict(reference_overrides or {})
+
     if verify_reachability:
         evaluator_mod.verify_reachable(evaluate, reachability_probe_case_ids)
 
-    reference_full = evaluate({}, tuple(search_set_ids))
-    reference_fast = evaluate({}, tuple(fast_tier_ids))
+    reference_full = evaluate(dict(reference_overrides or {}), tuple(search_set_ids))
+    reference_fast = evaluate(dict(reference_overrides or {}), tuple(fast_tier_ids))
     if _has_infrastructure_error(reference_full.records) or _has_infrastructure_error(
         reference_fast.records
     ):
@@ -592,8 +604,9 @@ def run_loop(
         meta = dict(getattr(proposer, "last_meta", {}))
         git_commit = ledger_mod.read_git_commit()
 
-        fast_result = evaluate(overrides, tuple(fast_tier_ids))
-
+        fast_result = evaluate(
+            {**reference_overrides, **overrides}, tuple(fast_tier_ids)
+        )
         if _has_infrastructure_error(fast_result.records):
             entry = _build_entry(
                 iteration=iteration,
@@ -632,7 +645,9 @@ def run_loop(
                     regression_baseline_iteration=recovery_baseline_iteration,
                 )
             else:
-                full_result = evaluate(overrides, tuple(search_set_ids))
+                full_result = evaluate(
+                    {**reference_overrides, **overrides}, tuple(search_set_ids)
+                )
                 last_result = full_result
 
                 if _has_infrastructure_error(full_result.records):
@@ -720,6 +735,9 @@ def run_loop(
             "objective_adjusted": reference_objective_adjusted,
             "median_latency_answered_s": reference_latency.get("answered"),
             "median_latency_retrieval_only_s": reference_latency.get("retrieval_only"),
+            # Provenance: what every measurement this run actually applied,
+            # so a pinned campaign is auditable from the report alone.
+            "overrides_applied": dict(reference_overrides),
         },
         "ratchet": ratchet,
         "best_iteration": best_iteration,

--- a/harness/tests/test_cli.py
+++ b/harness/tests/test_cli.py
@@ -1,5 +1,6 @@
-"""Tests for harness.cli -- --replay (criterion 7) wiring."""
+"""Tests for harness.cli -- --replay (criterion 7) and --set wiring."""
 
+import json
 import sys
 from pathlib import Path
 
@@ -84,8 +85,10 @@ def test_set_overrides_reach_the_reference_and_unknown_keys_fail_hard(tmp_path, 
         "--set", "retrieval.top_k_final=6",
     ])
     assert code == 0
-    report = (tmp_path / "report.json")
-    assert report.exists()
+    report = json.loads((tmp_path / "report.json").read_text(encoding="utf-8"))
+    # The pin reached the MEASURED pipeline, not only the bookkeeping object:
+    # the demo evaluator echoes its applied overrides as effective_config.
+    assert report["reference"]["overrides_applied"] == {"retrieval.top_k_final": 6}
 
     code = cli.main([
         "--dry-run", "--max-iterations", "1", "--ledger-dir", str(tmp_path),

--- a/harness/tests/test_loop.py
+++ b/harness/tests/test_loop.py
@@ -906,3 +906,71 @@ def test_describe_comparability_explains_fast_tier_only_history(tmp_path):
     assert info["incomparable_reasons"] == [
         "config matches the latest entry but it carries no complete search-set pass vector"
     ]
+
+
+# REFERENCE OVERRIDES (issue #101, caught live 2026-08-23): --set pins used to
+# exist only on the harness's bookkeeping AppConfig, while the measured
+# pipeline re-derived its config from environment and settings.json -- a
+# sabotaged reference that scores healthy. The pins must reach every evaluate()
+# call this run makes.
+
+
+def test_reference_overrides_reach_every_evaluation(tmp_path):
+    """The reference measurement applies the pins; each candidate's evaluation
+    merges them under its own overrides."""
+    seen: list = []
+
+    def evaluate(overrides, case_ids):
+        seen.append(dict(overrides))
+        records = [_rec(cid, "factual_number", True, 200.0) for cid in case_ids]
+        return ev.EvaluationResult(records=tuple(records), effective_config=dict(overrides))
+
+    report = loop.run_loop(
+        reference=AppConfig(),
+        evaluate=evaluate,
+        proposer=_FixedProposer({"retrieval.top_k_final": 12}),
+        search_set_ids=("a", "b", "c"),
+        fast_tier_ids=("a",),
+        unreachable_ids=(),
+        max_iterations=1,
+        patience=None,
+        ledger_dir=tmp_path,
+        verify_reachability=False,
+        reference_overrides={"retrieval.top_k_final": 1},
+    )
+
+    # Calls in order: reference full, reference fast, candidate fast, candidate full.
+    assert seen[0] == {"retrieval.top_k_final": 1}
+    assert seen[1] == {"retrieval.top_k_final": 1}
+    # Candidate evaluations carry the pins under the candidate's own value.
+    assert seen[2] == {"retrieval.top_k_final": 12}
+    assert seen[3] == {"retrieval.top_k_final": 12}
+    # Provenance lands in the report so a pinned campaign is auditable.
+    assert report["reference"]["overrides_applied"] == {"retrieval.top_k_final": 1}
+
+
+def test_candidate_overrides_win_over_reference_pins(tmp_path):
+    """A candidate key colliding with a pin is the candidate's to decide --
+    the proposer owns the searched axes even when the reference pins one."""
+
+    def evaluate(overrides, case_ids):
+        records = [_rec(cid, "factual_number", True, 200.0) for cid in case_ids]
+        return ev.EvaluationResult(records=tuple(records), effective_config=dict(overrides))
+
+    report = loop.run_loop(
+        reference=AppConfig(),
+        evaluate=evaluate,
+        proposer=_FixedProposer({"retrieval.top_k_final": 8}),
+        search_set_ids=("a",),
+        fast_tier_ids=("a",),
+        unreachable_ids=(),
+        max_iterations=1,
+        patience=None,
+        ledger_dir=tmp_path,
+        verify_reachability=False,
+        reference_overrides={"retrieval.top_k_final": 1},
+    )
+
+    entry = report["iterations"][0]
+    # The candidate's own value reached the ledger's provenance.
+    assert entry["config_overrides"] == {"retrieval.top_k_final": 8}


### PR DESCRIPTION
## Summary
Follow-up to #103, with a field failure that proves the point. In today's criterion-5 recovery campaign, \--set retrieval.top_k_final=1\ built a correctly-pinned \AppConfig\ for the harness's ratchet and comparability view, but the reference measurement calls \evaluate({})\, which re-derives its config from environment and settings.json. Result: the 'sabotaged' reference scored a healthy 27/32 while the bookkeeping claimed k=1 -- a campaign measuring one configuration and reporting another.

\un_loop\ now takes \eference_overrides\: applied verbatim to the reference's own evaluations, merged under each candidate's overrides (the proposer still owns the searched axes), and recorded in the report under \eference.overrides_applied\ so a pinned campaign is auditable from the report alone.

## Issue
Fixes #101 (the flag existed but silently did not steer what was measured; this closes the gap under the repo's hard-fail spirit)

## Test plan
- New loop test: call-order proof that pins hit both reference evaluations and merge into candidate evaluations; provenance lands in the report.
- New precedence test: a candidate key colliding with a pin wins.
- Strengthened CLI test: the dry-run report itself shows \overrides_applied\.
- \pytest harness/tests\: 159 passed. \uff check harness/\: clean.