### PR TITLE
Resolve Ollama's implicit :latest before declaring a model missing (#129)

### DIFF
--- a/tests/eval/run_eval.py
+++ b/tests/eval/run_eval.py
@@ -142,18 +142,42 @@ def _installed_ollama_models() -> List[str]:
     return [m["name"] for m in response.json().get("models", []) if m.get("name")]
 
 
+def _with_implicit_tag(name: str) -> str:
+    """``qwen3:8b`` unchanged, ``qwen3-coder-30b`` -> ``qwen3-coder-30b:latest``.
+
+    Ollama treats a bare name and ``name:latest`` as the same model everywhere
+    -- ``ollama run qwen3-coder-30b`` works on a model ``ollama list`` shows as
+    ``qwen3-coder-30b:latest`` -- but ``/api/tags`` always returns the tagged
+    form. Comparing the two directly told an operator to pull a model they
+    already had, and following that instruction is a no-op that leaves them no
+    wiser (issue #129).
+
+    A digest reference (``model@sha256:...``) is left alone: it already names
+    an exact blob, and appending a tag to it would be nonsense.
+    """
+    if ":" in name or "@" in name:
+        return name
+    return f"{name}:latest"
+
+
 def preflight_ollama(required_models: Iterable[str]) -> None:
     """Fail fast, with an exact `ollama pull` list, if any model is missing.
 
     Args:
-        required_models: Every Ollama model name this run will call.
+        required_models: Every Ollama model name this run will call. A name
+            with no tag is checked as ``:latest``, matching how Ollama itself
+            resolves it (issue #129).
 
     Raises:
         EvalSetupError: Ollama is unreachable, or one or more models are
             missing (message lists every missing model, not just the first).
     """
-    installed = set(_installed_ollama_models())
-    missing = sorted(set(required_models) - installed)
+    installed = {_with_implicit_tag(name) for name in _installed_ollama_models()}
+    # Reported by the name the caller passed, not the normalised one: the
+    # message has to be something they can paste back.
+    missing = sorted(
+        name for name in set(required_models) if _with_implicit_tag(name) not in installed
+    )
     if missing:
         pulls = "\n".join(f"  ollama pull {name}" for name in missing)
         raise EvalSetupError(f"{len(missing)} required Ollama model(s) not installed:\n{pulls}")

--- a/tests/eval/test_preflight_model_tags.py
+++ b/tests/eval/test_preflight_model_tags.py
@@ -1,0 +1,80 @@
+"""Ollama's implicit `:latest`, and the instruction that used to be wrong.
+
+Issue #129. `--models qwen3-coder-30b` aborted with
+
+    SETUP FAILED: 1 required Ollama model(s) not installed:
+      ollama pull qwen3-coder-30b
+
+on a machine where the model was installed. `ollama list` shows it as
+`qwen3-coder-30b:latest` and `ollama run qwen3-coder-30b` works, because
+Ollama resolves a bare name to `:latest`; `/api/tags` always returns the
+tagged form, and the check compared the two strings directly.
+
+The failure was fast and its message looked actionable, which is what made it
+worth fixing rather than shrugging at: it told the operator to pull something
+they already had, and following it is a no-op that teaches them nothing.
+
+No network, no Ollama: `_installed_ollama_models` is replaced with a list.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import pytest  # noqa: E402
+
+import run_eval  # noqa: E402
+
+
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        ("qwen3-coder-30b", "qwen3-coder-30b:latest"),
+        ("qwen3:8b", "qwen3:8b"),
+        ("gemma4:e4b", "gemma4:e4b"),
+        # A digest already names an exact blob; a tag on top of it is nonsense.
+        ("model@sha256:abc123", "model@sha256:abc123"),
+    ],
+)
+def test_the_implicit_tag_is_applied_only_where_ollama_applies_it(name, expected):
+    assert run_eval._with_implicit_tag(name) == expected
+
+
+def test_a_bare_name_matches_a_model_installed_as_latest(monkeypatch):
+    """The #129 reproduction, as a test."""
+    monkeypatch.setattr(
+        run_eval, "_installed_ollama_models", lambda: ["qwen3-coder-30b:latest"]
+    )
+    run_eval.preflight_ollama(["qwen3-coder-30b"])
+
+
+def test_a_tagged_name_still_matches_itself(monkeypatch):
+    monkeypatch.setattr(run_eval, "_installed_ollama_models", lambda: ["gemma4:e4b"])
+    run_eval.preflight_ollama(["gemma4:e4b"])
+
+
+def test_a_genuinely_missing_model_still_fails(monkeypatch):
+    """The check must not be weakened into never failing."""
+    monkeypatch.setattr(run_eval, "_installed_ollama_models", lambda: ["gemma4:e4b"])
+    with pytest.raises(run_eval.EvalSetupError) as exc:
+        run_eval.preflight_ollama(["nothing-like-this"])
+    assert "nothing-like-this" in str(exc.value)
+
+
+def test_the_message_names_the_model_the_caller_asked_for(monkeypatch):
+    """Reported by the caller's spelling, not the normalised one: the message
+    has to be something they can paste back."""
+    monkeypatch.setattr(run_eval, "_installed_ollama_models", lambda: [])
+    with pytest.raises(run_eval.EvalSetupError) as exc:
+        run_eval.preflight_ollama(["some-model"])
+    message = str(exc.value)
+    assert "ollama pull some-model" in message
+    assert "some-model:latest" not in message
+
+
+def test_every_missing_model_is_listed_not_just_the_first(monkeypatch):
+    monkeypatch.setattr(run_eval, "_installed_ollama_models", lambda: [])
+    with pytest.raises(run_eval.EvalSetupError) as exc:
+        run_eval.preflight_ollama(["a", "b"])
+    assert "ollama pull a" in str(exc.value) and "ollama pull b" in str(exc.value)


### PR DESCRIPTION
## Summary

`--models qwen3-coder-30b` aborted with `ollama pull qwen3-coder-30b` on a
machine where the model was installed. Ollama resolves a bare name to
`:latest`; `/api/tags` returns the tagged form; the check compared the strings.

The instruction it printed was a no-op — that is what made it worth fixing
rather than shrugging at.

## Issue

Fixes #129

## Test plan

- [x] The reproduction from the issue is now a test: a bare name matches a
      model installed as `:latest`.
- [x] **The check is not weakened** — a genuinely missing model still fails,
      with its own test, so this cannot quietly become "never complains".
- [x] A digest reference (`model@sha256:...`) is left alone.
- [x] The message still names the caller's spelling, not the normalised one.
- [x] Every missing model still listed, not just the first.
- [x] `pytest` 923 passed, 2 skipped; `ruff check .` clean.

## Protected zone

`tests/eval/` is owner-agreement territory (`AGENTS.md` rule 9). This touches
`run_eval.py`'s preflight only — **no grading rule, gold case or baseline is
modified** — and the owner asked for the open issues to be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)