### PR TITLE
Find MinerU's output directory by what it holds, not by its name (#118)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,7 +32,8 @@
 # ── MinerU (PDF/table extraction, external CLI, not a Python dependency) ────
 #MINERU_BIN=                                    # path to the mineru executable; defaults to .venv-mineru/Scripts/mineru.exe (Windows) or .venv-mineru/bin/mineru (Linux/Mac), whichever exists
 #MINERU_CACHE_DIR=                              # extraction cache directory; defaults to <repo_root>/.mineru_cache
-#MINERU_MODEL_SOURCE=local                      # forwarded to the MinerU CLI; "local" reuses the already-downloaded HuggingFace cache without attempting a download
+#MINERU_MODEL_SOURCE=local                      # forwarded to the MinerU CLI. MinerU 2.x: "local" reuses the already-downloaded HuggingFace cache without attempting a download.
+#                                               # MinerU 3.x: "local" instead means "read paths from a local models config file" and CRASHES without one (issue #118) -- use "huggingface" for a first run, which downloads the models.
 
 
 # ── Ollama connection ───────────────────────────────────────────────────────

--- a/README.md
+++ b/README.md
@@ -228,7 +228,16 @@ MinerU and Jina CLIP v2 do not run in that environment: their dependencies
 collide with the product's, so both are installed together into one isolated
 interpreter at `.venv-mineru/Scripts/python.exe` (Windows) or
 `.venv-mineru/bin/python` (Linux/Mac), at the project root, following each
-project's own install instructions. That interpreter needs a CUDA GPU: Jina
+project's own install instructions.
+
+> [!IMPORTANT]
+> **MinerU 3.x needs `MINERU_MODEL_SOURCE=huggingface` on a first run.** The
+> default, `local`, meant "reuse the already-downloaded HuggingFace cache" in
+> 2.x; in 3.x it means "read paths from a local models config file" and fails
+> without one, so nothing indexes (issue #118). Set it once so MinerU
+> downloads its models; the default works from then on. MinerU also names its
+> output directory after the backend that ran (`hybrid_auto/` rather than
+> 2.x's `auto/`) — the adapter finds it either way. That interpreter needs a CUDA GPU: Jina
 CLIP v2 can run on CPU (that is how the roughly 100 seconds per document
 figure was measured, impractical for indexing), but this project's worker
 refuses to start it there. That is the same "no silent fallbacks" policy

--- a/src/monkeygrab/adapters/extraction/mineru_extractor.py
+++ b/src/monkeygrab/adapters/extraction/mineru_extractor.py
@@ -140,29 +140,71 @@ def _cache_key(pdf_path: Path, mineru_bin: str) -> str:
     return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
 
 
+def _find_output_dir(dest: Path, pdf_stem: str) -> Path:
+    """The directory holding this extraction's Markdown, whatever it is called.
+
+    MinerU nests its output one level deeper than the ``-o`` directory it is
+    given. 2.x always named that level ``auto/``; 3.x names it after the
+    backend that ran -- ``hybrid_auto/``, ``vlm_auto/``, ``pipeline_auto/`` --
+    so the hardcoded name meant a fresh install extracted a PDF successfully
+    and had the result rejected (issue #118).
+
+    The directory is therefore located by what it CONTAINS (``<stem>.md``)
+    rather than by its name: no version detection, no list of backend names to
+    keep current as MinerU adds them, and 2.x's ``auto/`` keeps working
+    untouched.
+
+    Raises:
+        RuntimeError: No candidate, or more than one. Two output directories
+            side by side -- a stale one from an earlier run next to a fresh
+            one -- is ambiguous, and picking whichever sorted first would
+            index a mixture of two extractions while reporting one. That is
+            the failure this adapter's no-silent-fallback policy exists to
+            prevent, so it is a hard failure rather than a heuristic.
+    """
+    parent = dest / pdf_stem
+    candidates = (
+        sorted(child for child in parent.iterdir() if (child / f"{pdf_stem}.md").is_file())
+        if parent.is_dir()
+        else []
+    )
+
+    if not candidates:
+        raise RuntimeError(
+            f"MinerU produced no output directory containing {pdf_stem}.md under {parent}. "
+            "Check the CLI's own stderr/stdout for the real cause -- with MinerU 3.x, "
+            "MINERU_MODEL_SOURCE=local requires a local models config file and crashes "
+            "without one; MINERU_MODEL_SOURCE=huggingface downloads them instead "
+            "(issue #118)."
+        )
+    if len(candidates) > 1:
+        names = ", ".join(child.name for child in candidates)
+        raise RuntimeError(
+            f"MinerU left more than one output directory under {parent}: {names}. "
+            "This adapter will not guess which extraction is current -- delete the "
+            "stale one (or clear the extraction cache) and re-run."
+        )
+    return candidates[0]
+
+
 def _validate_output(dest: Path, pdf_stem: str) -> Tuple[Path, Path]:
     """Locate and sanity-check MinerU's output inside ``dest``.
 
-    MinerU nests its own output one level deeper than the ``-o`` directory it
-    is given: ``<dest>/<pdf_stem>/auto/<pdf_stem>.md`` plus a sibling
-    ``*_content_list.json`` with the structured block list this adapter
-    parses (SECTION 2).
+    The output directory is found by ``_find_output_dir`` (its name depends on
+    the MinerU version and backend); this checks that what is inside it is
+    usable -- the Markdown and the sibling ``*_content_list.json`` carrying
+    the structured block list this adapter parses (SECTION 2).
 
     Returns:
         ``(md_path, content_list_path)``.
 
     Raises:
-        RuntimeError: If the ``auto/`` directory, the Markdown file or the
+        RuntimeError: If the output directory, the Markdown file or the
             content-list JSON is missing, or the Markdown is empty --
             the three "MinerU silently produced nothing usable" failure
             modes this adapter must never paper over (see module docstring).
     """
-    auto_dir = dest / pdf_stem / "auto"
-    if not auto_dir.is_dir():
-        raise RuntimeError(
-            f"MinerU produced no output directory (expected {auto_dir}). "
-            "Check the CLI's own stderr/stdout for the real cause."
-        )
+    auto_dir = _find_output_dir(dest, pdf_stem)
 
     md_path = auto_dir / f"{pdf_stem}.md"
     if not md_path.is_file() or not md_path.read_text(encoding="utf-8").strip():

--- a/tests/unit/adapters/test_mineru_extractor.py
+++ b/tests/unit/adapters/test_mineru_extractor.py
@@ -53,9 +53,15 @@ def _dest_from_cmd(cmd):
     return Path(cmd[cmd.index("-o") + 1])
 
 
-def _write_valid_output(dest: Path, pdf_stem: str, blocks=None, md_text="# Heading\n\nSome text."):
-    """Write the directory tree MinerU produces for a successful extraction."""
-    auto = dest / pdf_stem / "auto"
+def _write_valid_output(
+    dest: Path, pdf_stem: str, blocks=None, md_text="# Heading\n\nSome text.", backend_dir="auto"
+):
+    """Write the directory tree MinerU produces for a successful extraction.
+
+    ``backend_dir`` is ``auto`` for MinerU 2.x and ``<backend>_auto`` for 3.x
+    (``hybrid_auto``, ``vlm_auto``, ``pipeline_auto``) -- see issue #118.
+    """
+    auto = dest / pdf_stem / backend_dir
     auto.mkdir(parents=True, exist_ok=True)
     (auto / f"{pdf_stem}.md").write_text(md_text, encoding="utf-8")
     (auto / f"{pdf_stem}_content_list.json").write_text(
@@ -457,3 +463,101 @@ def test_parses_a_representative_mineru_output_including_a_table_and_a_figure(mo
 
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-v"]))
+
+
+# MinerU 3.x moved its output directory (issue #118). 2.x wrote
+# <dest>/<stem>/auto/; 3.x names it after the backend that ran --
+# hybrid_auto/, vlm_auto/, pipeline_auto/ -- so a fresh install today
+# extracted a PDF successfully and the adapter rejected the result, having
+# looked in one hardcoded place. The directory is located by what it
+# contains, not by its name, which needs no version detection and keeps
+# working for 2.x.
+
+
+@pytest.mark.parametrize("backend_dir", ["auto", "hybrid_auto", "vlm_auto", "pipeline_auto"])
+def test_output_is_found_whatever_the_backend_named_its_directory(
+    monkeypatch, tmp_path, backend_dir
+):
+    pdf = _make_pdf(tmp_path)
+    binary = _make_bin(tmp_path)
+
+    blocks = [{"type": "text", "text": "Some text.", "text_level": 1, "page_idx": 0}]
+
+    def fake_run(cmd, **kwargs):
+        _write_valid_output(
+            _dest_from_cmd(cmd), pdf.stem, blocks=blocks, backend_dir=backend_dir
+        )
+        return _FakeCompleted()
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+    extractor = MineruExtractor(mineru_bin=str(binary), cache_dir=str(tmp_path / "cache"))
+    pages = extractor.extract(str(pdf))
+    assert pages and pages[0].text == "# Some text."
+
+
+def test_two_backend_directories_raise_instead_of_picking_one(monkeypatch, tmp_path):
+    """A stale directory from an earlier run beside a fresh one is ambiguous.
+    Guessing would silently index whichever sorted first -- a mixture of two
+    extractions reported as one, which is the failure the hard-fail policy
+    exists to prevent."""
+    pdf = _make_pdf(tmp_path)
+    binary = _make_bin(tmp_path)
+
+    def fake_run(cmd, **kwargs):
+        dest = _dest_from_cmd(cmd)
+        _write_valid_output(dest, pdf.stem, backend_dir="auto", md_text="# Old\n\nstale.")
+        _write_valid_output(dest, pdf.stem, backend_dir="hybrid_auto", md_text="# New\n\nfresh.")
+        return _FakeCompleted()
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+    extractor = MineruExtractor(mineru_bin=str(binary), cache_dir=str(tmp_path / "cache"))
+    with pytest.raises(RuntimeError) as exc:
+        extractor.extract(str(pdf))
+    assert "auto" in str(exc.value) and "hybrid_auto" in str(exc.value)
+
+
+def test_no_output_directory_still_names_what_it_looked_for(monkeypatch, tmp_path):
+    """The error must stay actionable now that the path is not one literal."""
+    pdf = _make_pdf(tmp_path)
+    binary = _make_bin(tmp_path)
+
+    def fake_run(cmd, **kwargs):
+        (_dest_from_cmd(cmd) / pdf.stem).mkdir(parents=True, exist_ok=True)
+        return _FakeCompleted()
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+    extractor = MineruExtractor(mineru_bin=str(binary), cache_dir=str(tmp_path / "cache"))
+    with pytest.raises(RuntimeError) as exc:
+        extractor.extract(str(pdf))
+    message = str(exc.value)
+    assert f"{pdf.stem}.md" in message
+    assert "MINERU_MODEL_SOURCE" in message
+
+
+def test_images_are_read_from_the_directory_that_was_found(monkeypatch, tmp_path):
+    """img_path is relative to the output directory, so locating the wrong one
+    would find the markdown and lose every figure."""
+    pdf = _make_pdf(tmp_path)
+    binary = _make_bin(tmp_path)
+    blocks = [
+        {
+            "type": "image",
+            "img_path": "images/fig.png",
+            "image_caption": ["Figure 1: a caption"],
+            "page_idx": 0,
+        }
+    ]
+
+    def fake_run(cmd, **kwargs):
+        out = _write_valid_output(
+            _dest_from_cmd(cmd), pdf.stem, blocks=blocks, backend_dir="hybrid_auto"
+        )
+        (out / "images").mkdir(exist_ok=True)
+        (out / "images" / "fig.png").write_bytes(_TINY_PNG)
+        return _FakeCompleted()
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+    extractor = MineruImageExtractor(mineru_bin=str(binary), cache_dir=str(tmp_path / "cache"))
+    images = extractor.extract(str(pdf))
+    assert list(images) == [0]
+    assert images[0][0].caption == "Figure 1: a caption"


### PR DESCRIPTION
## Summary

A fresh Linux install cannot index anything. `.venv-mineru` built today gets
**MinerU 3.4.5**, and the adapter fails against it at two separate points.

**Fixed here:** 2.x nested output as `<dest>/<stem>/auto/`; 3.x names that
level after the backend that ran (`hybrid_auto/`, `vlm_auto/`,
`pipeline_auto/`). `_validate_output` hardcoded `auto`, so MinerU extracted a
38-page PDF successfully and the adapter rejected the result. It now finds the
directory by the file it must contain (`<stem>.md`) — no version detection, no
backend-name list to keep current, 2.x unchanged.

Two candidates is a hard failure rather than a guess: a stale directory beside
a fresh one would otherwise index a mixture of two extractions while reporting
one.

**Deliberately not fixed here:** the default `MINERU_MODEL_SOURCE=local`
crashes MinerU 3.x (`'NoneType' object has no attribute 'get'` — in 3.x
`local` means "read a local models config file", not "reuse the HF cache").
Changing a shipped default is owner territory (`AGENTS.md` rules 5/6), so this
PR documents the workaround in `README.md` and `.env.example`, and makes the
adapter's not-found error name it. **#118 stays open for that decision.**

## Issue

Refs #118 — does not close it.

## Test plan

- [x] **Verified end to end on the real stack, not by unit tests alone.**
      Before: the gate died in 20 s on the first PDF. After, with
      `MINERU_MODEL_SOURCE=huggingface`:
      `[index] dev set: indexing 6 missing paper(s): [...]` — extraction is
      passed and all six dev-set papers index. That is #118's stated closure
      evidence for this half.
- [x] `pytest` green: 862 passed, 2 skipped (baseline 855).
- [x] `ruff check .` clean.
- [x] Parametrised over `auto`, `hybrid_auto`, `vlm_auto`, `pipeline_auto` —
      the 2.x path is covered by the same test as the 3.x ones.
- [x] Images are read from the directory that was found: locating the wrong
      one would find the Markdown and silently lose every figure, so that has
      its own test.
- [x] The not-found error still names `<stem>.md` and now names
      `MINERU_MODEL_SOURCE`.
- [ ] Full gate: running now on this machine; it is what produced the
      end-to-end evidence above. This PR does not change what gets extracted
      for anyone whose install already works — it changes where the adapter
      looks.
- [ ] No protected-zone edits. `requirements*.txt` untouched (MinerU is not in
      them; it is an external CLI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)