### PR TITLE
Record the criterion-5 field validation of recovery mode in the design doc (#92)

### DIFF
--- a/docs/design/2026-07-28-loop-automejorable.md
+++ b/docs/design/2026-07-28-loop-automejorable.md
@@ -577,6 +577,26 @@ Adoptados por defecto; cualquiera es revisable.
 > registra en `regression_baseline_iteration` (schema v2) contra qué iteración
 > del libro se emparejó. Implementación: `harness/loop.py`
 > (`_historical_high_water`, `_comparable_config_view`).
+>
+> **Validación de campo, 2026-08-23 (cierra #92).** Tres campañas reales en un
+> día, cada fallo con su lección: (A) lanzar con los defaults de máquina hizo
+> que `usar_contextual_retrieval` derivara a True frente al ledger sano
+> (False), historia comparable cero, modo recuperación silenciosamente apagado
+> y candidatos bloqueados igual que en #89 -- la razón de ser de la línea de
+> arranque de #100; (B) el `--set` de #103 sólo tocaba el objeto de
+> contabilidad del arnés mientras la medición rederivaba su configuración desde
+> settings: la referencia «saboteada» puntuó 27 sano -- arreglado en #106, y el
+> gate de alcanzabilidad rechazó además los pines de rol que `evaluate()` no
+> honra; (C) con los pines llegando al pipeline (`overrides_applied` en el
+> informe lo prueba): referencia saboteada 24/32, recuperación armada contra la
+> marca de agua de 2026-08-19 (27, iteración 3), el candidato `top_k_final=8`
+> dejó de ser castigado por re-perder `planck-sigma8-es` y fue rechazado por
+> una pérdida REAL (`planck-contours-figure`) contra lo ganado y nombrada con
+> su iteración base. El emparejamiento queda validado; la recuperación completa
+> de etapa 1 choca aparte con una deriva real del stack descubierta ese mismo
+> día -- el caso `planck-contours-figure` pasa en el ledger de agosto, falla hoy
+> sin descripciones y pasa hoy con ellas -- registrada como problema de
+> envejecimiento del baseline (#107), no como defecto del emparejamiento.
 - **Terminación:** presupuesto de iteraciones, o parada tras varias iteraciones
   seguidas sin superar el suelo de ruido.
 - **Comparación pareada** sobre los mismos casos, nunca entre tasas de runs


### PR DESCRIPTION
## Summary
Appends the 2026-08-23 field-validation note to the recovery-mode decision block in design doc section 5: three campaigns (A: silent incomparability from settings drift, motivating #100; B: pins that never reached the measured pipeline, fixed in #106, reachability gate refusing unhonourable role keys; C: end-to-end validation, sabotage measured at 24/32, recovery armed against the August high-water, luck pass not counted, real loss named with its baseline iteration). Stage-1 recovery's remaining blocker is baseline aging, filed as #107, not a pairing defect.

## Issue
Closes the documentation half of #92 (issue already closed with evidence).

## Test plan
Docs only. Harness suite still green (159 passed) after the edit.