### PR TITLE
Record that the loop fits on 8 GB even where the gate does not (#123)

### DIFF
--- a/harness/RUNBOOK.md
+++ b/harness/RUNBOOK.md
@@ -112,7 +112,22 @@ nvidia-smi --query-compute-apps=pid,used_memory --format=csv
 >
 > Do not run anything else on the card during a campaign, the jina-clip probe
 > in check 4 included. One probe alongside a live run is enough to take it
-> down.
+> down. Two campaigns at once will take each other down -- check `pgrep -f
+> harness.cli` before launching, since a backgrounded one leaves no obvious
+> trace in the terminal.
+
+> [!TIP]
+> **A campaign fits on 8 GB even though a full gate run does not.** The
+> harness only ever asks for search-set ids (`source: corpus`), and
+> `evaluate()` builds a corpus's stack only when the filtered case list
+> needs it -- so a campaign builds one embedder where a full `run_eval.py`
+> builds two, and two do not fit (#123). Measured: 32 cases, zero
+> `infrastructure_error`, ~6.6 of 7.6 GiB resident.
+>
+> The practical consequence, plainly: **on a card this size you can run the
+> loop but not the gate.** A candidate the loop accepts still needs the full
+> gate before anyone believes it, and until #123 is resolved that has to
+> happen somewhere with more VRAM.
 
 > [!NOTE]
 > A dry-run given `--ledger-dir <a ledger holding anything not marked demo>`


### PR DESCRIPTION
## Summary

A harness campaign runs clean on a card a full gate run cannot use, and
nothing said so.

`evaluate()` builds a corpus's stack only when the filtered case list needs
one. The harness only ever asks for search-set ids, so a campaign builds **one**
embedder where `run_eval.py` builds two — and two do not fit in 7.6 GiB.

Measured during phase 1 of a real campaign:

| tenant | MiB |
|---|---|
| jina-clip worker (dev stack's embedder) | 2802 |
| harness process (reranker) | 2452 |
| `llama-server` (decomposer) | 1376 |
| **total** | **~6.6 / 7.6 GiB** |

32 cases, zero `infrastructure_error`. **On a card this size you can run the
loop but not the gate** — so a candidate the loop accepts still needs the full
gate somewhere with more VRAM before anyone believes it. That is the sentence
that decides whether the loop is usable here, and it was in neither #123 nor
the runbook.

Also adds a warning I earned: two campaigns at once take each other down, and
a backgrounded one leaves no trace in the terminal. My first attempt at this
measurement was exactly that, and the errors looked like a product defect
until I read the process tree.

## Issue

Refs #123 — does not close it. The gate still cannot run on 8 GB; this
documents which half can.

## Test plan

- [x] Every number from a live campaign on this machine, read off
      `nvidia-smi --query-compute-apps` during phase 1.
- [x] Zero `infrastructure_error` in that campaign, against 19/51 in the full
      gate run on the same card.
- [x] `pytest` green, `ruff check .` clean.
- [ ] Documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)