### PR TITLE
Fix AGENTS.md's stale index, numbering gap and four links to nowhere (#130)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,6 +210,9 @@ Items 1–5 of §6 apply here too. What differs:
 > Detailed commands in `README.md` (CLI/Web).
 
 ```bash
+# Setup (both interpreters; --check verifies without installing)
+python tools/setup_environments.py             # .venv + .venv-mineru, then check
+
 # CLI / Web
 python rag/chat_pdfs.py                        # default es; MONKEYGRAB_LANG=en|ca for other UI
 python rag/web/app.py                          # http://localhost:5000 (ES/EN/VAL UI + corpus selector via POST /api/corpus)
@@ -223,6 +226,7 @@ pytest tests/unit tests/eval harness/tests --ignore=tests/unit/adapters   # what
 python tests/eval/run_eval.py --models <model...>           # full gate locally; needs Ollama + GPU
 
 # Configuration search harness (issue #31) — not product, see harness/README.md
+python -m harness.cli --status                              # what the ledger holds; evaluates nothing
 python -m harness.cli --dry-run --max-iterations 3          # smoke-test the loop, no GPU/Ollama needed
 
 # Misc
@@ -235,7 +239,7 @@ git check-ignore -v <path>
 
 ---
 
-## 11. Dependencies
+## 10. Dependencies
 
 ```bash
 pip install -r rag/requirements.txt                      # RAG core (required)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ which parses imports — not a convention to trust by eye): `application` may
 import `domain`/`ports`/`config`; `ports` may import `domain`; `domain` and
 `config` import nothing internal. `adapters` implement `ports` but are never
 imported *by* `domain`/`ports`/`config`/`application`. Full explanation and
-how to add a new adapter: [`src/monkeygrab/README.md`](../src/monkeygrab/README.md).
+how to add a new adapter: [`src/monkeygrab/README.md`](src/monkeygrab/README.md).
 
 ```
 src/monkeygrab/          Hexagonal core (see src/monkeygrab/README.md)
@@ -134,13 +134,13 @@ Other env vars: `DOCS_FOLDER` (default `rag/docs/en/`), `MONKEYGRAB_DATA_DIR` (w
 
 The Ollama endpoint has exactly one reader, `monkeygrab.config.env.read_env_ollama_base_url`, feeding `AppConfig.models.ollama.base_url` and `rag.chat_pdfs.OLLAMA_BASE_URL`. Every generation call, both `/chat` modes and both reachability checks (CLI startup, web control panel) resolve through it. Do not re-read the variable at a call site: a second resolution is how the CLI health check ended up reporting a server the pipeline never talked to.
 
-Desktop app: `rag/web/desktop.py` is the pywebview entry point frozen by PyInstaller (`packaging/MonkeyGrab.spec`, `packaging/build_exe.py`) into `MonkeyGrab.exe`. Built-in corpora ship in the bundle; Ollama is an external prerequisite. See [`packaging/README.md`](../packaging/README.md).
+Desktop app: `rag/web/desktop.py` is the pywebview entry point frozen by PyInstaller (`packaging/MonkeyGrab.spec`, `packaging/build_exe.py`) into `MonkeyGrab.exe`. Built-in corpora ship in the bundle; Ollama is an external prerequisite. See [`packaging/README.md`](packaging/README.md).
 
 ---
 
 ## 4. Pipeline architecture
 
-> Full reference with signatures and constants: [`rag/README.md`](../rag/README.md) → [`src/monkeygrab/README.md`](../src/monkeygrab/README.md). Pipeline behavior as currently observed: `tests/characterization/`.
+> Full reference with signatures and constants: [`rag/README.md`](rag/README.md) → [`src/monkeygrab/README.md`](src/monkeygrab/README.md). Pipeline behavior as currently observed: `tests/characterization/`.
 
 ---
 

--- a/tests/unit/test_docs_drift.py
+++ b/tests/unit/test_docs_drift.py
@@ -564,3 +564,60 @@ def test_the_tree_parser_actually_found_something():
         f"the AGENTS.md tree parser found {sorted(named)}, which does not look like "
         "the repository -- the fenced block it reads has moved or changed shape"
     )
+
+
+# CHECK 7 -- relative links in Markdown resolve to something (issue #130).
+
+# Anchors and external schemes are out of scope: an anchor needs the target's
+# heading structure and an external URL needs the network, neither of which
+# belongs in a gate that runs with no dependencies and no connection.
+_MARKDOWN_LINK = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+_EXTERNAL_SCHEMES = ("http://", "https://", "mailto:", "#")
+
+_NOT_REPO_MARKDOWN = frozenset({".venv", ".venv-mineru", "venv", "node_modules", ".git"})
+
+
+def _repository_markdown():
+    return sorted(
+        path
+        for path in ROOT.rglob("*.md")
+        if not _NOT_REPO_MARKDOWN.intersection(path.relative_to(ROOT).parts)
+    )
+
+
+def _broken_relative_links(path: Path):
+    """``(link text, target)`` for every relative link that resolves nowhere."""
+    broken = []
+    for text, target in _MARKDOWN_LINK.findall(path.read_text(encoding="utf-8")):
+        if target.startswith(_EXTERNAL_SCHEMES):
+            continue
+        without_anchor = target.split("#")[0]
+        if not without_anchor:
+            continue
+        if not (path.parent / without_anchor).exists():
+            broken.append((text, target))
+    return broken
+
+
+def test_the_markdown_file_list_is_not_accidentally_empty():
+    """Guards the guard: a bad skip list would make the check below vacuous."""
+    assert len(_repository_markdown()) > 5
+
+
+@pytest.mark.parametrize(
+    "path", _repository_markdown(), ids=lambda p: str(p.relative_to(ROOT))
+)
+def test_relative_links_resolve(path):
+    """AGENTS.md carried four `../` links for months after moving to the root.
+
+    Commit c07cd43 says it plainly -- "The contract moved from
+    .claude/CLAUDE.md to the repo root" -- and the links kept the extra level
+    the old location needed. Every one of them 404s on GitHub, which is where
+    the file is read. Same class as #109 and #122, in the form that is hardest
+    to notice: a link that looks right until someone clicks it.
+    """
+    broken = _broken_relative_links(path)
+    assert not broken, (
+        f"{path.relative_to(ROOT)} has relative link(s) resolving nowhere: "
+        + "; ".join(f"[{text}]({target})" for text, target in broken)
+    )


### PR DESCRIPTION
## Summary

`AGENTS.md` §9 is the quick command index and did not list
`tools/setup_environments.py` (#120, referenced from both `README.md` and
`CONTRIBUTING.md`) or `python -m harness.cli --status` (#114, the first check
in the runbook). The headings also ran 1-9 then 11.

Neither costs anyone an hour, and both are the class this repo keeps finding:
a file that is authoritative by design saying something slightly untrue.

## Issue

Fixes #130

## Test plan

- [x] `grep -n "^## " AGENTS.md` now runs 1 through 10 with no gap — #130's
      stated evidence.
- [x] **Checked before renumbering:** the repo's only double-digit reference
      is `CONTRIBUTING.md:41`'s "rule 10 of `AGENTS.md`", which is rule 10
      inside §1, not §10. Nothing referenced §11.
- [x] `pytest` green, `ruff check .` clean.
- [ ] Documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)