### PR TITLE
Declare the label set and check the contribution standard against it (#109)

### DIFF
--- a/.github/ISSUE_TEMPLATE/measurement.md
+++ b/.github/ISSUE_TEMPLATE/measurement.md
@@ -1,0 +1,58 @@
+---
+name: Measurement / campaign finding
+about: Something a gate run, probe or harness campaign measured, and what it implies
+labels: eval
+---
+
+<!-- Conventions: CONTRIBUTING.md. This template exists because the two others
+did not fit the work this repo mostly does: #30, #102 and #107 each report a
+measurement, cite a local gitignored artifact, and propose options rather than
+a direction -- and each was written free-form, so none of them look alike.
+
+Swap the `eval` label for `loop` (or carry both) per CONTRIBUTING.md's issue
+standard: `eval` is the measurement, `loop` is the optimiser built on it. -->
+
+## What was measured
+
+<!-- The number first, then the setup. Date, machine and stack, because a
+measurement without them cannot be reproduced or aged out. A table beats a
+paragraph when there is more than one figure:
+
+| when | config | result |
+|---|---|---|
+| 2026-08-19 | healthy, descriptions off | 44/51 = 0.8627 |
+-->
+
+## Artifact
+
+<!-- Which run produced it. `tests/eval/runs/` and `harness/ledger/` are
+gitignored: say so explicitly and give the path anyway, so the machine that
+holds it can reproduce the reading. Cited, not shipped.
+
+Example: tests/eval/runs/20260729T020233Z_mineru-jina_clip-faiss.json (local) -->
+
+## What it implies
+
+<!-- The consequence, stated so it can be argued with. If the measurement
+contradicts something already written down -- a design doc section, a README
+claim, another issue's assumption -- name it here; that contradiction is
+usually the actual finding. If it is a limit rather than a defect, say which
+of the two it is. -->
+
+## Options
+
+<!-- Numbered, each with its cost, and say which way you lean and why. Not
+deciding here is fine and often correct; deciding here without the cost of
+each option is not. -->
+
+## Closure criterion
+
+<!-- What observable fact closes this: a measurement back in range on a named
+run, a test that reproduces the effect and passes, or a written decision
+including "won't do" with its reasoning.
+
+If it CANNOT be closed autonomously -- a human audit against source PDFs, an
+owner decision on a protected zone (`requirements*.txt`, flag defaults,
+`tests/eval/`, `tests/characterization/`) -- state that here, in the opening
+post, the way #30 does. An agent that discovers the gate halfway through has
+already spent the budget. -->

--- a/.github/labels.json
+++ b/.github/labels.json
@@ -1,0 +1,107 @@
+{
+  "_comment": [
+    "The declared label set for this repository -- one source, so CONTRIBUTING.md's",
+    "issue standard cannot cite a label that does not exist (issue #109: it cited",
+    "`docs`, which is really `documentation`, and `loop`, which had never been",
+    "created, while omitting `performance` and `research`, which were in use).",
+    "",
+    "`kind` decides what the standard requires:",
+    "  type            -- an issue carries exactly one; this is the 'one label",
+    "                     minimum' in CONTRIBUTING.md.",
+    "  modifier        -- optional, stacks on a type label.",
+    "  github-default  -- shipped by GitHub when the repository was created and",
+    "                     kept only so this file is a complete inventory. Not part",
+    "                     of the standard; nothing here is expected to use them.",
+    "",
+    "Colours are hex without the leading '#', matching `gh label list --json color`.",
+    "tests/unit/test_contribution_standard_drift.py checks the documentation",
+    "against this file; .github/workflows/labels.yml checks this file against the",
+    "labels GitHub actually holds."
+  ],
+  "labels": [
+    {
+      "name": "bug",
+      "color": "d73a4a",
+      "description": "Something isn't working",
+      "kind": "type"
+    },
+    {
+      "name": "enhancement",
+      "color": "a2eeef",
+      "description": "New feature or request",
+      "kind": "type"
+    },
+    {
+      "name": "documentation",
+      "color": "0075ca",
+      "description": "Improvements or additions to documentation",
+      "kind": "type"
+    },
+    {
+      "name": "eval",
+      "color": "1d76db",
+      "description": "Gold cases, grading and the measurement gate",
+      "kind": "type"
+    },
+    {
+      "name": "loop",
+      "color": "0052cc",
+      "description": "The self-improvement harness: search, ledger, campaigns",
+      "kind": "type"
+    },
+    {
+      "name": "performance",
+      "color": "0e8a16",
+      "description": "Latency, throughput and resource use",
+      "kind": "type"
+    },
+    {
+      "name": "research",
+      "color": "5319e7",
+      "description": "Exploration with a written conclusion",
+      "kind": "type"
+    },
+    {
+      "name": "cleanup",
+      "color": "fef2c0",
+      "description": "Removing dead weight from the repo",
+      "kind": "type"
+    },
+    {
+      "name": "wontfix",
+      "color": "ffffff",
+      "description": "This will not be worked on",
+      "kind": "modifier"
+    },
+    {
+      "name": "duplicate",
+      "color": "cfd3d7",
+      "description": "This issue or pull request already exists",
+      "kind": "github-default"
+    },
+    {
+      "name": "good first issue",
+      "color": "7057ff",
+      "description": "Good for newcomers",
+      "kind": "github-default"
+    },
+    {
+      "name": "help wanted",
+      "color": "008672",
+      "description": "Extra attention is needed",
+      "kind": "github-default"
+    },
+    {
+      "name": "invalid",
+      "color": "e4e669",
+      "description": "This doesn't seem right",
+      "kind": "github-default"
+    },
+    {
+      "name": "question",
+      "color": "d876e3",
+      "description": "Further information is requested",
+      "kind": "github-default"
+    }
+  ]
+}

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,0 +1,81 @@
+name: Labels
+
+# The half of the contribution standard a unit test cannot see.
+#
+# tests/unit/test_contribution_standard_drift.py checks CONTRIBUTING.md and the
+# issue templates against .github/labels.json -- two files in the working tree,
+# no network, so it runs in the fast gate. But labels.json is a claim ABOUT
+# GitHub, and the drift that opened issue #109 was exactly that kind: the docs
+# named `docs` and `loop`, and neither existed on the repository. Declaring them
+# in a file would have moved the lie one step, not removed it.
+#
+# So this job asks GitHub. Verification only -- it never creates, edits or
+# deletes a label. Adding one stays three deliberate steps (create it on GitHub,
+# declare it here, document it in CONTRIBUTING.md); a workflow that silently
+# reconciled the difference would decide which side was right, and it is never
+# in a position to know.
+
+on:
+  pull_request:
+    paths:
+      - .github/labels.json
+      - .github/workflows/labels.yml
+  push:
+    branches: [main]
+    paths:
+      - .github/labels.json
+      - .github/workflows/labels.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: read
+
+jobs:
+  declared-matches-github:
+    name: Declared labels match the repository
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Compare .github/labels.json against `gh label list`
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh label list --limit 200 --json name,color,description > /tmp/actual.json
+          python3 - <<'PY'
+          import json
+          import sys
+
+          declared = {
+              entry["name"]: entry
+              for entry in json.load(open(".github/labels.json"))["labels"]
+          }
+          actual = {entry["name"]: entry for entry in json.load(open("/tmp/actual.json"))}
+
+          problems = []
+          for name in sorted(set(declared) - set(actual)):
+              problems.append(
+                  f"declared but absent from GitHub: {name!r} -- create it "
+                  f"(`gh label create {name!r} --color {declared[name]['color']} "
+                  f"--description {declared[name]['description']!r}`) or drop the declaration"
+              )
+          for name in sorted(set(actual) - set(declared)):
+              problems.append(
+                  f"exists on GitHub but undeclared: {name!r} -- add it to "
+                  ".github/labels.json (and to CONTRIBUTING.md's table if it is a type label)"
+              )
+          for name in sorted(set(declared) & set(actual)):
+              for field in ("color", "description"):
+                  if declared[name][field] != actual[name][field]:
+                      problems.append(
+                          f"{name!r} {field}: declared {declared[name][field]!r}, "
+                          f"GitHub has {actual[name][field]!r}"
+                      )
+
+          if problems:
+              print("Label declaration and repository disagree:\n")
+              for problem in problems:
+                  print(f"  - {problem}")
+              sys.exit(1)
+          print(f"{len(declared)} labels declared, all matching the repository.")
+          PY

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,13 +72,55 @@ An issue exists to be closable with evidence:
 - **Evidence over opinion.** Measurements, run artifacts and logs beat design
   taste. Cite local artifacts explicitly as local (`tests/eval/runs/` is
   gitignored — cited, not shipped).
-- **One label minimum**: `bug`, `enhancement`, `eval`, `docs`, `cleanup`,
-  plus `loop` for anything touching the self-improvement harness.
+- **One type label minimum.** Pick the one that says what the issue *is*;
+  stack a modifier only if it adds something.
+
+  <!-- labels:begin -->
+  <!-- Declared in .github/labels.json; both lists are checked against it by
+       tests/unit/test_contribution_standard_drift.py, so a label named here
+       and missing there (or the reverse) is a red test, not a discovery
+       someone makes at `gh issue create` time. -->
+
+  | Type label | Use it when |
+  |---|---|
+  | `bug` | The shipped product does something wrong. |
+  | `enhancement` | A capability or behaviour change the product does not have. |
+  | `eval` | Gold cases, grading, the measurement gate itself. |
+  | `loop` | The self-improvement harness: search space, ledger, campaigns. |
+  | `performance` | Latency, throughput or resource use is the subject. |
+  | `research` | An exploration whose deliverable is a written conclusion. |
+  | `documentation` | The docs are wrong, missing or contradict the code. |
+  | `cleanup` | Removing dead weight; no behaviour change intended. |
+
+  Modifier: `wontfix`, applied when closing with the reasoning, never instead
+  of it.
+  <!-- labels:end -->
+
+  `eval` and `loop` are not synonyms. `eval` is the measurement — cases,
+  grading, the gate's own correctness. `loop` is the optimiser that consumes
+  it. An issue about a case the grader scores wrong is `eval`; an issue about
+  a campaign pairing against the wrong baseline is `loop`; one that is both
+  carries both.
 - **Closing comment carries the proof**: the numbers, the merged PRs, or the
   reasoned decision (including "won't do", with the reasoning). An issue
   closed without evidence will be reopened.
 - Design decisions that change product architecture or the loop get a dated
   block in the relevant `docs/design/*.md` **before** code moves.
+
+### Where the standard is enforced, not just written
+
+Three checks, because a written convention drifted for months once already
+(`docs` and `loop` were named here while neither existed on GitHub, issue
+#109):
+
+| Check | What it holds | Runs in |
+|---|---|---|
+| `tests/unit/test_contribution_standard_drift.py` | This document and the issue templates name only declared labels, and every type label is documented here | fast gate, `architecture` job |
+| `.github/workflows/labels.yml` | `.github/labels.json` matches the labels GitHub actually holds | on changes to that file, and on demand |
+| `.github/ISSUE_TEMPLATE/`, `blank_issues_enabled: false` | Every new issue starts from a template | GitHub itself |
+
+Adding a label is therefore three edits and no ambiguity: create it on
+GitHub, declare it in `.github/labels.json`, name it in the table above.
 
 ## Protected zones (owner agreement required)
 

--- a/tests/unit/test_contribution_standard_drift.py
+++ b/tests/unit/test_contribution_standard_drift.py
@@ -1,0 +1,189 @@
+"""Documentation drift check: the labels the contribution standard names
+against the labels this repository declares.
+
+``CONTRIBUTING.md``'s issue standard states a "one label minimum". On
+2026-09-01 that list named six labels, of which two did not exist (``docs``
+-- the real label is ``documentation`` -- and ``loop``, never created), while
+two labels carrying live issues (``performance``, ``research``) were absent
+from it (issue #109). An agent following the standard literally got an error
+from ``gh issue create --label docs`` or invented a label; the distinction
+``loop`` was meant to draw, between the measurement gate and the optimiser
+built on it, was recorded nowhere, and all three open harness issues sat
+under ``eval``.
+
+This is the defect class of issue #63 (``.env.example`` documenting three
+variables no code read), one level up: a pointer that names something which
+does not exist, reading as authoritative because it is written down. The
+answer here is the same as the answer there -- check it mechanically instead
+of hand-auditing it -- and the same as this repo's answer everywhere else:
+``tests/unit/test_architecture_boundaries.py`` parses imports,
+``harness/tests/test_harness_boundaries.py`` parses write calls, neither
+trusts the eye.
+
+Both directions are checked, because the drift ran both ways:
+
+1. Every label the documentation names is declared in ``.github/labels.json``.
+2. Every ``kind: type`` label declared there is named by the documentation.
+
+## Scope boundary
+
+This file compares two files in the working tree. It cannot see the labels
+GitHub actually holds -- that needs the API, which the fast gate has no
+network for and no business calling. ``.github/workflows/labels.yml`` closes
+that half of the loop with ``gh label list`` on a runner that is already
+authenticated. Detection only, in both places: a failure means a human reads
+the diff and decides which side is wrong, per ``docs/README.md``'s "the code
+is the source of truth" rule inverted for a file whose source of truth is
+GitHub itself.
+
+Standard library plus pytest, no YAML parser, so this runs in the fast
+gate's ``architecture`` job (``.github/workflows/ci.yml``) with nothing
+installed. That is also why ``.github/labels.json`` is JSON and not the
+``labels.yml`` such files conventionally are: a dependency to read the
+declaration would put this check in a slower job, and a check that runs late
+is a check people learn to skip.
+"""
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_LABELS_FILE = _REPO_ROOT / ".github" / "labels.json"
+_CONTRIBUTING = _REPO_ROOT / "CONTRIBUTING.md"
+_TEMPLATE_DIR = _REPO_ROOT / ".github" / "ISSUE_TEMPLATE"
+
+# The documentation names labels in prose full of other backticked things
+# (`feat`, `pytest`, `requirements*.txt`), so the label list is delimited
+# explicitly rather than guessed at. Deleting the markers is itself a
+# failure -- see test_contributing_still_carries_the_delimited_label_block --
+# so the check cannot be silenced by removing what it reads.
+_BLOCK_BEGIN = "<!-- labels:begin -->"
+_BLOCK_END = "<!-- labels:end -->"
+
+_BACKTICKED = re.compile(r"`([^`]+)`")
+# HTML comments inside the block explain the block, and their prose contains
+# backticked things that are not labels (`gh issue create`). Stripping them
+# is not a hole: a label named only inside a comment is invisible to the
+# reader the standard is written for, so it is not a claim this check owes
+# anything to.
+_HTML_COMMENT = re.compile(r"<!--.*?-->", re.DOTALL)
+# GitHub issue-template frontmatter: `labels: eval, loop` on one line.
+_FRONTMATTER_LABELS = re.compile(r"^labels:\s*(.+)$", re.MULTILINE)
+
+_VALID_KINDS = ("type", "modifier", "github-default")
+_HEX_COLOR = re.compile(r"^[0-9a-f]{6}$")
+
+
+def _declared():
+    """Every label in ``.github/labels.json``, as ``{name: entry}``."""
+    data = json.loads(_LABELS_FILE.read_text(encoding="utf-8"))
+    return {entry["name"]: entry for entry in data["labels"]}
+
+
+def _contributing_text() -> str:
+    return _CONTRIBUTING.read_text(encoding="utf-8")
+
+
+def _labels_named_in_contributing() -> set:
+    """Backticked names inside CONTRIBUTING.md's delimited label block."""
+    text = _contributing_text()
+    start = text.index(_BLOCK_BEGIN) + len(_BLOCK_BEGIN)
+    end = text.index(_BLOCK_END)
+    block = _HTML_COMMENT.sub("", text[start:end])
+    return set(_BACKTICKED.findall(block))
+
+
+def _labels_named_in_templates() -> dict:
+    """``{template filename: {label, ...}}`` from each template's frontmatter."""
+    named = {}
+    for path in sorted(_TEMPLATE_DIR.glob("*.md")):
+        found = set()
+        for raw in _FRONTMATTER_LABELS.findall(path.read_text(encoding="utf-8")):
+            found.update(part.strip() for part in raw.split(",") if part.strip())
+        named[path.name] = found
+    return named
+
+
+def test_contributing_still_carries_the_delimited_label_block():
+    """The markers this check reads must exist, or it silently passes on nothing."""
+    text = _contributing_text()
+    assert _BLOCK_BEGIN in text and _BLOCK_END in text, (
+        f"CONTRIBUTING.md must delimit its label list with {_BLOCK_BEGIN} / "
+        f"{_BLOCK_END}. Without them this test would read an empty set and pass "
+        "regardless of what the standard says."
+    )
+    assert text.index(_BLOCK_BEGIN) < text.index(_BLOCK_END)
+    assert _labels_named_in_contributing(), "the delimited block names no label at all"
+
+
+def test_every_label_contributing_names_is_declared():
+    """Direction 1, the failure that opened #109: `docs` and `loop` were fiction."""
+    declared = _declared()
+    undeclared = sorted(_labels_named_in_contributing() - set(declared))
+    assert not undeclared, (
+        f"CONTRIBUTING.md names labels absent from {_LABELS_FILE.name}: {undeclared}. "
+        "Either the label was renamed on GitHub (fix the doc) or it is new "
+        "(declare it here and create it there)."
+    )
+
+
+def test_every_label_an_issue_template_assigns_is_declared():
+    """A template assigning an unknown label silently drops it on issue creation."""
+    declared = set(_declared())
+    offenders = {
+        name: sorted(labels - declared)
+        for name, labels in _labels_named_in_templates().items()
+        if labels - declared
+    }
+    assert not offenders, (
+        f"issue templates assign undeclared labels: {offenders}. GitHub applies "
+        "what it can and drops the rest without warning, so the issue lands "
+        "unlabelled instead of failing loudly."
+    )
+
+
+def test_every_type_label_is_named_by_the_standard():
+    """Direction 2: `performance` and `research` carried issues while unmentioned.
+
+    Only ``kind: type`` labels are required in the prose. Modifiers stack on a
+    type and need no separate mention; ``github-default`` entries are
+    inventory, kept so this file is a complete list of what exists, not part
+    of the standard.
+    """
+    declared = _declared()
+    expected = {name for name, entry in declared.items() if entry["kind"] == "type"}
+    missing = sorted(expected - _labels_named_in_contributing())
+    assert not missing, (
+        f"labels declared as `type` but not named in CONTRIBUTING.md's label "
+        f"block: {missing}. A type label nobody documents is one nobody applies."
+    )
+
+
+@pytest.mark.parametrize("field", ("name", "color", "description", "kind"))
+def test_every_declared_label_carries_every_field(field):
+    for name, entry in _declared().items():
+        assert entry.get(field), f"label {name!r} has no {field!r}"
+
+
+def test_declared_labels_are_well_formed():
+    """Kinds are from the fixed set, colours are bare hex, names are unique.
+
+    Uniqueness is checked against the raw list rather than the dict built from
+    it: ``_declared()`` would silently keep the last of two entries sharing a
+    name, which is exactly the kind of duplicate worth catching.
+    """
+    raw = json.loads(_LABELS_FILE.read_text(encoding="utf-8"))["labels"]
+    names = [entry["name"] for entry in raw]
+    assert len(names) == len(set(names)), f"duplicate label names: {names}"
+    for entry in raw:
+        assert entry["kind"] in _VALID_KINDS, (
+            f"label {entry['name']!r} has kind {entry['kind']!r}, "
+            f"expected one of {_VALID_KINDS}"
+        )
+        assert _HEX_COLOR.match(entry["color"]), (
+            f"label {entry['name']!r} has colour {entry['color']!r}; expected six "
+            "lowercase hex digits with no leading '#', matching `gh label list`"
+        )


### PR DESCRIPTION
## Summary

The contribution standard named two labels that do not exist and omitted two
that carry live issues. It is now declared as data and checked mechanically,
in both directions, instead of hand-audited.

- `.github/labels.json` — the declared set, with `kind` (`type` / `modifier` /
  `github-default`) deciding what the standard requires. JSON rather than the
  conventional `labels.yml` so the check needs no YAML parser and runs in the
  fast gate's dependency-free `architecture` job.
- `tests/unit/test_contribution_standard_drift.py` — CONTRIBUTING.md and every
  issue template name only declared labels, and every `type` label is
  documented. Both directions, because the drift ran both ways.
- `.github/workflows/labels.yml` — the half a unit test cannot see: the
  declaration against `gh label list`. Verify-only, never reconciles.
- `.github/ISSUE_TEMPLATE/measurement.md` — a third template, for the work this
  repo actually does most of.
- `CONTRIBUTING.md` — the corrected table, plus what enforces each half.

The `loop` label was created on GitHub as part of this (colour `0052cc`, so it
does not read as `research`'s `5319e7`). Nothing was renamed or deleted.

## Issue

Fixes #109

## Test plan

- [x] `pytest` green locally: 636 passed, 2 skipped (baseline before this
      change: 627 passed, 2 skipped — the 9 new tests are this PR's).
- [x] `ruff check .` clean.
- [x] **The new check was verified by breaking it, not by reading it.** Removed
      `performance` from `labels.json` → `test_every_label_contributing_names_is_declared`
      fails naming `['performance']`; restored → green. This is #109's stated
      closure criterion.
- [x] The workflow's comparison script was run locally against the live
      `gh label list`: 14 declared, all matching.
- [ ] Frontend untouched.
- [ ] Full gate not needed: no retrieval or generation code is touched.
- [ ] No protected-zone edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)