### PR TITLE
Record the stack each iteration measured on, and stop pairing across a known drift (#107)

### DIFF
--- a/docs/design/2026-07-28-loop-automejorable.md
+++ b/docs/design/2026-07-28-loop-automejorable.md
@@ -597,6 +597,49 @@ Adoptados por defecto; cualquiera es revisable.
 > día -- el caso `planck-contours-figure` pasa en el ledger de agosto, falla hoy
 > sin descripciones y pasa hoy con ellas -- registrada como problema de
 > envejecimiento del baseline (#107), no como defecto del emparejamiento.
+>
+> **Huella de entorno en la comparabilidad (decisión del 2026-09-01,
+> issue #107).** `_comparable_config_view` decide la comparabilidad a partir
+> de la *configuración* -- modelos, troceado, flags de indexado -- y es muda
+> sobre si el pipeline era el mismo. La campaña C de 2026-08-23 lo demostró:
+> la entrada sana de 2026-08-19 retenía un pase que el stack de aquel día ya
+> no alcanzaba, así que el rechazo era correcto en la lógica y falso en el
+> fondo. Sin arreglo, basta con acumular deriva para que toda campaña de
+> criterio 5 termine en `rejected_regression` sobre pases fantasma, esta vez
+> sin defecto que corregir, y la tentación pase a ser editar la historia en
+> lugar de refrescarla. Decisión: cada entrada registra la **pila instalada**
+> con la que se midió (`harness/environment.py`, ledger schema v3), y una
+> entrada medida sobre una pila **conocidamente distinta** deja de ser
+> comparable. Dos entornos separados y nunca fundidos, porque deciden cosas
+> distintas y conviven con versiones distintas a propósito: el aislado
+> (`.venv-mineru`: MinerU y jina-clip construyen el índice) y el del producto
+> (reranker BGE, FAISS, BM25, cliente Ollama). El commit de git queda fuera
+> de la comparación: ya se registra por entrada y se mueve con cualquier
+> cambio, incluido un README, así que incluirlo no sería estricto sino
+> inservible.
+>
+> Lo que fija la decisión no es qué se compara sino **qué significa no
+> saberlo**: `environment.compare` responde `match`, `differs` o `unknown`, y
+> sólo `differs` descarta. Toda entrada anterior al schema v3 carece de
+> huella, y tratar «desconocido» como «distinto» desarmaría el modo
+> recuperación sobre el ledger entero, es decir, resolvería #107 tirando la
+> evidencia sobre la que se construyó #92. Es la misma distinción que el
+> producto ya hace en `index_fingerprint.fingerprint_is_stale`: un valor
+> ausente no es un desacuerdo. En consecuencia, una huella ilegible es `None`
+> y nunca un diccionario de `None`s (dos entornos que no saben nada
+> compararían iguales y afirmarían una comparabilidad verificada que no
+> tienen), y la línea de arranque separa los estados comparables en
+> verificados y no verificados, para que «12 estados comparables» no se lea
+> como «12 medidos sobre esta pila» cuando ninguno lo dijo.
+>
+> Alcance declarado: esto hace **visible** la deriva, no vuelve alcanzable un
+> baseline envejecido. Eso es la opción 1 del propio #107, la campaña de
+> refresco -- volver a medir una rejilla sana sobre la pila actual contra el
+> mismo ledger, que la regla de empate-al-más-reciente prefiere sola. Esta
+> mitad es la que avisa, en el arranque y antes de pagar horas, de que lo que
+> el ledger necesita es un refresco. Implementación: `harness/environment.py`,
+> `harness/loop.py` (`is_comparable_search_set_entry`,
+> `describe_ledger_comparability`, `_historical_high_water`).
 - **Terminación:** presupuesto de iteraciones, o parada tras varias iteraciones
   seguidas sin superar el suelo de ruido.
 - **Comparación pareada** sobre los mismos casos, nunca entre tasas de runs

--- a/harness/README.md
+++ b/harness/README.md
@@ -456,3 +456,78 @@ Fixed alongside:
   it"), a healthy campaign's entries are what makes a later sabotaged run
   recoverable. Pointing a criterion-5 campaign at the same `--ledger-dir` as
   its healthy sibling is what arms recovery mode.
+
+## Environment drift (issue #107, decided 2026-09-01)
+
+Recovery mode above pairs against a comparable prior state, and
+`_comparable_config_view` decides comparability from **configuration alone**:
+model roles, chunking, index-time flags. That view is complete for what a
+campaign *asked* the pipeline and silent about whether the pipeline was the
+same one.
+
+The gap is not hypothetical. During the criterion-5 validation campaign of
+2026-08-23, the restoration candidate was rejected for losing
+`planck-contours-figure` against the healthy high water of 2026-08-19 — and
+the loss was real that day, measured three ways. Nothing in the pairing logic
+was wrong; the August entry simply held a pass the then-current stack could no
+longer reach. Left alone, enough drift makes every criterion-5 campaign end
+`rejected_regression` on ghost passes, recovery becomes structurally
+unreachable again with **no bug to fix**, and the tempting move is to edit
+history instead of refreshing it.
+
+`environment.py` records what was *installed*, per entry, alongside what was
+configured:
+
+- **Two environments, never merged.** `.venv-mineru` (MinerU, jina-clip) builds
+  the index; the product interpreter (BGE reranker, FAISS, BM25, the Ollama
+  client) decides retrieval and generation. `transformers`,
+  `sentence-transformers` and `torch` are installed in both at deliberately
+  different versions, so keys are qualified (`isolated:transformers` vs
+  `product:transformers`). One merged key would record one of the two and drop
+  the other, and the dropped one is a real input to the result.
+- **A declared package list**, hand-written like `SEARCH_SPACE`: each entry is
+  a claim that this package can change a case's outcome. A `pip freeze`
+  fingerprint would report drift on every unrelated transitive bump.
+- **The git commit is not part of it.** It is already recorded per entry and it
+  moves on every commit, README edits included. Folding it in would make every
+  entry incomparable with every other one — not strict, useless.
+- **Read from `*.dist-info` directory names**, because `importlib` and
+  `subprocess` are both banned under `harness/`
+  (`test_harness_boundaries.py`). The restriction turns out to be the right
+  tool anyway: it is the only one of the three that can read the *isolated*
+  venv, a different interpreter this process never runs.
+
+### Unknown is not the same as different
+
+`environment.compare` answers `match`, `differs` or `unknown`, and
+`is_comparable_search_set_entry` rejects **only** `differs`.
+
+That is the whole design decision. Every entry written before ledger schema v3
+carries no fingerprint, so treating unknown as different would disarm recovery
+mode across the entire existing ledger — solving #107 by discarding the
+evidence #92 was built on. It is the same distinction
+`index_fingerprint.fingerprint_is_stale` draws in the product: a missing value
+is not a mismatch.
+
+Two consequences follow, and both are reported rather than hidden:
+
+- A fingerprint that could not be read at all is `None`, never a dict of
+  `None`s. Two environments that know nothing would otherwise compare equal
+  and claim a verified comparability neither has.
+- The launch line splits comparable states into verified and unverified, so
+  "12 comparable states" cannot be read as "12 measured on this stack" when
+  none of them said. Every report carries an `environment` block with the
+  fingerprint and whether it was readable.
+- **The count is not the fact that decides; the high water is.** A campaign
+  pairs against exactly one entry, so the launch line says separately whether
+  *that* entry's stack was verified (`high_water_environment_verified`). The
+  two answers differ precisely when the aged entry outscores every verified
+  one — the situation that opened #107 — and that is when a refresh is due.
+
+### What this does not do
+
+It makes drift **visible**; it does not make an aged baseline reachable again.
+That is issue #107's option 1, the refresh campaign: re-run a healthy grid on
+the current stack into the same ledger, and the latest-tie rule prefers the
+newer high water on its own. This half is what tells an operator, at launch
+and before hours are paid, that a refresh is what the ledger needs.

--- a/harness/cli.py
+++ b/harness/cli.py
@@ -33,6 +33,7 @@ import tempfile
 from pathlib import Path
 from typing import Any, Dict, Optional, Sequence
 
+from harness import environment as environment_mod
 from harness import evaluator as evaluator_mod
 from harness import ledger as ledger_mod
 from harness import loop as loop_mod
@@ -113,6 +114,54 @@ def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
+def format_comparability_lines(comparability: Dict[str, Any]) -> list:
+    """The launch line an operator reads before any evaluation is paid.
+
+    A function rather than a run of ``print`` calls so the lines themselves are
+    testable: their whole job is to carry facts a campaign depends on (issues
+    #100 and #107), and a mistyped key would silently drop the warning that
+    matters most while everything still ran green.
+
+    Args:
+        comparability: ``loop.describe_ledger_comparability``'s return value.
+
+    Returns:
+        Lines to print, in order.
+    """
+    lines = [
+        f"ledger history: {comparability['history_entries']} entry(ies), "
+        f"{comparability['comparable_search_set_states']} comparable search-set state(s)"
+    ]
+    if comparability["high_water_objective_adjusted"] is not None:
+        lines.append(
+            f"  historical high water: {comparability['high_water_objective_adjusted']} "
+            "(recovery mode arms only if the measured reference scores lower)"
+        )
+        # Issue #107's exact situation: the entry that will be paired against
+        # is itself the one whose stack nobody recorded. The count below is
+        # about the history; this is about the single entry that decides.
+        if comparability["high_water_environment_verified"] is False:
+            lines.append(
+                "  WARNING that high-water entry was NOT measured on a stack "
+                "comparable to this launch's -- it can hold passes this stack "
+                "cannot reach, which reads as a regression no candidate can fix. "
+                "A refresh campaign on the current stack is what replaces it (#107)"
+            )
+    # An unverified state still pairs. Saying so is the difference between
+    # "12 comparable states" read as "12 measured on this stack" and read as
+    # what it is: a stack an old entry never recorded is a stack nobody checked.
+    if comparability["environment_unverified_states"]:
+        lines.append(
+            f"  {comparability['environment_unverified_states']} of those carry no "
+            f"comparable stack fingerprint ({comparability['environment_verified_states']} "
+            "verified against this launch) -- pairing against them is unverified, "
+            "not wrong; a refresh campaign on this stack replaces them (#107)"
+        )
+    for reason in comparability["incomparable_reasons"]:
+        lines.append(f"  WARNING recovery-mode history mismatch -- {reason}")
+    return lines
+
+
 def _run_replay(iteration: int, evaluate, ledger_dir: Path) -> int:
     """Criterion 7: reconstruct one ledger entry and compare the pass vector."""
     try:
@@ -183,21 +232,22 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     # evidence against its own fix. Say what the ledger offers BEFORE the
     # reference measurement is paid; arming itself still depends on that
     # measurement, so nothing here promises it.
+    # Issue #107: read the stack once and hand the same fingerprint to both
+    # the launch line and the loop, so what the operator is told and what the
+    # campaign pairs against cannot come from two different readings.
+    launch_environment = environment_mod.environment_fingerprint()
+    if launch_environment is None:
+        print(
+            "environment: stack versions unreadable -- entries will carry no "
+            "fingerprint and no prior entry can be rejected for drift (#107)"
+        )
+
     if ledger_dir.exists():
         comparability = loop_mod.describe_ledger_comparability(
-            reference, list(ledger_mod.read_history(ledger_dir))
+            reference, list(ledger_mod.read_history(ledger_dir)), launch_environment
         )
-        print(
-            f"ledger history: {comparability['history_entries']} entry(ies), "
-            f"{comparability['comparable_search_set_states']} comparable search-set state(s)"
-        )
-        if comparability["high_water_objective_adjusted"] is not None:
-            print(
-                f"  historical high water: {comparability['high_water_objective_adjusted']} "
-                "(recovery mode arms only if the measured reference scores lower)"
-            )
-        for reason in comparability["incomparable_reasons"]:
-            print(f"  WARNING recovery-mode history mismatch -- {reason}")
+        for line in format_comparability_lines(comparability):
+            print(line)
 
     try:
         report = loop_mod.run_loop(
@@ -207,6 +257,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             max_iterations=args.max_iterations, patience=args.patience,
             ledger_dir=ledger_dir,
             reference_overrides=set_overrides,
+            launch_environment=launch_environment,
         )
     except evaluator_mod.ReachabilityError as exc:
         print(f"REACHABILITY GATE FAILED: {exc}", file=sys.stderr)

--- a/harness/environment.py
+++ b/harness/environment.py
@@ -1,0 +1,242 @@
+"""environment -- the installed stack an iteration was measured on.
+
+Issue #107. Two ledger entries are treated as comparable when their models,
+chunking and index-time flags match (``loop._comparable_config_view``). That
+view is complete for *configuration* and blind to everything else: MinerU and
+jina-clip get upgraded, an upstream fix changes what a page extracts to, the
+corpus is reindexed. The entry from August still declares itself comparable,
+still holds passes the current stack cannot reach, and recovery mode pairs
+against a high water nobody can climb back to -- so every campaign ends
+``rejected_regression`` on ghost passes, with no bug to fix.
+
+This module makes that drift visible instead of silent: which versions of the
+stack an iteration ran on, recorded per entry, so a later launch can say
+whether it is standing in the same world.
+
+## What "the stack" means here, and what it deliberately excludes
+
+Two environments decide a case's outcome, and they are not the same
+environment (README.md, "Install, models and configuration"):
+
+- **isolated** (``.venv-mineru``) -- MinerU and jina-clip-v2 build the index.
+  A change here changes stored content, which no amount of retrieval tuning
+  can undo.
+- **product** (whatever interpreter runs the gate) -- the BGE reranker, FAISS
+  and BM25 decide retrieval; the Ollama client decides how generation is
+  called.
+
+``transformers``, ``sentence-transformers`` and ``torch`` are installed in
+BOTH, at deliberately different versions (transformers 4.x isolated, 5.x
+product -- ``rag/requirements.txt`` explains why), and they mean different
+things in each. So versions are recorded per environment, never merged: a
+single ``transformers`` key would record one of the two and silently drop the
+other.
+
+**The git commit is not part of this.** It is already recorded per entry
+(``ledger.read_git_commit``) and it moves on every commit, including the ones
+that touch a README. Folding it into comparability would make every entry
+incomparable with every other one, which is not "strict", it is useless.
+
+## Why this reads directories instead of asking Python
+
+``importlib`` and ``subprocess`` are both banned under ``harness/``
+(``harness/tests/test_harness_boundaries.py``, issue #31 spec section 1), and
+that ban is what makes the "this harness cannot invoke git" claim checked
+rather than asserted. Neither ``importlib.metadata.version`` nor
+``pip freeze`` is available, so versions are read the one way left: the name
+of the ``*.dist-info`` directory pip writes, which carries the version
+already. That restriction turns out to be the right tool anyway -- it is the
+only one of the three that can read the *isolated* venv, which is a different
+interpreter this process never runs.
+
+Best-effort throughout, like ``ledger.read_git_commit``: an unreadable
+environment records ``None`` and the loop carries on. A campaign must not die
+over provenance.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Sequence
+
+FINGERPRINT_SCHEMA = 1
+
+# Declared by hand, like search_space.SEARCH_SPACE: each entry is a decision
+# that this package can change a case's outcome, not a dump of what happens to
+# be installed. A `pip freeze` fingerprint would change on every unrelated
+# transitive bump and report drift that decides nothing.
+#
+# Read in both environments -- a package absent from one records None there
+# and is skipped when comparing (see `compare`), so one list serves both
+# without pretending the product venv holds MinerU.
+TRACKED_PACKAGES = (
+    "mineru",                 # extraction: what a PDF becomes
+    "transformers",           # jina-clip's and the reranker's runtime
+    "sentence-transformers",  # BGE reranker; jina-clip's loader in the isolated venv
+    "torch",                  # numerics under both of the above
+    "faiss-cpu",              # the index and its search
+    "rank-bm25",              # the keyword half of hybrid retrieval
+    "ollama",                 # how generation is called
+)
+
+# Ordered: the isolated environment is what builds the index, so it is named
+# first everywhere a human reads this.
+ISOLATED_ENV = "isolated"
+PRODUCT_ENV = "product"
+
+MATCH = "match"
+DIFFERS = "differs"
+UNKNOWN = "unknown"
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _normalize(name: str) -> str:
+    """`sentence_transformers` and `sentence-transformers` are one package.
+
+    pip writes the underscore form into the ``.dist-info`` directory name and
+    the hyphen form is what humans and requirements files use.
+    """
+    return name.replace("_", "-").lower()
+
+
+def read_stack_versions(roots: Iterable[Path]) -> Dict[str, Optional[str]]:
+    """Versions of ``TRACKED_PACKAGES`` found under ``roots``, first root wins.
+
+    Args:
+        roots: ``site-packages`` directories, most specific first. Missing
+            directories are skipped rather than raising -- an environment that
+            was never installed is a normal state here, not an error.
+
+    Returns:
+        One entry per tracked package, ``None`` where it was not found.
+    """
+    found: Dict[str, Optional[str]] = {name: None for name in TRACKED_PACKAGES}
+    tracked = set(TRACKED_PACKAGES)
+    for root in roots:
+        try:
+            entries = sorted(Path(root).glob("*.dist-info"))
+        except OSError:
+            continue
+        for entry in entries:
+            stem = entry.name[: -len(".dist-info")]
+            dist_name, _, version = stem.rpartition("-")
+            normalized = _normalize(dist_name)
+            if normalized in tracked and found[normalized] is None and version:
+                found[normalized] = version
+    return found
+
+
+def _isolated_site_packages() -> List[Path]:
+    """``.venv-mineru``'s site-packages, both layouts, matching composition.py."""
+    venv = _PROJECT_ROOT / ".venv-mineru"
+    candidates = list(venv.glob("lib/python*/site-packages"))
+    windows = venv / "Lib" / "site-packages"
+    if windows.exists():
+        candidates.append(windows)
+    return candidates
+
+
+def _product_site_packages() -> List[Path]:
+    """The running interpreter's site-packages, read off ``sys.path``.
+
+    Not ``site.getsitepackages()``: under a virtualenv that reports the base
+    interpreter's directories too, which is where a *different* copy of these
+    packages can sit. ``sys.path`` is what imports actually resolve against.
+    """
+    return [Path(entry) for entry in sys.path if entry.endswith("site-packages")]
+
+
+def default_environments() -> Dict[str, List[Path]]:
+    """Where to look for each environment's packages."""
+    return {
+        ISOLATED_ENV: _isolated_site_packages(),
+        PRODUCT_ENV: _product_site_packages(),
+    }
+
+
+def environment_fingerprint(
+    environments: Optional[Dict[str, Sequence[Path]]] = None,
+) -> Optional[Dict[str, Any]]:
+    """The installed stack, per environment, or ``None`` if nothing is readable.
+
+    ``None`` rather than a dict full of ``None``s on purpose: two environments
+    that know nothing about themselves would otherwise compare equal and claim
+    a verified comparability neither of them has. Absence has to stay
+    distinguishable from agreement -- the same distinction
+    ``index_fingerprint.fingerprint_is_stale`` draws between "unknown" and
+    "mismatch".
+
+    Args:
+        environments: ``{name: [site-packages, ...]}``. Defaults to the
+            isolated venv and this interpreter's own packages.
+
+    Returns:
+        ``{"schema": ..., "packages": {"<env>:<package>": version | None}}``,
+        or ``None`` when not a single version could be read.
+    """
+    environments = environments if environments is not None else default_environments()
+    packages: Dict[str, Optional[str]] = {}
+    for env_name, roots in environments.items():
+        for package, version in read_stack_versions(roots).items():
+            packages[f"{env_name}:{package}"] = version
+    if not any(version is not None for version in packages.values()):
+        return None
+    return {"schema": FINGERPRINT_SCHEMA, "packages": packages}
+
+
+def _comparable_pairs(left: Dict[str, Any], right: Dict[str, Any]) -> List[tuple]:
+    """``(key, left_version, right_version)`` for keys both sides actually know."""
+    left_packages = left.get("packages") or {}
+    right_packages = right.get("packages") or {}
+    return [
+        (key, left_packages[key], right_packages[key])
+        for key in sorted(set(left_packages) & set(right_packages))
+        if left_packages[key] is not None and right_packages[key] is not None
+    ]
+
+
+def compare(left: Optional[Dict[str, Any]], right: Optional[Dict[str, Any]]) -> str:
+    """``MATCH``, ``DIFFERS`` or ``UNKNOWN`` for two fingerprints.
+
+    ``UNKNOWN`` is not a hedge, it is the honest third answer, and keeping it
+    separate from ``DIFFERS`` is what stops this feature from disarming
+    recovery mode across the whole existing ledger: entries written before
+    schema v3 carry no fingerprint, and calling them "different" would discard
+    the very evidence issue #92 was built on. Callers decide what to do with
+    an unverified comparison; they are told which one they have.
+
+    A schema change also reads as ``UNKNOWN``: a later schema may track a
+    different package set, and comparing across two definitions of "the stack"
+    is a guess dressed as a measurement.
+    """
+    if left is None or right is None:
+        return UNKNOWN
+    if left.get("schema") != right.get("schema"):
+        return UNKNOWN
+    pairs = _comparable_pairs(left, right)
+    if not pairs:
+        return UNKNOWN
+    return MATCH if all(a == b for _, a, b in pairs) else DIFFERS
+
+
+def describe_difference(
+    ledger_fingerprint: Optional[Dict[str, Any]],
+    launch_fingerprint: Optional[Dict[str, Any]],
+) -> List[str]:
+    """Field-level differences, phrased like ``loop._diff_comparable_views``.
+
+    Empty when the two match, when either is missing, or when they share no
+    known package -- in all three cases there is no difference to name, which
+    is exactly why ``compare`` is the function that says whether one exists.
+    """
+    if ledger_fingerprint is None or launch_fingerprint is None:
+        return []
+    if ledger_fingerprint.get("schema") != launch_fingerprint.get("schema"):
+        return []
+    return [
+        f"{key}: this launch {launch!r}, ledger {stored!r}"
+        for key, stored, launch in _comparable_pairs(ledger_fingerprint, launch_fingerprint)
+        if stored != launch
+    ]

--- a/harness/ledger.py
+++ b/harness/ledger.py
@@ -24,7 +24,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 3
 
 LEDGER_DIR = Path(__file__).resolve().parent / "ledger"
 INDEX_FILE_NAME = "index.jsonl"
@@ -111,6 +111,20 @@ class LedgerEntry:
             would reject every candidate that restores healthy behaviour,
             because the sabotage can luck into passing a case the healthy
             pipeline fails. See ``loop._historical_high_water``.
+        environment_fingerprint: The installed stack this iteration was
+            measured on (``harness.environment.environment_fingerprint``), or
+            ``None`` when it could not be read -- and always ``None`` in v1/v2
+            files, which predate the field (schema v3, issue #107).
+            ``effective_config`` records what was *configured*; this records
+            what was *installed*, and the two drift independently: a MinerU
+            upgrade or an upstream fix changes what a case can pass without
+            moving a single config value, which is how a healthy August
+            baseline came to hold passes the current stack cannot reach.
+            Unknown is deliberately not the same as different --
+            ``environment.compare`` returns three answers, and
+            ``loop.is_comparable_search_set_entry`` rejects only a KNOWN
+            mismatch, so pre-v3 history stays usable and is reported as
+            unverified rather than silently trusted.
     """
 
     schema_version: int
@@ -137,6 +151,7 @@ class LedgerEntry:
     verdict: str
     reason: str
     regression_baseline_iteration: Optional[int] = None
+    environment_fingerprint: Optional[Dict[str, Any]] = None
 
     def to_dict(self) -> Dict[str, Any]:
         return dataclasses.asdict(self)

--- a/harness/loop.py
+++ b/harness/loop.py
@@ -98,6 +98,7 @@ import dataclasses
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Sequence
 
+from harness import environment as environment_mod
 from harness import evaluator as evaluator_mod
 from harness import ledger as ledger_mod
 from harness import proposers as proposers_mod
@@ -145,6 +146,15 @@ RESOLUTION_WARNING: Dict[str, Any] = {
         "(block B, the corpus expansion this harness is sized against)."
     ),
 }
+
+
+# run_loop's `launch_environment` has three meaningful states and only two
+# would fit in `None`: "read it from this machine" (the default), "this exact
+# fingerprint" (tests, and any caller that already read it), and "unreadable,
+# so verify nothing" -- which IS None, because that is what
+# environment.environment_fingerprint returns when it cannot read the stack.
+# A sentinel keeps the third from being spelled the same as the first.
+_READ_ENVIRONMENT = object()
 
 
 def _bucket_stats(records: Sequence[evaluator_mod.CaseRecord], key_fn) -> Dict[str, Dict[str, Any]]:
@@ -266,17 +276,36 @@ def _comparable_config_view(effective_config: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def is_comparable_search_set_entry(
-    entry: ledger_mod.LedgerEntry, comparable_view: Dict[str, Any]
+    entry: ledger_mod.LedgerEntry,
+    comparable_view: Dict[str, Any],
+    launch_environment: Optional[Dict[str, Any]] = None,
 ) -> bool:
     """Whether ``entry`` can serve as a recovery-mode baseline for this view.
 
     Only complete, non-``inconclusive`` search-set evaluations carry the full
     pass vector recovery pairing needs; fast-tier-rejected entries do not.
+
+    An entry measured on a KNOWN-different stack is rejected too (issue #107).
+    Configuration equality says the two runs asked the pipeline the same
+    question; it says nothing about whether the pipeline was the same, and a
+    2026-08 baseline held passes the current MinerU/jina-clip cannot reach --
+    so recovery paired against a high water nobody could climb back to and
+    every campaign ended ``rejected_regression`` with no bug to fix.
+
+    "Known" is doing real work in that sentence. ``environment.compare``
+    answers ``UNKNOWN`` for any entry written before schema v3, and this
+    function treats that as comparable: the alternative disarms recovery mode
+    across the entire existing ledger, which would fix #107 by discarding the
+    evidence #92 was built on. ``describe_ledger_comparability`` counts those
+    entries separately so an operator sees how much of the pairing is
+    unverified rather than assuming all of it was checked.
     """
     return (
         entry.evaluated_case_set == "search_set"
         and entry.verdict != "inconclusive"
         and _comparable_config_view(entry.effective_config) == comparable_view
+        and environment_mod.compare(entry.environment_fingerprint, launch_environment)
+        != environment_mod.DIFFERS
     )
 
 
@@ -304,7 +333,9 @@ def _diff_comparable_views(
     return diffs
 
 
-def describe_ledger_comparability(reference, entries) -> Dict[str, Any]:
+def describe_ledger_comparability(
+    reference, entries, launch_environment: Optional[Dict[str, Any]] = None
+) -> Dict[str, Any]:
     """What an operator should know about prior history BEFORE paying evaluations.
 
     Recovery mode's actual arming additionally depends on the reference
@@ -313,27 +344,64 @@ def describe_ledger_comparability(reference, entries) -> Dict[str, Any]:
     silently incomparable ledger is how a campaign spends hours fabricating
     evidence against its own fix).
 
+    Issue #107 adds the second half of that warning. Counting comparable
+    states was never the same as counting *verified* ones: an entry with no
+    recorded stack still pairs, and until schema v3 every entry was in that
+    position. The two counts are reported separately so "12 comparable
+    states" cannot be read as "12 states measured on this stack" when the
+    truth is that none of them said.
+
     Returns:
         A dict with ``history_entries``, ``comparable_search_set_states``,
         ``high_water_objective_adjusted`` (max among comparable states, or
-        ``None``), and ``incomparable_reasons`` -- empty unless entries exist
-        and none of them is comparable, in which case it names the fields
-        that differ against the latest entry.
+        ``None``), ``environment_verified_states`` and
+        ``environment_unverified_states`` (the comparable ones split by
+        whether their stack was actually checked against this launch's), and
+        ``incomparable_reasons`` -- empty unless entries exist and none of
+        them is comparable, in which case it names the fields that differ
+        against the latest entry, stack included.
     """
     comparable_view = _comparable_config_view(dataclasses.asdict(reference))
-    comparable = [e for e in entries if is_comparable_search_set_entry(e, comparable_view)]
+    comparable = [
+        e
+        for e in entries
+        if is_comparable_search_set_entry(e, comparable_view, launch_environment)
+    ]
+    verified = sum(
+        1
+        for e in comparable
+        if environment_mod.compare(e.environment_fingerprint, launch_environment)
+        == environment_mod.MATCH
+    )
+    # The count of unverified states says how much of the history is
+    # unchecked; this says whether the ONE entry that will actually be paired
+    # against is among them, which is the fact that decides whether a refresh
+    # campaign is due (#107). They differ exactly when the high water is the
+    # aged entry -- the situation that opened the issue.
+    high_water = _historical_high_water(entries, comparable_view, launch_environment)
     info: Dict[str, Any] = {
         "history_entries": len(entries),
         "comparable_search_set_states": len(comparable),
-        "high_water_objective_adjusted": max(
-            (e.objective_adjusted for e in comparable), default=None
+        "high_water_objective_adjusted": (
+            high_water.objective_adjusted if high_water is not None else None
         ),
+        "high_water_environment_verified": (
+            None
+            if high_water is None
+            else environment_mod.compare(high_water.environment_fingerprint, launch_environment)
+            == environment_mod.MATCH
+        ),
+        "environment_verified_states": verified,
+        "environment_unverified_states": len(comparable) - verified,
         "incomparable_reasons": [],
     }
     if entries and not comparable:
         latest = entries[-1]
         diffs = _diff_comparable_views(
             comparable_view, _comparable_config_view(latest.effective_config)
+        )
+        diffs += environment_mod.describe_difference(
+            latest.environment_fingerprint, launch_environment
         )
         info["incomparable_reasons"] = diffs or [
             "config matches the latest entry but it carries no complete search-set pass vector"
@@ -344,6 +412,7 @@ def describe_ledger_comparability(reference, entries) -> Dict[str, Any]:
 def _historical_high_water(
     entries: Sequence[ledger_mod.LedgerEntry],
     comparable_view: Dict[str, Any],
+    launch_environment: Optional[Dict[str, Any]] = None,
 ) -> Optional[ledger_mod.LedgerEntry]:
     """The best comparable search-set state in prior ledger history, or ``None``.
 
@@ -356,7 +425,7 @@ def _historical_high_water(
     """
     best: Optional[ledger_mod.LedgerEntry] = None
     for entry in entries:
-        if is_comparable_search_set_entry(entry, comparable_view):
+        if is_comparable_search_set_entry(entry, comparable_view, launch_environment):
             if best is None or entry.objective_adjusted >= best.objective_adjusted:
                 best = entry
     return best
@@ -395,6 +464,7 @@ def _build_entry(
     reason: str,
     candidate_latency: Optional[Dict[str, Optional[float]]] = None,
     regression_baseline_iteration: Optional[int] = None,
+    environment_fingerprint: Optional[Dict[str, Any]] = None,
 ) -> ledger_mod.LedgerEntry:
     objective_raw, objective_adjusted = evaluator_mod.compute_objective(
         result.records, unreachable_ids
@@ -426,6 +496,7 @@ def _build_entry(
         verdict=verdict,
         reason=reason,
         regression_baseline_iteration=regression_baseline_iteration,
+        environment_fingerprint=environment_fingerprint,
     )
 
 
@@ -443,6 +514,7 @@ def run_loop(
     verify_reachability: bool = True,
     reachability_probe_case_ids: Sequence[str] = (),
     reference_overrides: Optional[Dict[str, Any]] = None,
+    launch_environment: Any = _READ_ENVIRONMENT,
 ) -> Dict[str, Any]:
     """Run the search until termination, writing one ledger entry per iteration.
 
@@ -490,6 +562,12 @@ def run_loop(
         written this run. Always returned, on every termination path
         (criterion 8) -- including when the search space is exhausted.
 
+        launch_environment: The installed stack this campaign runs on, stamped
+            into every entry and used to reject a ledger entry measured on a
+            known-different one (issue #107). Defaults to reading this
+            machine; pass ``None`` to verify nothing, or an explicit
+            fingerprint to pin it.
+
     Raises:
         ValueError: Neither ``max_iterations`` nor ``patience`` is set.
         evaluator.ReachabilityError: ``evaluate`` rejects a declared key at
@@ -502,6 +580,8 @@ def run_loop(
         raise ValueError("run_loop needs max_iterations and/or patience to guarantee termination")
 
     reference_overrides = dict(reference_overrides or {})
+    if launch_environment is _READ_ENVIRONMENT:
+        launch_environment = environment_mod.environment_fingerprint()
 
     if verify_reachability:
         evaluator_mod.verify_reachable(evaluate, reachability_probe_case_ids)
@@ -530,7 +610,7 @@ def run_loop(
     # vector. Frozen here from PRIOR history; this run's own entries never
     # move it mid-campaign.
     comparable_view = _comparable_config_view(dataclasses.asdict(reference))
-    high_water = _historical_high_water(entries_so_far, comparable_view)
+    high_water = _historical_high_water(entries_so_far, comparable_view, launch_environment)
     if high_water is not None and high_water.objective_adjusted > reference_objective_adjusted:
         recovery_mode = True
         # The high-water entry carries the full search-set pass vector, which
@@ -542,7 +622,7 @@ def run_loop(
         eligible_history_entries = sum(
             1
             for e in entries_so_far
-            if is_comparable_search_set_entry(e, comparable_view)
+            if is_comparable_search_set_entry(e, comparable_view, launch_environment)
         )
     else:
         recovery_mode = False
@@ -593,6 +673,7 @@ def run_loop(
                 reference_latency=reference_latency,
                 verdict="inconclusive",
                 reason="fast-tier evaluation carries infrastructure_error record(s) -- not scored",
+                environment_fingerprint=launch_environment,
             )
         else:
             regressed = _regressed_ids(fast_regression_baseline, fast_result.records)
@@ -615,7 +696,8 @@ def run_loop(
                     reference_latency=reference_latency,
                     verdict="rejected_regression",
                     reason=f"fast-tier regression on {regressed}{baseline_note}",
-                    regression_baseline_iteration=recovery_baseline_iteration,
+                    environment_fingerprint=launch_environment,
+                regression_baseline_iteration=recovery_baseline_iteration,
                 )
             else:
                 full_result = evaluate(
@@ -636,6 +718,7 @@ def run_loop(
                         reference_latency=reference_latency,
                         verdict="inconclusive",
                         reason="search-set evaluation carries infrastructure_error record(s) -- not scored",
+                        environment_fingerprint=launch_environment,
                     )
                 else:
                     candidate_latency = evaluator_mod.median_latency_by_bucket(full_result.records)
@@ -687,7 +770,8 @@ def run_loop(
                         # Provenance on every SCORED entry, accepted ones
                         # included: which pass vector the regression checks
                         # paired against is part of the evidence.
-                        regression_baseline_iteration=recovery_baseline_iteration,
+                        environment_fingerprint=launch_environment,
+                regression_baseline_iteration=recovery_baseline_iteration,
                     )
 
         ledger_mod.write_entry(entry, ledger_dir)
@@ -725,6 +809,14 @@ def run_loop(
                 high_water.objective_adjusted if recovery_mode and high_water is not None else None
             ),
             "eligible_history_entries": eligible_history_entries,
+        },
+        "environment": {
+            # Issue #107: which stack this campaign measured on. `readable` is
+            # False when the versions could not be read at all -- a gap in
+            # provenance, not evidence that anything drifted, and the two read
+            # identically in a report that only carried the fingerprint.
+            "fingerprint": launch_environment,
+            "readable": launch_environment is not None,
         },
         "resolution_warning": RESOLUTION_WARNING,
         "iterations": [e.to_dict() for e in new_entries],

--- a/harness/tests/test_cli.py
+++ b/harness/tests/test_cli.py
@@ -120,3 +120,73 @@ def test_cli_replay_exits_nonzero_when_the_iteration_is_missing(tmp_path, capsys
     code = cli.main(["--dry-run", "--replay", "9", "--ledger-dir", str(tmp_path)])
     assert code == 1
     assert "iteration 9" in capsys.readouterr().err
+
+
+# THE LAUNCH LINE (issues #100 and #107). Its whole job is carrying facts a
+# campaign depends on before hours are paid, so the lines are tested rather
+# than trusted: a mistyped key would drop the warning that matters most while
+# everything still ran green.
+
+
+def _comparability(**overrides):
+    base = {
+        "history_entries": 3,
+        "comparable_search_set_states": 2,
+        "high_water_objective_adjusted": 30,
+        "high_water_environment_verified": True,
+        "environment_verified_states": 2,
+        "environment_unverified_states": 0,
+        "incomparable_reasons": [],
+    }
+    base.update(overrides)
+    return base
+
+
+def test_launch_line_reports_counts_and_the_high_water():
+    lines = cli.format_comparability_lines(_comparability())
+    assert lines[0] == "ledger history: 3 entry(ies), 2 comparable search-set state(s)"
+    assert "historical high water: 30" in lines[1]
+    assert not any("WARNING" in line for line in lines)
+
+
+def test_launch_line_warns_when_the_high_water_itself_is_unverified():
+    """Issue #107: the one entry pairing will use is the one nobody's stack
+    matched. That is the fact that decides whether a refresh is due."""
+    lines = cli.format_comparability_lines(
+        _comparability(high_water_environment_verified=False,
+                       environment_verified_states=1, environment_unverified_states=1)
+    )
+    warning = [line for line in lines if "high-water entry was NOT measured" in line]
+    assert len(warning) == 1
+    assert "#107" in warning[0]
+
+
+def test_launch_line_counts_unverified_states_without_calling_them_wrong():
+    lines = cli.format_comparability_lines(
+        _comparability(environment_verified_states=1, environment_unverified_states=1)
+    )
+    unverified = [line for line in lines if "carry no comparable stack fingerprint" in line]
+    assert len(unverified) == 1
+    assert "unverified, not wrong" in unverified[0]
+
+
+def test_launch_line_says_nothing_about_the_stack_when_everything_is_verified():
+    lines = cli.format_comparability_lines(_comparability())
+    assert not any("fingerprint" in line for line in lines)
+
+
+def test_launch_line_still_names_a_config_mismatch():
+    """Issue #100's own warning must survive #107's additions."""
+    lines = cli.format_comparability_lines(
+        _comparability(
+            comparable_search_set_states=0,
+            high_water_objective_adjusted=None,
+            high_water_environment_verified=None,
+            environment_verified_states=0,
+            environment_unverified_states=0,
+            incomparable_reasons=["models.chat: this launch 'a', ledger 'b'"],
+        )
+    )
+    assert lines[-1] == (
+        "  WARNING recovery-mode history mismatch -- models.chat: this launch 'a', ledger 'b'"
+    )

--- a/harness/tests/test_environment.py
+++ b/harness/tests/test_environment.py
@@ -1,0 +1,163 @@
+"""Environment fingerprint: reading it, and what comparing two of them means.
+
+Issue #107. Comparable-view equality (models, chunking, index-time flags)
+does not capture stack drift, so an August high-water entry can hold passes
+today's MinerU/jina-clip cannot reach, and every criterion-5 campaign ends
+``rejected_regression`` on passes nobody can earn back.
+
+The tests here fix the two decisions that make the fingerprint honest rather
+than merely present:
+
+1. **An unreadable environment is ``None``, never a dict of ``None``s.** Two
+   fingerprints that know nothing would otherwise compare equal and claim a
+   verified comparability neither has.
+2. **Unknown is not the same as different.** Ledger entries written before
+   this field existed carry no fingerprint at all, and declaring them
+   incomparable would disarm recovery mode for the whole existing ledger --
+   solving #107 by discarding the evidence #92 was built on.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from harness import environment  # noqa: E402
+
+
+def _make_site_packages(tmp_path: Path, name: str, packages: dict) -> Path:
+    """Build a fake venv whose dist-info directories carry ``packages``."""
+    site = tmp_path / name / "lib" / "python3.12" / "site-packages"
+    site.mkdir(parents=True)
+    for dist_name, version in packages.items():
+        (site / f"{dist_name}-{version}.dist-info").mkdir()
+    return site
+
+
+class TestReadingVersions:
+    def test_reads_the_version_out_of_a_dist_info_directory_name(self, tmp_path):
+        site = _make_site_packages(tmp_path, "venv", {"transformers": "4.57.6"})
+        assert environment.read_stack_versions([site])["transformers"] == "4.57.6"
+
+    def test_normalizes_the_hyphen_underscore_difference(self, tmp_path):
+        """`pip install sentence-transformers` writes `sentence_transformers-*.dist-info`."""
+        site = _make_site_packages(
+            tmp_path, "venv", {"sentence_transformers": "5.6.1", "faiss_cpu": "1.15.0"}
+        )
+        versions = environment.read_stack_versions([site])
+        assert versions["sentence-transformers"] == "5.6.1"
+        assert versions["faiss-cpu"] == "1.15.0"
+
+    def test_a_package_that_is_not_installed_reads_as_none(self, tmp_path):
+        site = _make_site_packages(tmp_path, "venv", {"transformers": "4.57.6"})
+        assert environment.read_stack_versions([site])["mineru"] is None
+
+    def test_a_missing_directory_is_not_an_error(self, tmp_path):
+        versions = environment.read_stack_versions([tmp_path / "nope"])
+        assert set(versions) == set(environment.TRACKED_PACKAGES)
+        assert all(value is None for value in versions.values())
+
+    def test_the_first_root_holding_a_package_wins(self, tmp_path):
+        """The isolated venv is searched first: it is the one that builds the index."""
+        isolated = _make_site_packages(tmp_path, "isolated", {"transformers": "4.57.6"})
+        product = _make_site_packages(tmp_path, "product", {"transformers": "5.16.1"})
+        assert environment.read_stack_versions([isolated, product])["transformers"] == "4.57.6"
+        assert environment.read_stack_versions([product, isolated])["transformers"] == "5.16.1"
+
+
+class TestFingerprint:
+    def test_an_environment_with_nothing_readable_fingerprints_as_none(self, tmp_path):
+        """Not a dict of Nones -- see this module's docstring, decision 1."""
+        environments = {environment.PRODUCT_ENV: [tmp_path / "nope"]}
+        assert environment.environment_fingerprint(environments) is None
+
+    def test_a_readable_environment_fingerprints_as_a_dict(self, tmp_path):
+        site = _make_site_packages(tmp_path, "venv", {"transformers": "4.57.6"})
+        fingerprint = environment.environment_fingerprint({environment.PRODUCT_ENV: [site]})
+        assert fingerprint["packages"]["product:transformers"] == "4.57.6"
+        assert fingerprint["schema"] == environment.FINGERPRINT_SCHEMA
+
+    def test_the_two_environments_are_recorded_separately(self, tmp_path):
+        """transformers 4.x isolated and 5.x product mean different things.
+
+        One merged key would record whichever was searched first and silently
+        drop the other -- and the dropped one is a real input to the result.
+        """
+        isolated = _make_site_packages(tmp_path, "isolated", {"transformers": "4.57.6"})
+        product = _make_site_packages(tmp_path, "product", {"transformers": "5.16.1"})
+        fingerprint = environment.environment_fingerprint(
+            {environment.ISOLATED_ENV: [isolated], environment.PRODUCT_ENV: [product]}
+        )
+        assert fingerprint["packages"]["isolated:transformers"] == "4.57.6"
+        assert fingerprint["packages"]["product:transformers"] == "5.16.1"
+
+    def test_the_fingerprint_survives_a_json_round_trip(self, tmp_path):
+        """It is written into a ledger entry, so it has to be plain JSON."""
+        site = _make_site_packages(tmp_path, "venv", {"mineru": "2.6.3"})
+        fingerprint = environment.environment_fingerprint({environment.ISOLATED_ENV: [site]})
+        assert json.loads(json.dumps(fingerprint)) == fingerprint
+
+    def test_the_real_environment_never_raises(self):
+        """Whatever this machine has installed, reading it is best-effort."""
+        environment.environment_fingerprint()
+
+    def test_the_default_environments_name_both_and_only_both(self):
+        assert set(environment.default_environments()) == {
+            environment.ISOLATED_ENV,
+            environment.PRODUCT_ENV,
+        }
+
+
+class TestComparison:
+    def test_identical_stacks_match(self):
+        one = {"schema": 1, "packages": {"isolated:mineru": "2.6.3", "isolated:torch": "2.6.0"}}
+        assert environment.compare(one, dict(one)) == environment.MATCH
+
+    def test_a_changed_version_differs(self):
+        old = {"schema": 1, "packages": {"isolated:mineru": "2.6.3"}}
+        new = {"schema": 1, "packages": {"isolated:mineru": "2.7.0"}}
+        assert environment.compare(old, new) == environment.DIFFERS
+
+    @pytest.mark.parametrize(
+        "pair",
+        [
+            (None, {"schema": 1, "packages": {"isolated:mineru": "2.6.3"}}),
+            ({"schema": 1, "packages": {"isolated:mineru": "2.6.3"}}, None),
+            (None, None),
+        ],
+    )
+    def test_a_missing_fingerprint_is_unknown_not_different(self, pair):
+        """Decision 2: pre-#107 ledger entries stay usable, flagged as unverified."""
+        assert environment.compare(*pair) == environment.UNKNOWN
+
+    def test_two_stacks_sharing_no_known_package_are_unknown(self):
+        """Nothing was actually compared, so nothing was actually verified."""
+        one = {"schema": 1, "packages": {"isolated:mineru": "2.6.3", "isolated:torch": None}}
+        two = {"schema": 1, "packages": {"isolated:mineru": None, "isolated:torch": "2.6.0"}}
+        assert environment.compare(one, two) == environment.UNKNOWN
+
+    def test_packages_only_one_side_knows_are_skipped_not_counted_as_difference(self):
+        one = {"schema": 1, "packages": {"isolated:mineru": "2.6.3", "isolated:torch": "2.6.0"}}
+        two = {"schema": 1, "packages": {"isolated:mineru": "2.6.3", "isolated:torch": None}}
+        assert environment.compare(one, two) == environment.MATCH
+
+    def test_a_schema_change_is_unknown_rather_than_a_silent_mismatch(self):
+        """A later schema may track different packages; comparing across is a guess."""
+        one = {"schema": 1, "packages": {"isolated:mineru": "2.6.3"}}
+        two = {"schema": 2, "packages": {"isolated:mineru": "2.6.3"}}
+        assert environment.compare(one, two) == environment.UNKNOWN
+
+    def test_the_difference_is_described_field_by_field(self):
+        old = {"schema": 1, "packages": {"isolated:mineru": "2.6.3", "isolated:torch": "2.6.0"}}
+        new = {"schema": 1, "packages": {"isolated:mineru": "2.7.0", "isolated:torch": "2.6.0"}}
+        described = environment.describe_difference(old, new)
+        assert described == ["isolated:mineru: this launch '2.7.0', ledger '2.6.3'"]
+
+    def test_describing_a_match_yields_nothing(self):
+        one = {"schema": 1, "packages": {"isolated:mineru": "2.6.3"}}
+        assert environment.describe_difference(one, dict(one)) == []

--- a/harness/tests/test_loop.py
+++ b/harness/tests/test_loop.py
@@ -509,6 +509,7 @@ def _seed_entry(
     verdict="accepted",
     effective_config=None,
     evaluated_case_set="search_set",
+    environment_fingerprint=None,
 ):
     import dataclasses
 
@@ -542,6 +543,7 @@ def _seed_entry(
         latency_ceiling_multiplier=loop.LATENCY_CEILING_MULTIPLIER,
         verdict=verdict,
         reason="seeded",
+        environment_fingerprint=environment_fingerprint,
     )
     ledger_mod.write_entry(entry, tmp_path_ledger)
 
@@ -853,6 +855,12 @@ def test_describe_comparability_on_an_empty_ledger():
         "history_entries": 0,
         "comparable_search_set_states": 0,
         "high_water_objective_adjusted": None,
+        # Issue #107: no comparable state, so none verified and none
+        # unverified -- the split is over what pairing would actually use --
+        # and no high water whose stack could be verified either way.
+        "high_water_environment_verified": None,
+        "environment_verified_states": 0,
+        "environment_unverified_states": 0,
         "incomparable_reasons": [],
     }
 
@@ -974,3 +982,181 @@ def test_candidate_overrides_win_over_reference_pins(tmp_path):
     entry = report["iterations"][0]
     # The candidate's own value reached the ledger's provenance.
     assert entry["config_overrides"] == {"retrieval.top_k_final": 8}
+
+
+# ENVIRONMENT DRIFT (issue #107): comparable-view equality covers models,
+# chunking and index-time flags, and nothing else. A healthy August baseline
+# can therefore hold passes today's MinerU/jina-clip cannot reach -- recovery
+# pairs against a high water nobody can climb back to, every campaign ends
+# rejected_regression on ghost passes, and there is no bug to fix. The stack
+# each iteration ran on is recorded per entry, and a KNOWN-different stack
+# makes an entry incomparable. Unknown does not: pre-v3 entries carry no
+# fingerprint, and calling them different would disarm recovery mode across
+# the whole existing ledger, discarding the evidence #92 was built on.
+
+_STACK_AUGUST = {"schema": 1, "packages": {"isolated:mineru": "2.6.3"}}
+_STACK_TODAY = {"schema": 1, "packages": {"isolated:mineru": "3.4.5"}}
+
+_ONE_PASS = [{"id": "a", "case_type": "factual_number", "passed": True, "elapsed_seconds": 200.0}]
+
+
+def test_an_entry_measured_on_a_different_stack_is_not_comparable(tmp_path):
+    from harness import ledger as ledger_mod
+
+    _seed_entry(tmp_path, 1, 27, _ONE_PASS, environment_fingerprint=_STACK_AUGUST)
+    info = loop.describe_ledger_comparability(
+        AppConfig(), list(ledger_mod.read_history(tmp_path)), launch_environment=_STACK_TODAY
+    )
+    assert info["comparable_search_set_states"] == 0
+    assert info["high_water_objective_adjusted"] is None
+    assert info["incomparable_reasons"] == [
+        "isolated:mineru: this launch '3.4.5', ledger '2.6.3'"
+    ]
+
+
+def test_an_entry_from_the_same_stack_is_comparable_and_reported_as_verified(tmp_path):
+    from harness import ledger as ledger_mod
+
+    _seed_entry(tmp_path, 1, 27, _ONE_PASS, environment_fingerprint=_STACK_TODAY)
+    info = loop.describe_ledger_comparability(
+        AppConfig(), list(ledger_mod.read_history(tmp_path)), launch_environment=_STACK_TODAY
+    )
+    assert info["comparable_search_set_states"] == 1
+    assert info["environment_verified_states"] == 1
+    assert info["environment_unverified_states"] == 0
+
+
+def test_an_entry_without_a_fingerprint_stays_comparable_but_counts_as_unverified(tmp_path):
+    """Every entry written before schema v3 is this case. Disarming them would
+    solve #107 by throwing away #92's evidence -- so they still pair, and the
+    launch line says how many are unverified."""
+    from harness import ledger as ledger_mod
+
+    _seed_entry(tmp_path, 1, 27, _ONE_PASS, environment_fingerprint=None)
+    info = loop.describe_ledger_comparability(
+        AppConfig(), list(ledger_mod.read_history(tmp_path)), launch_environment=_STACK_TODAY
+    )
+    assert info["comparable_search_set_states"] == 1
+    assert info["environment_verified_states"] == 0
+    assert info["environment_unverified_states"] == 1
+    assert info["incomparable_reasons"] == []
+
+
+def test_an_unreadable_launch_environment_verifies_nothing_and_rejects_nothing(tmp_path):
+    """environment_fingerprint() returns None when it cannot read the stack.
+    That is a gap in provenance, not evidence that anything drifted."""
+    from harness import ledger as ledger_mod
+
+    _seed_entry(tmp_path, 1, 27, _ONE_PASS, environment_fingerprint=_STACK_AUGUST)
+    info = loop.describe_ledger_comparability(
+        AppConfig(), list(ledger_mod.read_history(tmp_path)), launch_environment=None
+    )
+    assert info["comparable_search_set_states"] == 1
+    assert info["environment_unverified_states"] == 1
+
+
+def test_the_high_water_skips_an_entry_measured_on_a_different_stack(tmp_path):
+    """The #107 failure in one assertion: the drifted entry scores higher, and
+    pairing against it is what makes recovery structurally unreachable."""
+    from harness import ledger as ledger_mod
+
+    _seed_entry(tmp_path, 1, 30, _ONE_PASS, environment_fingerprint=_STACK_AUGUST)
+    _seed_entry(tmp_path, 2, 27, _ONE_PASS, environment_fingerprint=_STACK_TODAY)
+    entries = list(ledger_mod.read_history(tmp_path))
+    import dataclasses
+
+    view = loop._comparable_config_view(dataclasses.asdict(AppConfig()))
+
+    high_water = loop._historical_high_water(entries, view, launch_environment=_STACK_TODAY)
+    assert high_water is not None and high_water.iteration == 2
+
+    both = loop._historical_high_water(entries, view, launch_environment=None)
+    assert both is not None and both.iteration == 1
+
+
+def test_run_loop_stamps_the_launch_environment_into_every_entry(tmp_path):
+    from harness import ledger as ledger_mod
+
+    search_ids = ["a", "b"]
+
+    def evaluate(overrides, case_ids):
+        return ev.EvaluationResult(
+            records=tuple(
+                ev.CaseRecord(id=cid, case_type="factual_number", passed=True, elapsed_seconds=1.0)
+                for cid in case_ids
+            ),
+            effective_config=dict(overrides),
+        )
+
+    report = loop.run_loop(
+        reference=AppConfig(),
+        evaluate=evaluate,
+        proposer=_FixedProposer({"retrieval.top_k_final": 12}),
+        search_set_ids=search_ids,
+        fast_tier_ids=["a"],
+        unreachable_ids=(),
+        max_iterations=1,
+        patience=None,
+        ledger_dir=tmp_path,
+        verify_reachability=False,
+        launch_environment=_STACK_TODAY,
+    )
+
+    written = list(ledger_mod.read_history(tmp_path))
+    assert written and all(e.environment_fingerprint == _STACK_TODAY for e in written)
+    assert report["environment"]["fingerprint"] == _STACK_TODAY
+
+
+def test_the_report_says_when_the_launch_environment_could_not_be_read(tmp_path):
+    def evaluate(overrides, case_ids):
+        return ev.EvaluationResult(
+            records=tuple(
+                ev.CaseRecord(id=cid, case_type="factual_number", passed=True, elapsed_seconds=1.0)
+                for cid in case_ids
+            ),
+            effective_config=dict(overrides),
+        )
+
+    report = loop.run_loop(
+        reference=AppConfig(),
+        evaluate=evaluate,
+        proposer=_FixedProposer({"retrieval.top_k_final": 12}),
+        search_set_ids=["a", "b"],
+        fast_tier_ids=["a"],
+        unreachable_ids=(),
+        max_iterations=1,
+        patience=None,
+        ledger_dir=tmp_path,
+        verify_reachability=False,
+        launch_environment=None,
+    )
+    assert report["environment"]["fingerprint"] is None
+    assert report["environment"]["readable"] is False
+
+
+def test_the_launch_line_says_when_the_high_water_itself_is_unverified(tmp_path):
+    """The exact #107 situation: an aged entry outscores every verified one, so
+    the count of unverified states is not the fact that decides -- which entry
+    pairing will actually use is."""
+    from harness import ledger as ledger_mod
+
+    _seed_entry(tmp_path, 1, 30, _ONE_PASS, environment_fingerprint=None)
+    _seed_entry(tmp_path, 2, 25, _ONE_PASS, environment_fingerprint=_STACK_TODAY)
+    info = loop.describe_ledger_comparability(
+        AppConfig(), list(ledger_mod.read_history(tmp_path)), launch_environment=_STACK_TODAY
+    )
+    assert info["comparable_search_set_states"] == 2
+    assert info["high_water_objective_adjusted"] == 30
+    assert info["high_water_environment_verified"] is False
+
+
+def test_a_verified_high_water_is_reported_as_verified(tmp_path):
+    from harness import ledger as ledger_mod
+
+    _seed_entry(tmp_path, 1, 25, _ONE_PASS, environment_fingerprint=None)
+    _seed_entry(tmp_path, 2, 30, _ONE_PASS, environment_fingerprint=_STACK_TODAY)
+    info = loop.describe_ledger_comparability(
+        AppConfig(), list(ledger_mod.read_history(tmp_path)), launch_environment=_STACK_TODAY
+    )
+    assert info["high_water_objective_adjusted"] == 30
+    assert info["high_water_environment_verified"] is True


### PR DESCRIPTION
## Summary

A ledger entry now records **what was installed**, not only what was
configured, and an entry measured on a known-different stack stops counting as
a comparable baseline.

This is issue #107's option 2. The campaign of 2026-08-23 rejected a
restoration candidate for losing a case the August baseline held and that
day's stack could not reach: the pairing logic was correct and its conclusion
was false. Configuration equality says two runs asked the pipeline the same
question; it says nothing about whether the pipeline was the same.

**Three decisions worth reviewing on their own:**

1. **Unknown is not the same as different.** `environment.compare` returns
   `match` / `differs` / `unknown`, and only `differs` disqualifies. Every
   pre-v3 entry carries no fingerprint, and calling those "different" would
   disarm recovery mode across the entire existing ledger — fixing #107 by
   throwing away the evidence #92 was built on. Same distinction the product
   already draws in `index_fingerprint.fingerprint_is_stale`.
2. **Two environments, never merged.** `.venv-mineru` builds the index; the
   product interpreter decides retrieval and generation. `transformers`,
   `sentence-transformers` and `torch` are installed in both at deliberately
   different versions, so keys are qualified (`isolated:` / `product:`).
3. **The unverified count is not the deciding fact.** A campaign pairs against
   exactly one entry, so the launch line reports separately whether *that*
   entry's stack was verified. The two differ exactly when the aged entry
   outscores every verified one — #107's own situation.

Versions come from `*.dist-info` directory names because `importlib` and
`subprocess` are both banned under `harness/`. That constraint turns out to be
the right tool: it is the only one of the three that can read the isolated
venv, a different interpreter this process never runs.

## Issue

Refs #107 — **does not close it.** The issue leans (1)+(2); this is (2). Drift
is now visible and a known-different stack is rejected, but an aged baseline
does not become reachable again: that needs the refresh campaign, option 1,
which the issue stays open for.

## Test plan

- [x] `pytest` green: 835 passed, 2 skipped (baseline 828 before this change).
- [x] `ruff check .` clean.
- [x] **Verified end to end against both scenarios, not just unit-tested.**
      Seeded a ledger and read the actual launch lines:
      - Aged entry with no fingerprint (today's real ledger shape): still
        pairs, high water 27, and the line warns that this high-water entry
        was not measured on a comparable stack and a refresh is what replaces
        it.
      - Entry from a known-different stack: excluded, high water drops from
        27 to the verified 25. That exclusion is the fix.
- [x] `harness/tests` 194 passed; the launch line itself is tested via
      `cli.format_comparability_lines` (extracted so a mistyped key cannot
      drop a warning while everything runs green).
- [x] Real environment read on this machine: `mineru 3.4.5` /
      `transformers 4.57.6` / `torch 2.6.0+cu124` isolated,
      `transformers 5.16.1` / `torch 2.13.0` / `faiss-cpu 1.15.0` product —
      the two-environment split is not hypothetical here.
- [x] Docs in the same change: `harness/README.md` gets an "Environment drift"
      section; the design doc gets its dated decision block (rule 2).
- [ ] Full gate not needed: `harness/` is not product, and no retrieval or
      generation code is touched.
- [ ] No protected-zone edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)