### PR TITLE
Let an agent read the ledger without paying a campaign, and write down the procedure (#114)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@
 | `rag/README.md` | What `rag/` is today and where the rest of the docs live. |
 | `AGENTS.md` (root) | Operating contract for any agent or human working in this repo; `.claude/CLAUDE.md` and `.codex/AGENTS.md` are pointers to it and must stay pointers. |
 | `CONTRIBUTING.md` | How to branch, open PRs and issues, what a change must carry, how issues get closed. |
+| `harness/RUNBOOK.md` | An agent or person about to run a loop campaign: the procedure, the decision points, what each verdict means. Procedure only — the reasoning lives in `harness/README.md`. |
 | `docs/design/*.md` | Current standing design decisions and their rationale; update them when architecture changes. |
 | Directory-local `README.md` | Only where a directory's purpose isn't obvious from its code — not one per folder by default. |
 

--- a/harness/README.md
+++ b/harness/README.md
@@ -6,6 +6,11 @@ candidate so a run can be reconstructed. Implements
 [`docs/design/2026-07-28-loop-automejorable.md`](../docs/design/2026-07-28-loop-automejorable.md)
 §4 ("Arquitectura del arnés").
 
+> [!TIP]
+> **About to run a campaign rather than change the harness?** Read
+> [`RUNBOOK.md`](RUNBOOK.md) instead: the procedure, the decision points and
+> what each verdict means, without the reasoning this file exists to carry.
+
 > [!CAUTION]
 > The harness may **read and run** the evaluation gate under `tests/eval/`.
 > It never redefines how the evaluation scores. `tests/eval/grade.py`,

--- a/harness/RUNBOOK.md
+++ b/harness/RUNBOOK.md
@@ -1,0 +1,248 @@
+# Runbook — operating the self-improvement loop
+
+**Audience: an agent (or a person) about to run a campaign.** This file says
+what to do and in what order. It says almost nothing about *why*, because
+[`README.md`](README.md) next to it already does, at length, and the two
+questions are not answered well by one document. Every claim here that has a
+reason behind it links to where that reason lives.
+
+Registered in [`docs/README.md`](../docs/README.md)'s table. Issue #114.
+
+---
+
+## 0. What this is, and what it is not
+
+The loop searches for a pipeline configuration with a higher gold-case pass
+rate, subject to a latency ceiling, recording every candidate.
+
+**It proposes. It never integrates.** No code path here writes a winning
+configuration into the product, commits anything, or touches `grade.py`,
+`gold_cases.jsonl` or `baseline_min_pass_rate.txt` — structurally, not by
+convention ([`README.md`](README.md), the CAUTION block). If a campaign
+finds something, a human decides what happens to it.
+
+**A green campaign is not a shipped improvement.** Every report carries a
+`resolution_warning` for a reason; see §7.
+
+---
+
+## 1. Before launching: five checks, in order
+
+Stop at the first one that fails. Each is cheap; the campaign is not.
+
+```bash
+python -m harness.cli --status
+```
+
+This is the whole precondition check for the ledger, and it evaluates
+nothing. On a clean clone:
+
+```
+ledger dir: /path/to/repo/harness/ledger
+reference models: rag=gemma4:e4b, chat=gemma4:e4b, contextual=gemma4:e4b, recomp=gemma4:e4b
+environment: isolated:mineru=3.4.5, isolated:sentence-transformers=5.6.1, isolated:torch=2.6.0+cu124, isolated:transformers=4.57.6, product:faiss-cpu=1.15.0, product:ollama=0.6.2, product:rank-bm25=0.2.2, product:sentence-transformers=6.0.1, product:torch=2.13.0, product:transformers=5.16.1
+ledger: directory does not exist yet -- a first campaign creates it
+```
+
+Read it top to bottom:
+
+| Line | What it tells you | What to do about it |
+|---|---|---|
+| `reference models` | The four roles this campaign would measure under. Environment beats `settings.json` beats defaults. | If these are not what you intended, fix the environment or pass `--set models.rag=...`. A campaign A of 2026-08-23 lost hours to a `settings.json` value nobody had checked. |
+| `environment` | The installed stack, per environment. `isolated:` builds the index, `product:` decides retrieval and generation. | If `isolated:mineru` is missing, `.venv-mineru` is not installed and indexing cannot run. |
+| `ledger:` | What prior history exists. | See §2. |
+
+The remaining four checks:
+
+```bash
+# 2. The fast gate is green, so a failure later is the campaign's, not the tree's.
+pytest -q
+ruff check .
+
+# 3. Ollama answers and holds the models the roles name.
+curl -s -m 5 http://localhost:11434/api/tags -o /dev/null -w '%{http_code}\n'   # expect 200
+ollama list
+
+# 4. The isolated stack loads on this GPU. ~30 s the first time, then cached.
+echo '{"id": 1, "op": "text", "text": "probe"}' \
+  | .venv-mineru/bin/python src/monkeygrab/adapters/embedding/jina_clip_worker.py
+# expect: {"event": "ready", "dim": 512} then {"id": 1, "ok": true, "vector": [...]}
+
+# 5. The wiring runs end to end, with no GPU and no models, into a temp dir.
+python -m harness.cli --dry-run --max-iterations 3
+```
+
+> [!WARNING]
+> Never pass `--ledger-dir <a real ledger>` to `--dry-run`. It **appends its
+> demo iterations to that ledger** and they are indistinguishable from
+> measured ones afterwards (issue #115). Without `--ledger-dir`, a dry-run
+> writes to a fresh temp directory, which is the safe form used above.
+
+A missing Ollama model is caught by the gate itself, at launch, with the exact
+`ollama pull` line to run — verified 2026-09-01, it failed in 20 s rather than
+mid-campaign. That is a real preflight; do not build another.
+
+---
+
+## 2. Reading `--status` on a ledger with history
+
+```
+ledger: 2 entry(ies), iterations 1-2 (accepted 2)
+  last: iteration 2 accepted on the search_set -- seeded
+  best search-set objective in this ledger: 27 (iteration 1) -- comparability decides whether this launch can use it
+ledger history: 2 entry(ies), 1 comparable search-set state(s)
+  historical high water: 25 (recovery mode arms only if the measured reference scores lower)
+```
+
+The two blocks answer different questions and the gap between them is the
+point:
+
+- `best ... in this ledger` is the best entry that exists.
+- `historical high water` is the best entry **this launch could actually pair
+  against**. Anything with different model roles, chunking, index-time flags,
+  or a known-different stack is excluded.
+
+When those two numbers differ, some history is not usable under this
+configuration. That is normal and is not an error.
+
+Three lines are decision points:
+
+**`WARNING recovery-mode history mismatch -- <field>: this launch X, ledger Y`**
+No prior entry is comparable. A criterion-5 recovery campaign launched in this
+state runs with recovery mode silently off and rejects every candidate that
+restores healthy behaviour (this is #92, and it happened). Either pin the
+field with `--set` to match the ledger, or accept that this campaign starts
+its own history.
+
+**`WARNING that high-water entry was NOT measured on a stack comparable to this launch's`**
+The entry your candidates will be judged against ran on a different (or
+unrecorded) stack. It can hold passes the current stack cannot reach, which
+reads as a regression no candidate can fix. A refresh campaign on the current
+stack is what replaces it — issue #107, still open for exactly that.
+
+**`N entry(ies) carry no stack fingerprint (written before ledger schema v3)`**
+Historical entries, usable but unverifiable. Not a problem by itself; it
+becomes one when the high water is among them, which the previous warning
+tells you.
+
+---
+
+## 3. Launching
+
+```bash
+# Deterministic control: coordinate descent, reproducible from the ledger alone.
+python -m harness.cli --proposer grid --max-iterations 8 --patience 3
+
+# LLM proposer, same guardrails. Falls back to grid on any invalid output.
+python -m harness.cli --proposer llm --llm-model gemma4:e4b --max-iterations 8 --patience 3
+
+# A campaign that must be comparable with prior history: pin the fields.
+python -m harness.cli \
+    --ledger-dir tests/eval/runs/harness-loop \
+    --set models.rag=gemma4:e4b --set models.chat=gemma4:e2b
+```
+
+`--set` is repeatable, JSON-decodes its values, and unknown keys abort at
+launch rather than being silently ignored. The pins reach every measured
+evaluation, the reference's included (#101/#106) — an earlier version only
+pinned the harness's own bookkeeping object, and a "sabotaged" reference
+scored healthy.
+
+Always give `--max-iterations`, `--patience`, or both. The loop refuses to
+start without at least one; it is what guarantees termination.
+
+**Budget.** A full search-set evaluation was ~20 min at 2026-08-19 rates on
+the reference GPU; the fast tier is ~4 min. A candidate rejected at the fast
+tier costs the fast tier only. Expect a night to fit many candidates, not
+three or four — the design doc's original estimate was ~6x too pessimistic
+and has been corrected.
+
+---
+
+## 4. The five verdicts, and what each one means you should do
+
+| Verdict | What happened | Next |
+|---|---|---|
+| `accepted` | Beat the ratchet, no regression, within latency. | **Not a shipped improvement.** Record it, apply §7's warning, and hand it to a human. Stage 1 is a single-field sweep from a fixed reference, so an acceptance usually ends the run shortly after (patience). |
+| `rejected_no_gain` | Measured fine, did not beat the ratchet. | Nothing. This is the normal outcome and it is evidence, not failure. |
+| `rejected_regression` | Lost cases against the pairing baseline. | Check *which* baseline: the entry records `regression_baseline_iteration`. If it paired against an aged high water, see §2's second warning — the rejection may be about the baseline, not the candidate. |
+| `rejected_latency` | A bucket's median exceeded 1.20x the reference's. | Real. Answered and retrieval-only buckets are checked separately on purpose; a blended median would hide exactly this. |
+| `inconclusive` | **The measurement failed, not the candidate.** A dead or overloaded Ollama, a retrieval exception. | Fix the infrastructure and re-run. Never read this as a regression. It still counts toward `--patience`, so a broken Ollama ends the campaign rather than filling the ledger with fiction. |
+
+If the **reference** measurement itself carries an infrastructure error, the
+loop refuses to start at all (`InconclusiveEvaluationError`). That is
+deliberate: no ratchet baseline can be trusted in that state.
+
+---
+
+## 5. Reproducing one iteration
+
+```bash
+python -m harness.cli --replay 3 --ledger-dir <that ledger>
+```
+
+Re-runs iteration 3's exact overrides on its exact case ids and exits 0 only
+if the pass/fail vector matches. This is criterion 7, and it is the check to
+run before believing a surprising result.
+
+---
+
+## 6. What is forbidden
+
+Not style preferences — each has a mechanism behind it and, in most cases, a
+red test.
+
+- **Never edit `tests/eval/grade.py`, `gold_cases.jsonl` or
+  `baseline_min_pass_rate.txt`** to make a result look better. The harness
+  cannot reach them by construction (`test_harness_boundaries.py` parses for
+  it), and neither should you.
+- **Never write a winning configuration into the product.** The loop proposes,
+  a human integrates (design doc §5). Flipping a shipped `USAR_*` flag or a
+  numeric default needs owner agreement (`AGENTS.md` rule 6).
+- **Never hand-edit the ledger** to remove an inconvenient entry. It is
+  append-only evidence. If the history is stale, the answer is a refresh
+  campaign, not a delete (#107).
+- **Never run `--dry-run` against a real ledger** (§1's warning, #115).
+- **Never weaken a test to make a campaign pass.** `tests/characterization/`
+  pins current behaviour including its bugs; changing one is a signal to stop
+  and confirm (`AGENTS.md` rule 9).
+
+---
+
+## 7. What is true of every result today
+
+State these when reporting a campaign; they are not disclaimers, they are the
+measurement's actual resolution.
+
+- **The search set can win at most 5 cases**, and it registered only 3 net
+  flips under a known-catastrophic sabotage — below the ~6 flips the design
+  sets as the threshold for a difference not attributable to chance. An
+  accepted improvement on today's corpus is **a candidate for confirmation,
+  not a demonstrated result**. This is issue #30, the binding constraint on
+  the whole loop, and every report carries it as `resolution_warning`.
+- **Index-time knobs are not searched.** Chunking and the index-time flags
+  force a full reindex per candidate, which no budget survives inside a search
+  loop (#102). Declaring one is a red test, not an oversight.
+- **Stage 1 is a single-field sweep from a fixed reference**, not a
+  compounding hill climb. Two accepted single-field changes cannot combine
+  within a run.
+- **An aged baseline is visible but not fixed.** Drift is now recorded and
+  reported (#107 option 2); making an aged high water reachable again needs a
+  refresh campaign, which is still open work.
+
+---
+
+## 8. Closing a campaign
+
+1. The ledger and `report.json` are the evidence. `tests/eval/runs/` and
+   `harness/ledger/` are gitignored — cite paths explicitly as local, never
+   assume a reader can open them.
+2. Comment on the issue the campaign was run for, with the numbers, not a
+   summary of the numbers. An issue closed without evidence gets reopened
+   (`CONTRIBUTING.md`).
+3. If the campaign changed a standing decision about the loop, it gets a
+   dated block in `docs/design/2026-07-28-loop-automejorable.md` **before**
+   code moves (`AGENTS.md` rule 2).
+4. If it found a defect, open an issue with the reproduction, using the
+   measurement template. If it found a limit, say which of the two it is —
+   they lead to different work.

--- a/harness/cli.py
+++ b/harness/cli.py
@@ -104,6 +104,13 @@ def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
                              "(criterion 7). Skips the search loop. Needs --ledger-dir "
                              "pointing at the ledger that holds that entry."
                          ))
+    parser.add_argument("--status", action="store_true",
+                         help=(
+                             "Print what the ledger holds and how much of it this launch "
+                             "could pair against, evaluate nothing, exit 0. Reads the same "
+                             "ledger the run would (--ledger-dir), under the same reference "
+                             "config (--set is honoured)."
+                         ))
     parser.add_argument("--set", action="append", default=[], metavar="KEY=VALUE",
                          help=(
                              "Pin a reference-config field for this campaign (repeatable), "
@@ -160,6 +167,106 @@ def format_comparability_lines(comparability: Dict[str, Any]) -> list:
     for reason in comparability["incomparable_reasons"]:
         lines.append(f"  WARNING recovery-mode history mismatch -- {reason}")
     return lines
+
+
+def format_ledger_summary(entries: Sequence[ledger_mod.LedgerEntry]) -> list:
+    """What a ledger holds, for an operator deciding whether to launch.
+
+    Answers the questions the per-entry JSONs make expensive: how far the
+    history goes, what it decided, how much of it predates the stack
+    fingerprint, and what the last iteration did. Comparability is NOT
+    answered here -- that depends on this launch's config and stack, and
+    ``format_comparability_lines`` is the one place that decides it.
+
+    Args:
+        entries: Ledger history, oldest first (``ledger.read_history``).
+
+    Returns:
+        Lines to print, in order. A single line when the ledger is empty.
+    """
+    if not entries:
+        return ["ledger: empty -- no prior campaign has written here"]
+
+    verdicts: Dict[str, int] = {}
+    for entry in entries:
+        verdicts[entry.verdict] = verdicts.get(entry.verdict, 0) + 1
+    by_verdict = ", ".join(f"{name} {count}" for name, count in sorted(verdicts.items()))
+
+    latest = entries[-1]
+    search_set = [e for e in entries if e.evaluated_case_set == "search_set"]
+    best = max(search_set, key=lambda e: e.objective_adjusted, default=None)
+    # Entries predating schema v3 carry no stack fingerprint at all, so a
+    # count of them is a count of how much of this history can never be
+    # verified against the current stack (#107) -- the number that says
+    # whether a refresh campaign is what the ledger needs.
+    without_fingerprint = sum(1 for e in entries if e.environment_fingerprint is None)
+
+    lines = [
+        f"ledger: {len(entries)} entry(ies), iterations "
+        f"{entries[0].iteration}-{latest.iteration} ({by_verdict})",
+        f"  last: iteration {latest.iteration} {latest.verdict} "
+        f"on the {latest.evaluated_case_set} -- {latest.reason}",
+    ]
+    if best is not None:
+        lines.append(
+            f"  best search-set objective in this ledger: {best.objective_adjusted} "
+            f"(iteration {best.iteration}) -- comparability decides whether this launch can use it"
+        )
+    if without_fingerprint:
+        lines.append(
+            f"  {without_fingerprint} entry(ies) carry no stack fingerprint "
+            "(written before ledger schema v3) -- their stack can never be verified (#107)"
+        )
+    return lines
+
+
+def _run_status(reference, ledger_dir: Path) -> int:
+    """Report the ledger without evaluating anything (issue #114).
+
+    The launch line was previously reachable only from a real campaign, which
+    pays the reference measurement (~20 min) before printing it, or from
+    ``--dry-run``, whose demo evaluator writes a partial ``effective_config``
+    that can never match a real ``AppConfig`` -- so it reported 0 comparable
+    states whatever the ledger held. An agent deciding whether to launch
+    needs the answer before either.
+
+    Deliberately reuses ``format_comparability_lines``: what ``--status``
+    reports and what a campaign pairs against must not come from two
+    readings that can drift apart.
+    """
+    launch_environment = environment_mod.environment_fingerprint()
+    print(f"ledger dir: {ledger_dir}")
+    # The model roles are half of what decides comparability, and the half a
+    # settings.json change moves without anyone noticing -- the 2026-08-23
+    # campaign A failure. Printing them here means an agent never has to
+    # guess which configuration its --status answer was computed under.
+    roles = ", ".join(
+        f"{role}={getattr(reference.models, role)}"
+        for role in ("rag", "chat", "contextual", "recomp")
+    )
+    print(f"reference models: {roles}")
+    if launch_environment is None:
+        print("environment: stack versions unreadable (#107)")
+    else:
+        readable = ", ".join(
+            f"{key}={value}"
+            for key, value in sorted(launch_environment["packages"].items())
+            if value is not None
+        )
+        print(f"environment: {readable}")
+
+    if not ledger_dir.exists():
+        print("ledger: directory does not exist yet -- a first campaign creates it")
+        return 0
+
+    entries = list(ledger_mod.read_history(ledger_dir))
+    for line in format_ledger_summary(entries):
+        print(line)
+    for line in format_comparability_lines(
+        loop_mod.describe_ledger_comparability(reference, entries, launch_environment)
+    ):
+        print(line)
+    return 0
 
 
 def _run_replay(iteration: int, evaluate, ledger_dir: Path) -> int:
@@ -219,6 +326,9 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     else:
         evaluate = evaluator_mod.real_evaluate
         ledger_dir = args.ledger_dir or ledger_mod.LEDGER_DIR
+
+    if args.status:
+        return _run_status(reference, ledger_dir)
 
     if args.replay is not None:
         return _run_replay(args.replay, evaluate, ledger_dir)

--- a/harness/tests/test_cli.py
+++ b/harness/tests/test_cli.py
@@ -1,4 +1,4 @@
-"""Tests for harness.cli -- --replay (criterion 7) and --set wiring."""
+"""Tests for harness.cli -- --replay (criterion 7), --set wiring, --status."""
 
 import json
 import sys
@@ -190,3 +190,109 @@ def test_launch_line_still_names_a_config_mismatch():
     assert lines[-1] == (
         "  WARNING recovery-mode history mismatch -- models.chat: this launch 'a', ledger 'b'"
     )
+
+
+# --status (issue #114): the ledger's state without paying a campaign. The
+# launch line used to be reachable only after the reference measurement
+# (~20 min), or from --dry-run, whose demo evaluator writes a partial
+# effective_config that can never match a real AppConfig -- so it reported 0
+# comparable states whatever the ledger held.
+
+
+def _seed_search_set_entry(ledger_dir, iteration, objective, *, fingerprint=None):
+    import dataclasses
+
+    from monkeygrab.config.app_config import AppConfig
+
+    ledger.write_entry(
+        ledger.LedgerEntry(
+            schema_version=ledger.SCHEMA_VERSION,
+            iteration=iteration,
+            parent_iteration=None,
+            git_commit=None,
+            config_overrides={},
+            effective_config=dataclasses.asdict(AppConfig()),
+            proposer="grid",
+            proposer_rationale=None,
+            proposer_model=None,
+            proposer_fallback=False,
+            proposer_fallback_reason=None,
+            evaluated_case_set="search_set",
+            case_records=[
+                {"id": "a", "case_type": "factual_number", "passed": True, "elapsed_seconds": 1.0}
+            ],
+            summary={"total": 1, "passed": 1, "pass_rate": 1.0},
+            objective_raw=objective,
+            objective_adjusted=objective,
+            median_latency_answered_s=1.0,
+            median_latency_retrieval_only_s=None,
+            reference_median_latency_answered_s=1.0,
+            reference_median_latency_retrieval_only_s=None,
+            latency_ceiling_multiplier=1.2,
+            verdict="accepted",
+            reason="seeded",
+            environment_fingerprint=fingerprint,
+        ),
+        ledger_dir,
+    )
+
+
+def test_status_never_calls_the_evaluator(tmp_path, monkeypatch, capsys):
+    """The whole point: an answer before the measurement, not after it."""
+
+    def explode(*args, **kwargs):
+        raise AssertionError("--status must not evaluate anything")
+
+    monkeypatch.setattr(ev, "real_evaluate", explode)
+    _seed_search_set_entry(tmp_path, 1, 27)
+
+    assert cli.main(["--status", "--ledger-dir", str(tmp_path)]) == 0
+    assert "ledger: 1 entry(ies)" in capsys.readouterr().out
+
+
+def test_status_reads_the_ledger_without_writing_to_it(tmp_path, capsys):
+    """The other half of "without paying a campaign": --dry-run pointed at a
+    real ledger to inspect it APPENDS demo entries to an append-only file,
+    indistinguishable from real ones afterwards. --status is read-only."""
+    _seed_search_set_entry(tmp_path, 1, 27)
+    before = sorted(p.name for p in tmp_path.iterdir())
+
+    cli.main(["--status", "--ledger-dir", str(tmp_path)])
+
+    assert sorted(p.name for p in tmp_path.iterdir()) == before
+    out = capsys.readouterr().out
+    assert "1 comparable search-set state(s)" in out
+    assert "historical high water: 27" in out
+
+
+def test_status_honours_set_so_it_answers_for_the_campaign_you_would_launch(tmp_path, capsys):
+    """A --set pin changes comparability; --status computed under a different
+    reference than the campaign would use is worse than no answer."""
+    _seed_search_set_entry(tmp_path, 1, 27)
+
+    cli.main(["--status", "--ledger-dir", str(tmp_path), "--set", "models.chat=other:model"])
+    out = capsys.readouterr().out
+    assert "chat=other:model" in out
+    assert "0 comparable search-set state(s)" in out
+
+
+def test_status_on_a_directory_that_does_not_exist_yet(tmp_path, capsys):
+    assert cli.main(["--status", "--ledger-dir", str(tmp_path / "nope")]) == 0
+    assert "directory does not exist yet" in capsys.readouterr().out
+
+
+def test_ledger_summary_of_an_empty_history():
+    assert cli.format_ledger_summary([]) == [
+        "ledger: empty -- no prior campaign has written here"
+    ]
+
+
+def test_ledger_summary_counts_pre_v3_entries_separately(tmp_path):
+    """How much of this history can never be verified against the current
+    stack is the number that says whether a refresh campaign is due (#107)."""
+    _seed_search_set_entry(tmp_path, 1, 27, fingerprint=None)
+    _seed_search_set_entry(tmp_path, 2, 25, fingerprint={"schema": 1, "packages": {"a": "1"}})
+
+    lines = cli.format_ledger_summary(list(ledger.read_history(tmp_path)))
+    assert any("1 entry(ies) carry no stack fingerprint" in line for line in lines)
+    assert any("iterations 1-2" in line for line in lines)


### PR DESCRIPTION
## Summary

Two things an agent told to "run the loop" could not do: see what the ledger
holds, and know what to do with what it sees.

**`--status`** prints the launch line and a ledger summary, evaluates nothing,
and leaves the directory byte-identical. Previously that line was reachable
only from inside a campaign, after the reference measurement (~20 min) — and
the obvious workaround, pointing `--dry-run` at the ledger, **appends demo
iterations to an append-only evidence file** with nothing marking them as demo
(measured; opened as #115).

It reuses `format_comparability_lines` rather than formatting its own, so what
`--status` says and what a campaign pairs against cannot come from two
readings that drift apart, and it honours `--set` so the answer is for the
campaign you would actually launch.

```
ledger dir: /path/to/repo/harness/ledger
reference models: rag=gemma4:e4b, chat=gemma4:e4b, contextual=gemma4:e4b, recomp=gemma4:e4b
environment: isolated:mineru=3.4.5, isolated:transformers=4.57.6, ... product:torch=2.13.0, ...
ledger: 2 entry(ies), iterations 1-2 (accepted 2)
  last: iteration 2 accepted on the search_set -- seeded
  best search-set objective in this ledger: 27 (iteration 1) -- comparability decides whether this launch can use it
ledger history: 2 entry(ies), 1 comparable search-set state(s)
  historical high water: 25 (recovery mode arms only if the measured reference scores lower)
```

**`harness/RUNBOOK.md`** is the procedure: five checks before launching, how to
read each line of `--status` and which are decision points, what each of the
five verdicts means and what to do next (`inconclusive` is the measurement
failing, not the candidate — the one an unattended agent will get wrong), what
is forbidden and what mechanism enforces it, and the limits true of every
result today. It links to `harness/README.md` for reasoning instead of
restating it, and is registered in `docs/README.md`'s table.

## Issue

Fixes #114. See [the correction comment](https://github.com/iDiagoValeta/localOllamaRAG/issues/114#issuecomment-5486977508):
the issue's first bullet claimed a dry-run always reports 0 comparable states,
which a test I wrote to assert it disproved. The real defect turned out to be
worse and is now #115.

## Test plan

- [x] `pytest` green: 841 passed, 2 skipped (baseline 835).
- [x] `ruff check .` clean.
- [x] **`--status` proven not to evaluate**: `monkeypatch` replaces
      `real_evaluate` with a function that raises `AssertionError` if called;
      the test passes.
- [x] **Proven read-only**: the ledger directory listing is compared before and
      after, unchanged.
- [x] `--set` honoured: pinning `models.chat` flips the same ledger from 1
      comparable state to 0, and the pin shows in the printed reference.
- [x] **Every command in the RUNBOOK was run on this machine and its real
      output pasted**, per the issue's closure criterion: `--status` on a clean
      clone, `pytest`/`ruff`, the Ollama probe (200), the jina-clip worker
      (`{"event": "ready", "dim": 512}`), and `--dry-run` writing to
      `/tmp/harness_dry_run_xis6sqwf` while `harness/ledger` stays absent.
- [ ] Full gate not needed: `harness/` is not product; no retrieval or
      generation code is touched.
- [ ] No protected-zone edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)