### PR TITLE
Delete _build_entry's unreachable second return, and check for the shape (#111)

### DIFF
--- a/harness/loop.py
+++ b/harness/loop.py
@@ -427,33 +427,6 @@ def _build_entry(
         reason=reason,
         regression_baseline_iteration=regression_baseline_iteration,
     )
-    if candidate_latency is None:
-        candidate_latency = evaluator_mod.median_latency_by_bucket(result.records)
-    return ledger_mod.LedgerEntry(
-        schema_version=ledger_mod.SCHEMA_VERSION,
-        iteration=iteration,
-        parent_iteration=parent_iteration,
-        git_commit=git_commit,
-        config_overrides=dict(overrides),
-        effective_config=dict(result.effective_config),
-        proposer=meta.get("proposer", "unknown"),
-        proposer_rationale=meta.get("rationale"),
-        proposer_model=meta.get("model"),
-        proposer_fallback=bool(meta.get("fallback", False)),
-        proposer_fallback_reason=meta.get("fallback_reason"),
-        evaluated_case_set=evaluated_case_set,
-        case_records=[dataclasses.asdict(r) for r in result.records],
-        summary=_summary(result.records),
-        objective_raw=objective_raw,
-        objective_adjusted=objective_adjusted,
-        median_latency_answered_s=candidate_latency.get("answered"),
-        median_latency_retrieval_only_s=candidate_latency.get("retrieval_only"),
-        reference_median_latency_answered_s=reference_latency.get("answered"),
-        reference_median_latency_retrieval_only_s=reference_latency.get("retrieval_only"),
-        latency_ceiling_multiplier=LATENCY_CEILING_MULTIPLIER,
-        verdict=verdict,
-        reason=reason,
-    )
 
 
 def run_loop(

--- a/tests/unit/test_no_unreachable_code.py
+++ b/tests/unit/test_no_unreachable_code.py
@@ -1,0 +1,145 @@
+"""No statement in this repository sits after a `return`, `raise`, `break` or
+`continue` in the same block.
+
+Issue #111. ``harness/loop.py::_build_entry`` carried two consecutive
+``return ledger_mod.LedgerEntry(...)`` statements for months. PR #94 (issue
+#92, recovery mode) added the new construction above the one it replaced and
+did not delete the old one, so 26 lines could never execute.
+
+No behaviour was wrong -- the first return is the live, correct one. What
+made it worth a check rather than a shrug is that **the two copies had
+diverged, and in the direction that matters**: the dead one did not pass
+``regression_baseline_iteration``, the field whose entire purpose is making
+it auditable which baseline an entry was paired against. A reader saw two
+plausible constructions of the same object; any edit removing or reordering
+the first would have silently dropped recovery mode's provenance. Redundant
+is noise. Redundant *and* subtly wrong is a trap.
+
+Nothing in the repo would have caught it. ``ruff.toml`` enables no
+unreachable-code rule, and the failure is invisible to a reader who does not
+happen to scroll past the first ``return`` of a 30-line constructor call --
+which is exactly the shape a merge resolution leaves behind.
+
+## Scope
+
+Every ``.py`` file in the repository except the virtualenvs: the defect is a
+merge-resolution artifact, and merges happen in ``src/``, ``rag/``, ``tests/``
+and ``harness/`` alike. It was zero everywhere else when this test was
+written (2026-09-01), so the check costs no triage -- it starts green and
+stays that way or something real happened.
+
+Standard library only, so this runs in the fast gate's ``architecture`` job.
+``test_the_check_catches_a_module_that_has_unreachable_code`` parses a
+deliberately broken source string, so "this passes" means the detector works,
+not merely that today's files happen to be clean -- the same guard-the-guard
+pattern as ``harness/tests/test_harness_boundaries.py``'s adversarial module.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Directories that are installed, generated or vendored -- not this repo's code.
+_SKIP_DIRS = frozenset(
+    {".venv", ".venv-mineru", "venv", "node_modules", "__pycache__", ".git", "build", "dist"}
+)
+
+# Statements after which nothing in the same block can run. `sys.exit()` and
+# `os._exit()` are deliberately absent: they are ordinary calls as far as the
+# parser is concerned, and treating them as terminal would need a name
+# resolution this check has no business doing.
+_TERMINAL = (ast.Return, ast.Raise, ast.Continue, ast.Break)
+
+# Every attribute of an AST node that holds a list of statements. A dead
+# statement can hide in an `else:` or a `finally:` as easily as in a body.
+_BLOCK_FIELDS = ("body", "orelse", "finalbody")
+
+
+def _unreachable_statements(tree: ast.AST):
+    """``(terminal_line, dead_line, dead_node_type)`` for each dead statement.
+
+    One report per block: the first statement after the terminal is enough to
+    locate the problem, and listing the remaining twenty-five would bury it.
+    """
+    found = []
+    for node in ast.walk(tree):
+        for field in _BLOCK_FIELDS:
+            block = getattr(node, field, None)
+            if not isinstance(block, list):
+                continue
+            for index, statement in enumerate(block[:-1]):
+                if isinstance(statement, _TERMINAL):
+                    dead = block[index + 1]
+                    found.append((statement.lineno, dead.lineno, type(dead).__name__))
+                    break
+    return found
+
+
+def _repository_python_files():
+    return sorted(
+        path
+        for path in _REPO_ROOT.rglob("*.py")
+        if not _SKIP_DIRS.intersection(path.relative_to(_REPO_ROOT).parts)
+    )
+
+
+def test_the_file_list_is_not_accidentally_empty():
+    """Guards the guard: a bad skip list would make the check below vacuous."""
+    files = _repository_python_files()
+    assert len(files) > 100, f"only {len(files)} python files found; the skip list is too broad"
+
+
+@pytest.mark.parametrize(
+    "path",
+    _repository_python_files(),
+    ids=lambda p: str(p.relative_to(_REPO_ROOT)),
+)
+def test_module_has_no_unreachable_statements(path):
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    dead = _unreachable_statements(tree)
+    assert not dead, (
+        f"{path.relative_to(_REPO_ROOT)} has unreachable code: "
+        + "; ".join(
+            f"line {dead_line} ({kind}) cannot run, the block returns/raises at line {terminal}"
+            for terminal, dead_line, kind in dead
+        )
+        + ". A merge resolution usually leaves this behind -- check whether the "
+        "live copy and the dead one have drifted apart before deleting either."
+    )
+
+
+_MODULE_WITH_DEAD_CODE = '''
+def build(value):
+    if value is None:
+        value = 0
+    return {"live": value, "provenance": "kept"}
+    return {"live": value}
+
+
+def loop(items):
+    for item in items:
+        continue
+        print(item)
+'''
+
+
+def test_the_check_catches_a_module_that_has_unreachable_code():
+    """The #111 shape, plus a dead statement after `continue` in a loop body."""
+    dead = _unreachable_statements(ast.parse(_MODULE_WITH_DEAD_CODE))
+    assert len(dead) == 2, dead
+    assert [kind for _, _, kind in dead] == ["Return", "Expr"]
+
+
+def test_the_check_does_not_flag_a_terminal_that_ends_its_block():
+    """An `if`/`else` where both arms return is the normal shape, not a defect."""
+    source = '''
+def classify(value):
+    if value > 0:
+        return "positive"
+    else:
+        return "not positive"
+'''
+    assert _unreachable_statements(ast.parse(source)) == []


### PR DESCRIPTION
## Summary

`harness/loop.py::_build_entry` had two consecutive `return
ledger_mod.LedgerEntry(...)` statements. The second, and the `if` guard above
it, could never execute — 26 dead lines left behind by PR #94's merge
resolution.

The live return is the correct one, so nothing behaved wrongly. The reason
this is not just a delete: **the dead copy had drifted from the live one**,
omitting `regression_baseline_iteration` — recovery mode's provenance field
(#92). Two plausible constructions of the same object, one silently missing a
field, is a trap for the next person who edits that function.

`tests/unit/test_no_unreachable_code.py` covers the whole repository, not just
`harness/`: a merge resolution can leave this anywhere. It was zero outside
this one function, so the check starts green.

## Issue

Fixes #111

## Test plan

- [x] **Verified by reintroducing the defect**, not by reading the diff:
      `git stash` puts `main`'s dead block back →
      `test_module_has_no_unreachable_statements[harness/loop.py]` fails;
      `git stash pop` → 156 passed.
- [x] AST-confirmed `_build_entry` now has exactly one `Return` in its body.
- [x] `pytest` green: 783 passed, 2 skipped (baseline 627 before today's work;
      +156 are this PR's per-file parametrisation).
- [x] `ruff check .` clean.
- [x] `harness/tests` green (159 passed) — the harness's own behaviour is
      unchanged, which is the point: the deleted code never ran.
- [ ] Full gate not needed: no retrieval or generation code is touched.
- [ ] No protected-zone edits.

## Follow-up not taken here

Issue #111's option 2 (a lint rule instead of a test) is deliberately left
open: it would touch every file's lint configuration, and the fix should not
wait on that decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)