### PR TITLE
Refuse to write demo iterations into a ledger that holds real ones (#115)

### DIFF
--- a/harness/README.md
+++ b/harness/README.md
@@ -364,7 +364,13 @@ it has no opinion about which real configuration is better.
 > read the directory back via `ledger.read_history` to continue where the
 > last invocation left off. `--dry-run` deliberately does NOT default to
 > this directory (a fresh temp dir instead), precisely so demo runs never
-> mix into that history. A second real invocation against a non-empty
+> mix into that history. Issue #115 closed the gap that sentence left open:
+> the default was protected and an explicit `--ledger-dir` was not, so a
+> dry-run pointed at a real ledger *to inspect it* appended its own
+> iterations there, unmarked. Entries now record which evaluator wrote them
+> (schema v4), a demo run refuses a ledger holding anything not marked demo,
+> and a demo entry is never selected as a pairing baseline. Use `--status`
+> to inspect a ledger; it only reads. A second real invocation against a non-empty
 > `--ledger-dir` — including the default, after one real run — used to
 > crash (`ledger.read_history` fed `cli.py`'s own `report.json` to
 > `LedgerEntry(**data)`); fixed, see `harness/tests/test_ledger.py`'s

--- a/harness/RUNBOOK.md
+++ b/harness/RUNBOOK.md
@@ -72,11 +72,13 @@ echo '{"id": 1, "op": "text", "text": "probe"}' \
 python -m harness.cli --dry-run --max-iterations 3
 ```
 
-> [!WARNING]
-> Never pass `--ledger-dir <a real ledger>` to `--dry-run`. It **appends its
-> demo iterations to that ledger** and they are indistinguishable from
-> measured ones afterwards (issue #115). Without `--ledger-dir`, a dry-run
-> writes to a fresh temp directory, which is the safe form used above.
+> [!NOTE]
+> A dry-run given `--ledger-dir <a ledger holding anything not marked demo>`
+> now refuses to start (exit 2) rather than appending its synthetic iterations
+> to it — which is what it used to do, indistinguishably from measured entries
+> (issue #115). `--status` and `--replay` only read, so neither is affected.
+> Without `--ledger-dir`, a dry-run writes to a fresh temp directory, which is
+> the safe form used above.
 
 A missing Ollama model is caught by the gate itself, at launch, with the exact
 `ollama pull` line to run — verified 2026-09-01, it failed in 20 s rather than
@@ -202,7 +204,10 @@ red test.
 - **Never hand-edit the ledger** to remove an inconvenient entry. It is
   append-only evidence. If the history is stale, the answer is a refresh
   campaign, not a delete (#107).
-- **Never run `--dry-run` against a real ledger** (§1's warning, #115).
+- **Never hand-write a demo result into a real ledger.** The tool now refuses
+  to do it for you (§1), and the refusal exists because a demo entry is not
+  inert: `GridProposer` reads history back to skip points already tried, and
+  `_historical_high_water` picks a pairing baseline from it (#115).
 - **Never weaken a test to make a campaign pass.** `tests/characterization/`
   pins current behaviour including its bugs; changing one is a signal to stop
   and confirm (`AGENTS.md` rule 9).

--- a/harness/cli.py
+++ b/harness/cli.py
@@ -212,12 +212,34 @@ def format_ledger_summary(entries: Sequence[ledger_mod.LedgerEntry]) -> list:
             f"  best search-set objective in this ledger: {best.objective_adjusted} "
             f"(iteration {best.iteration}) -- comparability decides whether this launch can use it"
         )
+    demo_entries = sum(1 for e in entries if e.evaluator == ledger_mod.EVALUATOR_DEMO)
+    if demo_entries:
+        lines.append(
+            f"  {demo_entries} entry(ies) came from the demo evaluator -- never used as "
+            "a pairing baseline, and reported rather than filtered silently (#115)"
+        )
     if without_fingerprint:
         lines.append(
             f"  {without_fingerprint} entry(ies) carry no stack fingerprint "
             "(written before ledger schema v3) -- their stack can never be verified (#107)"
         )
     return lines
+
+
+def _entries_a_demo_run_must_not_join(ledger_dir: Path) -> int:
+    """How many entries in ``ledger_dir`` a demo run has no business joining.
+
+    Anything not positively marked as demo counts, ``None`` included: an entry
+    written before ledger schema v4 cannot be known to be real, and that
+    uncertainty is the defect (issue #115), not an exemption from it.
+    """
+    if not ledger_dir.exists():
+        return 0
+    return sum(
+        1
+        for entry in ledger_mod.read_history(ledger_dir)
+        if entry.evaluator != ledger_mod.EVALUATOR_DEMO
+    )
 
 
 def _run_status(reference, ledger_dir: Path) -> int:
@@ -322,10 +344,36 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
 
     if args.dry_run:
         evaluate = evaluator_mod.build_demo_evaluator()
+        evaluator_kind = ledger_mod.EVALUATOR_DEMO
         ledger_dir = args.ledger_dir or Path(tempfile.mkdtemp(prefix="harness_dry_run_"))
     else:
         evaluate = evaluator_mod.real_evaluate
+        evaluator_kind = ledger_mod.EVALUATOR_REAL
         ledger_dir = args.ledger_dir or ledger_mod.LEDGER_DIR
+
+    # Issue #115: refuse BEFORE anything is written. The demo evaluator has no
+    # opinion about which real configuration is better, and its entries used to
+    # land in an append-only evidence file with nothing marking them -- then act
+    # as points already tried and as pairing baselines. The default path (a
+    # fresh temp dir) is untouched; this guards only an explicit --ledger-dir,
+    # which is precisely the case harness/README.md already claimed was
+    # protected and was not.
+    # --status and --replay only read, so neither can contaminate anything;
+    # gating them would block the two commands an operator uses to inspect a
+    # ledger, which is the opposite of the point (caught by
+    # test_cli_replay_exits_zero_when_the_demo_evaluator_matches).
+    if args.dry_run and not args.status and args.replay is None:
+        blocking = _entries_a_demo_run_must_not_join(ledger_dir)
+        if blocking:
+            print(
+                f"REFUSING: {blocking} entry(ies) this dry-run must not write beside "
+                f"in {ledger_dir} -- they came from the real evaluator, or from before "
+                "the ledger recorded which evaluator wrote them (unknown is not "
+                "permission). Drop --ledger-dir to write to a fresh temp directory, "
+                "or point it at a scratch ledger of demo entries.",
+                file=sys.stderr,
+            )
+            return 2
 
     if args.status:
         return _run_status(reference, ledger_dir)
@@ -368,6 +416,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             ledger_dir=ledger_dir,
             reference_overrides=set_overrides,
             launch_environment=launch_environment,
+            evaluator_kind=evaluator_kind,
         )
     except evaluator_mod.ReachabilityError as exc:
         print(f"REACHABILITY GATE FAILED: {exc}", file=sys.stderr)

--- a/harness/ledger.py
+++ b/harness/ledger.py
@@ -24,7 +24,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-SCHEMA_VERSION = 3
+SCHEMA_VERSION = 4
 
 LEDGER_DIR = Path(__file__).resolve().parent / "ledger"
 INDEX_FILE_NAME = "index.jsonl"
@@ -38,6 +38,14 @@ INDEX_FILE_NAME = "index.jsonl"
 # against a non-empty ledger_dir, which the default harness/ledger/ becomes
 # after one real run.
 _ENTRY_FILENAME_RE = re.compile(r"^\d{4}_.*\.json$")
+
+# Which evaluator produced an entry (issue #115). `None` is a fourth state and
+# the default: an entry written before schema v4 CANNOT be known to be real,
+# because a --dry-run pointed at that ledger is exactly the defect this field
+# closes. Asserting "real" for them would repeat the mistake #107 avoided --
+# treating an absent record as a positive claim.
+EVALUATOR_DEMO = "demo"
+EVALUATOR_REAL = "real"
 
 VERDICTS = (
     "accepted",
@@ -125,6 +133,15 @@ class LedgerEntry:
             ``loop.is_comparable_search_set_entry`` rejects only a KNOWN
             mismatch, so pre-v3 history stays usable and is reported as
             unverified rather than silently trusted.
+        evaluator: ``EVALUATOR_REAL``, ``EVALUATOR_DEMO``, or ``None`` for an
+            entry written before schema v4 (issue #115). ``None`` means
+            unknown, not real: a ``--dry-run --ledger-dir <a real ledger>``
+            used to append its synthetic iterations here with nothing to tell
+            them apart, and a demo entry is not inert once written --
+            ``GridProposer`` reads history back to skip points already tried
+            and ``loop._historical_high_water`` picks a pairing baseline from
+            it, so a synthetic iteration that scored well became a baseline a
+            real campaign was judged against.
     """
 
     schema_version: int
@@ -152,6 +169,7 @@ class LedgerEntry:
     reason: str
     regression_baseline_iteration: Optional[int] = None
     environment_fingerprint: Optional[Dict[str, Any]] = None
+    evaluator: Optional[str] = None
 
     def to_dict(self) -> Dict[str, Any]:
         return dataclasses.asdict(self)

--- a/harness/loop.py
+++ b/harness/loop.py
@@ -303,6 +303,11 @@ def is_comparable_search_set_entry(
     return (
         entry.evaluated_case_set == "search_set"
         and entry.verdict != "inconclusive"
+        # Issue #115: a demo entry measures a synthetic landscape with no
+        # opinion about which real configuration is better. Pairing a real
+        # campaign against one is the "loop sobre una medida que miente"
+        # failure arriving through the door marked safe.
+        and entry.evaluator != ledger_mod.EVALUATOR_DEMO
         and _comparable_config_view(entry.effective_config) == comparable_view
         and environment_mod.compare(entry.environment_fingerprint, launch_environment)
         != environment_mod.DIFFERS
@@ -465,6 +470,7 @@ def _build_entry(
     candidate_latency: Optional[Dict[str, Optional[float]]] = None,
     regression_baseline_iteration: Optional[int] = None,
     environment_fingerprint: Optional[Dict[str, Any]] = None,
+    evaluator: Optional[str] = None,
 ) -> ledger_mod.LedgerEntry:
     objective_raw, objective_adjusted = evaluator_mod.compute_objective(
         result.records, unreachable_ids
@@ -497,6 +503,7 @@ def _build_entry(
         reason=reason,
         regression_baseline_iteration=regression_baseline_iteration,
         environment_fingerprint=environment_fingerprint,
+        evaluator=evaluator,
     )
 
 
@@ -515,6 +522,7 @@ def run_loop(
     reachability_probe_case_ids: Sequence[str] = (),
     reference_overrides: Optional[Dict[str, Any]] = None,
     launch_environment: Any = _READ_ENVIRONMENT,
+    evaluator_kind: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Run the search until termination, writing one ledger entry per iteration.
 
@@ -562,6 +570,10 @@ def run_loop(
         written this run. Always returned, on every termination path
         (criterion 8) -- including when the search space is exhausted.
 
+        evaluator_kind: ``ledger.EVALUATOR_REAL`` or ``EVALUATOR_DEMO``,
+            stamped into every entry so a demo iteration can never be mistaken
+            for a measured one later (issue #115). ``None`` records unknown,
+            which is what pre-v4 entries carry.
         launch_environment: The installed stack this campaign runs on, stamped
             into every entry and used to reject a ledger entry measured on a
             known-different one (issue #107). Defaults to reading this
@@ -674,6 +686,7 @@ def run_loop(
                 verdict="inconclusive",
                 reason="fast-tier evaluation carries infrastructure_error record(s) -- not scored",
                 environment_fingerprint=launch_environment,
+                evaluator=evaluator_kind,
             )
         else:
             regressed = _regressed_ids(fast_regression_baseline, fast_result.records)
@@ -697,6 +710,7 @@ def run_loop(
                     verdict="rejected_regression",
                     reason=f"fast-tier regression on {regressed}{baseline_note}",
                     environment_fingerprint=launch_environment,
+                    evaluator=evaluator_kind,
                 regression_baseline_iteration=recovery_baseline_iteration,
                 )
             else:
@@ -719,6 +733,7 @@ def run_loop(
                         verdict="inconclusive",
                         reason="search-set evaluation carries infrastructure_error record(s) -- not scored",
                         environment_fingerprint=launch_environment,
+                        evaluator=evaluator_kind,
                     )
                 else:
                     candidate_latency = evaluator_mod.median_latency_by_bucket(full_result.records)
@@ -771,6 +786,7 @@ def run_loop(
                         # included: which pass vector the regression checks
                         # paired against is part of the evidence.
                         environment_fingerprint=launch_environment,
+                        evaluator=evaluator_kind,
                 regression_baseline_iteration=recovery_baseline_iteration,
                     )
 

--- a/harness/tests/test_ledger_provenance.py
+++ b/harness/tests/test_ledger_provenance.py
@@ -1,0 +1,160 @@
+"""Which evaluator produced an entry, and the refusal that keeps the two apart.
+
+Issue #115. Pointing ``--dry-run`` at a real ledger to inspect it appended two
+synthetic iterations to an append-only evidence file, indistinguishable from
+measured ones afterwards. ``harness/README.md`` already claimed the protection
+existed -- "``--dry-run`` deliberately does NOT default to this directory ...
+precisely so demo runs never mix into that history" -- and the mechanism
+covered the default while leaving the explicit ``--ledger-dir`` open, which is
+the flag an operator reaches for when they want a *specific* ledger.
+
+A demo entry is not inert once written. ``GridProposer`` skips points "already
+tried" by reading history back, and ``_historical_high_water`` picks a pairing
+baseline from it, so a synthetic iteration that happens to score well becomes
+a baseline a real campaign is judged against.
+
+Two decisions, both tested here:
+
+1. **``evaluator`` is recorded per entry, defaulting to ``None``.** Not
+   ``"real"``: entries written before this field cannot be known to be real
+   (that is the whole defect), and asserting it would be the same mistake as
+   treating an unknown stack fingerprint as a match (#107).
+2. **A demo run refuses a ledger that holds anything not known to be demo**,
+   rather than filtering or warning. The repo's hard-fail policy, and the
+   only answer that cannot be missed in a log.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+for path in (ROOT, ROOT / "src"):
+    if str(path) not in sys.path:
+        sys.path.insert(0, str(path))
+
+from harness import cli  # noqa: E402
+from harness import ledger as ledger_mod  # noqa: E402
+
+
+def _entry(iteration: int, evaluator):
+    return ledger_mod.LedgerEntry(
+        schema_version=ledger_mod.SCHEMA_VERSION,
+        iteration=iteration,
+        parent_iteration=None,
+        git_commit=None,
+        config_overrides={},
+        effective_config={},
+        proposer="grid",
+        proposer_rationale=None,
+        proposer_model=None,
+        proposer_fallback=False,
+        proposer_fallback_reason=None,
+        evaluated_case_set="search_set",
+        case_records=[],
+        summary={"total": 0, "passed": 0, "pass_rate": 0.0},
+        objective_raw=0,
+        objective_adjusted=0,
+        median_latency_answered_s=None,
+        median_latency_retrieval_only_s=None,
+        reference_median_latency_answered_s=None,
+        reference_median_latency_retrieval_only_s=None,
+        latency_ceiling_multiplier=1.2,
+        verdict="accepted",
+        reason="seeded",
+        evaluator=evaluator,
+    )
+
+
+class TestTheFieldItself:
+    def test_an_entry_defaults_to_an_unknown_evaluator(self):
+        """Absence is not a claim. An entry written before this field may well
+        have come from a dry-run -- that is the defect being fixed."""
+        entry = ledger_mod.LedgerEntry.from_dict(
+            {k: v for k, v in _entry(1, None).to_dict().items() if k != "evaluator"}
+        )
+        assert entry.evaluator is None
+
+    def test_the_field_survives_a_write_and_read(self, tmp_path):
+        ledger_mod.write_entry(_entry(1, ledger_mod.EVALUATOR_DEMO), tmp_path)
+        assert ledger_mod.read_history(tmp_path)[0].evaluator == ledger_mod.EVALUATOR_DEMO
+
+
+class TestTheRefusal:
+    def test_a_demo_run_refuses_a_ledger_holding_real_entries(self, tmp_path, capsys):
+        ledger_mod.write_entry(_entry(1, ledger_mod.EVALUATOR_REAL), tmp_path)
+
+        code = cli.main(["--dry-run", "--max-iterations", "1", "--ledger-dir", str(tmp_path)])
+
+        assert code == 2
+        message = capsys.readouterr().err
+        assert "1 entry(ies) this dry-run must not write beside" in message
+        assert "--ledger-dir" in message
+
+    def test_a_demo_run_refuses_a_ledger_of_unknown_provenance(self, tmp_path, capsys):
+        """Pre-v4 entries. Unknown is not permission."""
+        ledger_mod.write_entry(_entry(1, None), tmp_path)
+
+        assert cli.main(["--dry-run", "--max-iterations", "1", "--ledger-dir", str(tmp_path)]) == 2
+        assert "unknown" in capsys.readouterr().err
+
+    def test_the_refusal_writes_nothing(self, tmp_path):
+        """A refusal that appended first would be no protection at all."""
+        ledger_mod.write_entry(_entry(1, ledger_mod.EVALUATOR_REAL), tmp_path)
+        before = sorted(p.name for p in tmp_path.iterdir())
+
+        cli.main(["--dry-run", "--max-iterations", "1", "--ledger-dir", str(tmp_path)])
+
+        assert sorted(p.name for p in tmp_path.iterdir()) == before
+
+    def test_a_demo_run_continues_into_a_ledger_of_its_own_demo_entries(self, tmp_path):
+        """Iterating on the proposer against a scratch directory stays legal --
+        the refusal is about mixing, not about reusing a demo ledger."""
+        ledger_mod.write_entry(_entry(1, ledger_mod.EVALUATOR_DEMO), tmp_path)
+
+        assert cli.main(["--dry-run", "--max-iterations", "1", "--ledger-dir", str(tmp_path)]) == 0
+        assert len(ledger_mod.read_history(tmp_path)) == 2
+
+    def test_a_demo_run_with_no_ledger_dir_is_unaffected(self):
+        """The default already wrote to a temp dir; that path must not change."""
+        assert cli.main(["--dry-run", "--max-iterations", "1"]) == 0
+
+
+class TestTheReverseDirection:
+    def test_a_real_campaign_reports_demo_entries_instead_of_pairing_against_them(self, tmp_path):
+        """Filtering silently is what this repo does not do. The campaign runs;
+        the line says what was set aside and why."""
+        entries = [_entry(1, ledger_mod.EVALUATOR_DEMO), _entry(2, ledger_mod.EVALUATOR_REAL)]
+        lines = cli.format_ledger_summary(entries)
+        assert any("1 entry(ies) came from the demo evaluator" in line for line in lines)
+
+
+def test_demo_entries_are_never_a_pairing_baseline(tmp_path):
+    """The consequence that makes this a bug and not untidiness: a demo
+    iteration scoring well would otherwise become the high water a real
+    campaign is judged against."""
+    from harness import loop
+
+    demo = _entry(1, ledger_mod.EVALUATOR_DEMO)
+    demo = ledger_mod.LedgerEntry.from_dict({**demo.to_dict(), "objective_adjusted": 99})
+    ledger_mod.write_entry(demo, tmp_path)
+    ledger_mod.write_entry(
+        ledger_mod.LedgerEntry.from_dict(
+            {**_entry(2, ledger_mod.EVALUATOR_REAL).to_dict(), "objective_adjusted": 27}
+        ),
+        tmp_path,
+    )
+
+    entries = list(ledger_mod.read_history(tmp_path))
+    view = loop._comparable_config_view({})
+    high_water = loop._historical_high_water(entries, view)
+    assert high_water is not None and high_water.iteration == 2, (
+        "a demo entry must never be selected as the pairing baseline"
+    )
+
+
+@pytest.mark.parametrize("value", [ledger_mod.EVALUATOR_DEMO, ledger_mod.EVALUATOR_REAL, None])
+def test_every_accepted_evaluator_value_round_trips_through_json(value, tmp_path):
+    ledger_mod.write_entry(_entry(1, value), tmp_path)
+    assert ledger_mod.read_history(tmp_path)[0].evaluator == value


### PR DESCRIPTION
## Summary

`--dry-run --ledger-dir <a real ledger>` appended its demo iterations to an
append-only evidence file, and nothing on a written entry said which evaluator
produced it.

The README already claimed this was prevented. The mechanism covered the
default (a temp dir) and not the explicit `--ledger-dir` — the flag you reach
for precisely when you want a *specific* ledger.

**Why it is a bug and not untidiness:** a demo entry is a live participant
afterwards. `GridProposer` reads history back to skip points already tried;
`_historical_high_water` picks a pairing baseline from it. A synthetic
iteration that scores well becomes the baseline a real campaign is judged
against.

- `LedgerEntry.evaluator` (schema v4), defaulting to **`None`, not `"real"`** —
  an entry written before this field cannot be known to be real, since a
  dry-run into that ledger is the defect itself. Same principle as #107's
  unknown-is-not-a-match.
- A demo run refuses, **before writing anything**, a ledger holding anything
  not positively marked demo.
- A demo entry is never selected as a pairing baseline.
- `--status` and `--replay` only read, so neither is gated. The existing replay
  test caught the first, over-broad version of the check — that is what it was
  there for.

## Issue

Fixes #115

## Test plan

- [x] **Verified against the issue's own reproduction**, before and after:

  ```
  antes:   0001_...json  index.jsonl
  REFUSING: 1 entry(ies) this dry-run must not write beside in ... -- they came from
  the real evaluator, or from before the ledger recorded which evaluator wrote them
  (unknown is not permission). Drop --ledger-dir to write to a fresh temp directory,
  or point it at a scratch ledger of demo entries.
  EXIT=2
  después: 0001_...json  index.jsonl
  ```

- [x] `pytest` green: 855 passed, 2 skipped (baseline 841).
- [x] `ruff check .` clean.
- [x] A demo run into a ledger of its own demo entries still works — the
      refusal is about mixing, not about reusing a scratch ledger.
- [x] A dry-run with no `--ledger-dir` is unaffected (still a temp dir).
- [x] A demo entry scoring 99 does not become the high water over a real entry
      scoring 27.
- [ ] Full gate not needed: `harness/` is not product; no retrieval or
      generation code is touched.
- [ ] No protected-zone edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)