### PR TITLE
Keep the setup diagnostic alive on the installs it describes (#125)

### DIFF
--- a/tests/unit/test_setup_environments.py
+++ b/tests/unit/test_setup_environments.py
@@ -115,3 +115,47 @@ class TestReporting:
         })
         assert setup.run_checks() == 1
         assert "1 component(s) missing" in capsys.readouterr().out
+
+
+class TestSurvivingWhatItDiagnoses:
+    """A diagnostic must outlive the broken install it is describing.
+
+    Found by re-reading the script rather than by a failure: every check
+    shells out to something that may be half-installed, and only
+    ``TimeoutExpired`` was caught. Anything else -- an ``OSError`` from a
+    binary that is not executable, a ``JSONDecodeError`` from a truncated
+    reply -- aborted the whole run and left the remaining components
+    unreported, which is exactly the state the script exists to describe.
+    """
+
+    def test_one_check_raising_does_not_abort_the_others(self, monkeypatch, capsys):
+        monkeypatch.setattr(setup, "_check_interpreter", lambda venv, label: (True, f"{label}: ok"))
+        monkeypatch.setattr(setup, "_check_cuda", lambda: (_ for _ in ()).throw(OSError("boom")))
+        monkeypatch.setattr(setup, "_check_mineru_binary", lambda: (True, "MinerU: 3.4.5"))
+        monkeypatch.setattr(setup, "_check_jina_worker", lambda: (True, "jina-clip: ready"))
+        monkeypatch.setattr(setup, "_check_ollama", lambda: (True, "Ollama: reachable"))
+
+        assert setup.run_checks() == 1
+        out = capsys.readouterr().out
+        assert "CUDA: raised OSError: boom" in out
+        # The checks after the raising one still ran and still reported.
+        assert "MinerU: 3.4.5" in out
+        assert "Ollama: reachable" in out
+
+    def test_a_binary_that_prints_no_version_is_still_reported_as_present(
+        self, monkeypatch, tmp_path
+    ):
+        """It used to raise IndexError off an empty splitlines()."""
+        binary = tmp_path / "bin" / "mineru"
+        binary.parent.mkdir(parents=True)
+        binary.write_text("", encoding="utf-8")
+        monkeypatch.setattr(setup, "ISOLATED_VENV", tmp_path)
+
+        class _Silent:
+            stdout = ""
+            stderr = ""
+
+        monkeypatch.setattr(setup.subprocess, "run", lambda *a, **k: _Silent())
+        passed, message = setup._check_mineru_binary()
+        assert passed
+        assert "printed nothing" in message

--- a/tools/setup_environments.py
+++ b/tools/setup_environments.py
@@ -178,7 +178,11 @@ def _check_mineru_binary() -> Tuple[bool, str]:
             result = subprocess.run(
                 [str(candidate), "--version"], capture_output=True, text=True, timeout=120
             )
-            version = (result.stdout or result.stderr).strip().splitlines()[-1] if result.stdout or result.stderr else "?"
+            # A binary that exists but prints nothing to either stream is the
+            # case that used to raise IndexError out of a diagnostic whose one
+            # job is to survive a broken install and describe it.
+            lines = (result.stdout or result.stderr or "").strip().splitlines()
+            version = lines[-1] if lines else "present, but --version printed nothing"
             return True, f"MinerU: {version}"
     return False, f"MinerU: no binary under {ISOLATED_VENV}"
 
@@ -251,22 +255,33 @@ def _check_ollama() -> Tuple[bool, str]:
 
 def run_checks() -> int:
     """Every precondition, each reported separately. Returns a process exit code."""
+    # Labelled explicitly rather than read off __name__: half the entries are
+    # lambdas, and a label guessed from a function object is the kind of
+    # pointer that names something real and wrong -- a raising CUDA probe
+    # reported as "interpreter check" sends the reader to rebuild a venv that
+    # is fine.
     checks = [
-        lambda: _check_interpreter(PRODUCT_VENV, ".venv"),
-        lambda: _check_interpreter(ISOLATED_VENV, ".venv-mineru"),
-        _check_cuda,
-        _check_mineru_binary,
-        _check_jina_worker,
-        _check_ollama,
+        (".venv", lambda: _check_interpreter(PRODUCT_VENV, ".venv")),
+        (".venv-mineru", lambda: _check_interpreter(ISOLATED_VENV, ".venv-mineru")),
+        ("CUDA", _check_cuda),
+        ("MinerU", _check_mineru_binary),
+        ("jina-clip", _check_jina_worker),
+        ("Ollama", _check_ollama),
     ]
     print("\nChecking:")
     failures = 0
     warnings = 0
-    for check in checks:
+    for label, check in checks:
         try:
             passed, message = check()
         except subprocess.TimeoutExpired:
-            passed, message = False, f"{check.__name__}: timed out"
+            passed, message = False, f"{label}: timed out"
+        except Exception as exc:  # noqa: BLE001 -- a diagnostic must outlive what it diagnoses
+            # Every check shells out to something that may be half-installed.
+            # One raising must report that check as failed, not abort the run
+            # and leave the remaining components unreported -- the state this
+            # script exists to describe is exactly the broken one.
+            passed, message = False, f"{label}: raised {type(exc).__name__}: {exc}"
         # Two states are not setup failures and must not read as one:
         # Ollama is the component this script does not build (a missing model
         # is a pull away), and a busy GPU means installed-and-occupied, which


### PR DESCRIPTION
## Summary

`tools/setup_environments.py` died on two kinds of broken install rather than
reporting them — the one situation it exists for.

- `run_checks` caught only `TimeoutExpired`; any other exception aborted the
  run and left the remaining components unreported. It now reports the
  raising check as failed and carries on.
- `_check_mineru_binary` raised `IndexError` when a binary exists but prints
  no version.

**The mistake worth reading:** the first fix labelled failures by the
function's `__name__`. Half the check list is lambdas, so a raising CUDA probe
came out as `interpreter check: raised OSError` — a label naming something
real and wrong, which sends the reader to rebuild a venv that is fine. Labels
are now explicit strings beside each check.

## Issue

Fixes #125

## Test plan

- [x] A check that raises is reported as failed **and the checks after it
      still run and report** — asserted on the output, which is what #125's
      closure criterion asked for.
- [x] A binary printing no version reports as present rather than raising.
- [x] `pytest` green: 878 passed, 2 skipped.
- [x] `ruff check .` clean.
- [x] `--check` re-run for real on this machine: all six components ok.
- [ ] Full gate not needed: tooling only, no product code paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)