### PR TITLE
Stop verifying an entry against an environment nobody measured (#132)

### DIFF
--- a/harness/RUNBOOK.md
+++ b/harness/RUNBOOK.md
@@ -32,9 +32,18 @@ Stop at the first one that fails. Each is cheap; the campaign is not. Check 0
 and check 6 both exist because a real run on 2026-09-01 skipped them and paid
 28.7 minutes to find out.
 
+> [!IMPORTANT]
+> **Run every command below with `.venv/bin/python`, not a bare `python`.**
+> `--status` works under a bare interpreter and prints a confident-looking
+> line, but the fingerprint it computes sees only the isolated venv — the
+> product stack shows as unmeasured, and an entry written that way describes
+> nothing about retrieval or generation (issue #132). The comparison now
+> answers `unknown` rather than `match` in that case, so the mistake is
+> visible instead of silent, but the entry is still worth nothing.
+
 ```bash
 # 0. Can this machine run anything at all? Installs nothing.
-python tools/setup_environments.py --check
+.venv/bin/python tools/setup_environments.py --check
 ```
 
 Six components, each reported separately: both interpreters, CUDA visible to
@@ -45,7 +54,7 @@ attention (see `tools/setup_environments.py`).
 
 ```bash
 # 1. What does the ledger hold, and how much can this launch pair against?
-python -m harness.cli --status
+.venv/bin/python -m harness.cli --status
 ```
 
 This is the whole precondition check for the ledger, and it evaluates

--- a/harness/environment.py
+++ b/harness/environment.py
@@ -197,6 +197,30 @@ def _comparable_pairs(left: Dict[str, Any], right: Dict[str, Any]) -> List[tuple
     ]
 
 
+def _environments_only_one_side_measured(
+    left: Dict[str, Any], right: Dict[str, Any]
+) -> List[str]:
+    """Declared environments one side read and the other did not read at all.
+
+    Distinct from a package missing on one side, which ``_comparable_pairs``
+    already skips for good reason. An environment with NO version on one side
+    was not measured there -- the campaign ran with an interpreter that has
+    none of its packages -- so it makes no claim the other side's versions can
+    be checked against (issue #132).
+    """
+    left_packages = left.get("packages") or {}
+    right_packages = right.get("packages") or {}
+    measured_left, measured_right = set(), set()
+    for packages, measured in ((left_packages, measured_left), (right_packages, measured_right)):
+        for key, version in packages.items():
+            if version is not None:
+                measured.add(key.split(":", 1)[0])
+    declared = {key.split(":", 1)[0] for key in set(left_packages) | set(right_packages)}
+    return sorted(
+        env for env in declared if (env in measured_left) != (env in measured_right)
+    )
+
+
 def compare(left: Optional[Dict[str, Any]], right: Optional[Dict[str, Any]]) -> str:
     """``MATCH``, ``DIFFERS`` or ``UNKNOWN`` for two fingerprints.
 
@@ -218,7 +242,18 @@ def compare(left: Optional[Dict[str, Any]], right: Optional[Dict[str, Any]]) -> 
     pairs = _comparable_pairs(left, right)
     if not pairs:
         return UNKNOWN
-    return MATCH if all(a == b for _, a, b in pairs) else DIFFERS
+    if not all(a == b for _, a, b in pairs):
+        # A stack that provably moved is not made uncertain by a second
+        # environment nobody read: DIFFERS is the stronger answer and wins.
+        return DIFFERS
+    # Everything both sides read agrees -- but agreement over half the stack
+    # is not verification of the stack. An entry whose product environment was
+    # never measured (a campaign launched with the wrong interpreter, issue
+    # #132) says nothing about retrieval or generation, and must not read as
+    # verified against one that does.
+    if _environments_only_one_side_measured(left, right):
+        return UNKNOWN
+    return MATCH
 
 
 def describe_difference(

--- a/harness/tests/test_environment.py
+++ b/harness/tests/test_environment.py
@@ -161,3 +161,80 @@ class TestComparison:
     def test_describing_a_match_yields_nothing(self):
         one = {"schema": 1, "packages": {"isolated:mineru": "2.6.3"}}
         assert environment.describe_difference(one, dict(one)) == []
+
+
+class TestAnEnvironmentNobodyMeasured:
+    """An entry that measured ONE environment must not verify against one that
+    measured both (issue #132).
+
+    ``compare`` skips a key either side reports as ``None``, which is right for
+    a package genuinely absent from one environment and wrong when an entire
+    environment went unmeasured. A campaign launched with the system
+    interpreter instead of ``.venv/bin/python`` records every ``product:*`` key
+    as ``None`` -- it says nothing at all about the stack that decides
+    retrieval and generation -- and used to compare as ``match`` against an
+    entry that does. That is a false positive of comparability, which is the
+    failure #107 exists to remove.
+    """
+
+    _BOTH = {
+        "schema": 1,
+        "packages": {
+            "isolated:mineru": "3.4.5",
+            "product:torch": "2.13.0",
+            "product:faiss-cpu": "1.15.0",
+        },
+    }
+    _ISOLATED_ONLY = {
+        "schema": 1,
+        "packages": {
+            "isolated:mineru": "3.4.5",
+            "product:torch": None,
+            "product:faiss-cpu": None,
+        },
+    }
+
+    def test_an_entirely_unmeasured_environment_is_unknown_not_a_match(self):
+        assert environment.compare(self._BOTH, self._ISOLATED_ONLY) == environment.UNKNOWN
+
+    def test_the_answer_does_not_depend_on_argument_order(self):
+        assert environment.compare(self._ISOLATED_ONLY, self._BOTH) == environment.UNKNOWN
+
+    def test_two_sides_that_both_skipped_the_same_environment_still_compare(self):
+        """Neither measured the product stack, so neither claims anything about
+        it. What they did both measure is comparable on its own terms."""
+        other = {
+            "schema": 1,
+            "packages": {
+                "isolated:mineru": "3.4.5",
+                "product:torch": None,
+                "product:faiss-cpu": None,
+            },
+        }
+        assert environment.compare(self._ISOLATED_ONLY, other) == environment.MATCH
+
+    def test_a_known_difference_still_wins_over_the_unmeasured_environment(self):
+        """DIFFERS is a stronger answer than UNKNOWN: a stack that provably
+        moved is not made uncertain by a second environment nobody read."""
+        drifted = {
+            "schema": 1,
+            "packages": {
+                "isolated:mineru": "2.6.3",
+                "product:torch": None,
+                "product:faiss-cpu": None,
+            },
+        }
+        assert environment.compare(self._BOTH, drifted) == environment.DIFFERS
+
+    def test_one_missing_package_is_still_just_a_missing_package(self):
+        """The narrow skip this module always had must survive: an environment
+        with SOME versions is measured, whatever it is missing."""
+        almost = {
+            "schema": 1,
+            "packages": {
+                "isolated:mineru": "3.4.5",
+                "product:torch": "2.13.0",
+                "product:faiss-cpu": None,
+            },
+        }
+        assert environment.compare(self._BOTH, almost) == environment.MATCH


### PR DESCRIPTION
## Summary

A ledger entry written by a campaign launched with the wrong interpreter
records every `product:*` version as `None` — it measured nothing about the
stack that decides retrieval and generation — and `compare` read that as
`match` against an entry that did measure it.

```python
compare(both_environments, isolated_only)   # was 'match', now 'unknown'
```

`compare` skips keys either side reports as `None`, which is right for a
package genuinely absent from one environment and wrong when an **entire
environment** went unread. Agreement over half the stack is not verification
of the stack.

This is a false positive of comparability — the failure #107 exists to
remove — and #113 introduced it. `UNKNOWN` was already this module's third
answer; this is a case that should have been in it.

**Reachable, not theoretical:** nothing forces the venv, and
`python -m harness.cli --status` works under a bare interpreter, printing a
confident-looking line. `RUNBOOK.md` now names the interpreter.

## Issue

Fixes #132

## Test plan

- [x] The exact comparison from the issue now answers `unknown`, both
      argument orders.
- [x] **`DIFFERS` still wins over `UNKNOWN`** — a stack that provably moved is
      not made uncertain by a second environment nobody read.
- [x] **The narrow skip survives**: an environment with some versions is
      measured, whatever single package it lacks. That test exists so this fix
      cannot quietly widen into "any `None` makes it unknown", which would
      disarm the mechanism for ordinary partial installs.
- [x] Two sides that both skipped the same environment still compare on what
      they did read.
- [x] `pytest` 913 passed, 2 skipped; `harness/tests` 223 passed;
      `ruff check .` clean.
- [ ] Full gate not needed: `harness/` is not product.

## Not done, deliberately

Recording `sys.executable` in the fingerprint. It changes on every machine, so
it would make every cross-machine entry incomparable — the "not strict,
useless" failure the design already rejected for the git commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)