### PR TITLE
Retrieve one corpus at a time, releasing each before the next (#123)

### DIFF
--- a/tests/eval/run_eval.py
+++ b/tests/eval/run_eval.py
@@ -756,10 +756,62 @@ def run_all_cases(
     pending: List[Dict[str, Any]] = []
 
     print("[phase 1/2] retrieval for every case (embedder + reranker on GPU)", flush=True)
+    # One corpus at a time, releasing each before the next is touched (issue
+    # #123). Interleaving them by case order kept both stacks resident, and
+    # each jina-clip worker costs ~2.8 GiB: on an 8 GB card the second one
+    # could not start, so every blind-set case came back
+    # infrastructure_error and the whole run was discarded -- after paying the
+    # full indexing time. The workers start lazily on first use, so grouping
+    # is enough; nothing needs to be built later than it already is.
+    #
+    # Execution order changes, result order does not: records are restored to
+    # the caller's case order below, so an artefact from this build is
+    # comparable with one from before it.
+    for corpus_source, retrieve, evidence in (
+        ("corpus", retrieve_dev, evidence_dev),
+        ("arxiv", retrieve_blind, evidence_blind),
+    ):
+        corpus_cases = [c for c in cases if c["source"] == corpus_source]
+        if not corpus_cases or retrieve is None:
+            continue
+        _run_retrieval_for_corpus(corpus_cases, retrieve, evidence, records, pending)
+        # Freed here rather than after both corpora, so the second corpus's
+        # worker starts on a card the first one is no longer holding.
+        _release_gpu_models(retrieve)
+
+    _restore_case_order(records, pending, cases)
+
+    print(f"\n[phase 2/2] generation for {len(pending)} case(s) (Ollama alone on GPU)", flush=True)
+    with _generation_keep_alive(set(models) | {AUX_MODEL}):
+        for item in pending:
+            records.extend(
+                run_factual_case(rag, item["case"], item["fragments"], models, item["elapsed"])
+            )
+    return records
+
+
+def _restore_case_order(records, pending, cases) -> None:
+    """Sort both lists back into the order ``cases`` came in.
+
+    Phase 1 now walks one corpus at a time (issue #123), which is a change to
+    execution order only. Reports aggregate rather than index, so nothing
+    depends on this -- but an artefact whose records appear in a different
+    order than an earlier one invites a reader to diff them and find a
+    difference that is not there.
+    """
+    position = {case["id"]: index for index, case in enumerate(cases)}
+    records.sort(key=lambda record: position.get(record["id"], len(position)))
+    pending.sort(key=lambda item: position.get(item["case"]["id"], len(position)))
+
+
+def _run_retrieval_for_corpus(cases, retrieve, evidence, records, pending) -> None:
+    """Retrieve every case of one corpus, appending to ``records``/``pending``.
+
+    Extracted from ``run_all_cases``'s loop body unchanged (issue #123); the
+    only difference is that the caller now hands it one corpus's cases and its
+    single stack, instead of switching stacks per case.
+    """
     for case in cases:
-        is_dev = case["source"] == "corpus"
-        retrieve = retrieve_dev if is_dev else retrieve_blind
-        evidence = evidence_dev if is_dev else evidence_blind
         t0 = time.perf_counter()
         try:
             result = retrieve.run(case["question"])
@@ -807,16 +859,6 @@ def run_all_cases(
                 f"  [retrieved] {case['id']} ({elapsed:.1f}s, {len(fragments)} fragments)",
                 flush=True,
             )
-
-    _release_gpu_models(retrieve_dev, retrieve_blind)
-
-    print(f"\n[phase 2/2] generation for {len(pending)} case(s) (Ollama alone on GPU)", flush=True)
-    with _generation_keep_alive(set(models) | {AUX_MODEL}):
-        for item in pending:
-            records.extend(
-                run_factual_case(rag, item["case"], item["fragments"], models, item["elapsed"])
-            )
-    return records
 
 
 # REPORTING

--- a/tests/eval/test_phase1_one_corpus_at_a_time.py
+++ b/tests/eval/test_phase1_one_corpus_at_a_time.py
@@ -1,0 +1,192 @@
+"""Phase 1 walks one corpus at a time, releasing each before touching the next.
+
+Issue #123. The loop used to pick a stack per case from `case["source"]`, so
+an interleaved case list kept both corpora's stacks resident for the whole
+phase. Each jina-clip worker costs ~2.8 GiB; on an 8 GB card the second one
+could not start, and every blind-set case came back `infrastructure_error` --
+19 of 51, after paying the full indexing time, with the gate correctly
+refusing to compare the run against the baseline. Measured 2026-09-01 on an
+RTX 4060 Laptop.
+
+Grouping is enough because the workers start lazily on first use: nothing has
+to be constructed later than it already is, only released earlier.
+
+These tests use fakes. The point is the *order of operations* -- which stack
+each case is retrieved through, and when each is released -- which is exactly
+what a real run cannot demonstrate cheaply and what a reader cannot verify by
+eye.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import pytest  # noqa: E402
+
+import run_eval  # noqa: E402
+
+
+class _FakeResult:
+    fragments = ()
+
+
+class _FakeRetrieve:
+    """Records which cases it was asked for, and whether it was released."""
+
+    def __init__(self, name, log):
+        self.name = name
+        self._log = log
+        self.released = False
+
+    def run(self, question):
+        self._log.append(("retrieve", self.name, question))
+        return _FakeResult()
+
+
+class _FakeEvidence:
+    def select_evidence(self, fragments):
+        return [], {}
+
+
+def _case(case_id, source, case_type="figure_retrieval"):
+    return {
+        "id": case_id,
+        "paper": "p",
+        "case_type": case_type,
+        "lang": "en",
+        "source": source,
+        "question": case_id,
+    }
+
+
+@pytest.fixture
+def harness(monkeypatch):
+    """Fakes for both stacks, plus a shared log of retrievals and releases."""
+    log = []
+    dev = _FakeRetrieve("dev", log)
+    blind = _FakeRetrieve("blind", log)
+
+    def fake_release(*retrievers):
+        for retrieve in retrievers:
+            retrieve.released = True
+            log.append(("release", retrieve.name))
+
+    monkeypatch.setattr(run_eval, "_release_gpu_models", fake_release)
+    monkeypatch.setattr(
+        run_eval,
+        "run_retrieval_case",
+        lambda case, retrieved, elapsed: {
+            "id": case["id"],
+            "passed": True,
+            "reason": "fake",
+            "case_type": case["case_type"],
+        },
+    )
+    return log, dev, blind
+
+
+def test_all_of_one_corpus_runs_before_any_of_the_other(harness):
+    """Interleaved input, grouped execution."""
+    log, dev, blind = harness
+    cases = [
+        _case("dev-1", "corpus"),
+        _case("blind-1", "arxiv"),
+        _case("dev-2", "corpus"),
+        _case("blind-2", "arxiv"),
+    ]
+
+    run_eval.run_all_cases(
+        None, cases, dev, blind, _FakeEvidence(), _FakeEvidence(), models=[]
+    )
+
+    order = [(kind, name) for kind, name, *_ in log]
+    assert order == [
+        ("retrieve", "dev"),
+        ("retrieve", "dev"),
+        ("release", "dev"),
+        ("retrieve", "blind"),
+        ("retrieve", "blind"),
+        ("release", "blind"),
+    ]
+
+
+def test_the_first_corpus_is_released_before_the_second_is_touched(harness):
+    """The whole point: the second worker starts on a card the first freed."""
+    log, dev, blind = harness
+    cases = [_case("dev-1", "corpus"), _case("blind-1", "arxiv")]
+
+    run_eval.run_all_cases(
+        None, cases, dev, blind, _FakeEvidence(), _FakeEvidence(), models=[]
+    )
+
+    kinds = [(kind, name) for kind, name, *_ in log]
+    release_dev = kinds.index(("release", "dev"))
+    first_blind = kinds.index(("retrieve", "blind"))
+    assert release_dev < first_blind
+
+
+def test_every_case_is_retrieved_through_its_own_corpus_stack(harness):
+    """Grouping must not send a case to the wrong index -- which would score a
+    question against a corpus that does not contain its answer."""
+    log, dev, blind = harness
+    cases = [_case("dev-1", "corpus"), _case("blind-1", "arxiv")]
+
+    run_eval.run_all_cases(
+        None, cases, dev, blind, _FakeEvidence(), _FakeEvidence(), models=[]
+    )
+
+    retrievals = {
+        entry[2]: entry[1] for entry in log if entry[0] == "retrieve"
+    }
+    assert retrievals == {"dev-1": "dev", "blind-1": "blind"}
+
+
+def test_records_come_back_in_the_callers_case_order(harness):
+    """Execution order changed; result order must not, or an artefact from this
+    build invites a reader to diff it against an older one and find a
+    difference that is not there."""
+    _log, dev, blind = harness
+    cases = [
+        _case("dev-1", "corpus"),
+        _case("blind-1", "arxiv"),
+        _case("dev-2", "corpus"),
+        _case("blind-2", "arxiv"),
+    ]
+
+    records = run_eval.run_all_cases(
+        None, cases, dev, blind, _FakeEvidence(), _FakeEvidence(), models=[]
+    )
+
+    assert [r["id"] for r in records] == ["dev-1", "blind-1", "dev-2", "blind-2"]
+
+
+def test_a_corpus_with_no_cases_is_neither_run_nor_released(harness):
+    """A search-set-only run (what the harness asks for) must not touch the
+    blind stack at all -- that is why a campaign fits on 8 GB."""
+    log, dev, blind = harness
+
+    run_eval.run_all_cases(
+        None,
+        [_case("dev-1", "corpus")],
+        dev,
+        blind,
+        _FakeEvidence(),
+        _FakeEvidence(),
+        models=[],
+    )
+
+    assert not any(name == "blind" for _kind, name, *_ in log)
+    assert blind.released is False
+    assert dev.released is True
+
+
+def test_a_missing_stack_is_skipped_rather_than_dereferenced(harness):
+    """evaluate() passes None for a corpus it never indexed."""
+    log, dev, _blind = harness
+
+    run_eval.run_all_cases(
+        None, [_case("dev-1", "corpus")], dev, None, _FakeEvidence(), None, models=[]
+    )
+
+    assert [(k, n) for k, n, *_ in log] == [("retrieve", "dev"), ("release", "dev")]

--- a/tests/eval/test_phase1_one_corpus_at_a_time.py
+++ b/tests/eval/test_phase1_one_corpus_at_a_time.py
@@ -73,6 +73,12 @@ def harness(monkeypatch):
             log.append(("release", retrieve.name))
 
     monkeypatch.setattr(run_eval, "_release_gpu_models", fake_release)
+    # Phase 2 releases the Ollama models on exit, which imports `requests`.
+    # The fast gate's `architecture` job installs pytest and nothing else --
+    # by design, to prove the pure layers need nothing else -- so a test that
+    # reaches that import fails there and passes locally, which is the worst
+    # way for a test to be wrong.
+    monkeypatch.setattr(run_eval, "_release_ollama_models", lambda *_a, **_kw: None)
     monkeypatch.setattr(
         run_eval,
         "run_retrieval_case",


### PR DESCRIPTION
## Summary

On an 8 GB card the gate could not complete a run. Phase 1 picked a stack per
case, so an interleaved case list kept both corpora's embedders resident;
each costs ~2.8 GiB, the second could not start, and **19 of 51 cases came back
`infrastructure_error`** after paying the full indexing time.

The rest of the design was already careful — conditional stack construction,
phase 2 alone on the card, keep-alive scoped to generation. The gap was
phase 1 holding two embedders.

Grouping by corpus is enough: the workers start **lazily on first use**, so
nothing is constructed later than before, only released earlier.

## Issue

Fixes #123

## Test plan

- [x] Six tests over the **order of operations**, which is what a real run
      cannot demonstrate cheaply and a reader cannot check by eye: grouped
      execution from interleaved input; dev released *before* the first blind
      retrieval; each case retrieved through its own index; results in caller
      order; a corpus with no cases neither run nor released; a `None` stack
      skipped rather than dereferenced.
- [x] **Result order is preserved deliberately** — execution order changed, so
      records are sorted back into the caller's case order. An artefact from
      this build stays diff-comparable with one from before it.
- [x] `pytest` 920 passed, 2 skipped; `ruff check .` clean.
- [ ] **Not yet verified on the real 8 GB run.** The card is busy with a
      harness campaign; the next full gate run on this machine is the
      evidence #123's closure criterion asks for, and I will post it there.

## Protected zone

`tests/eval/` is owner-agreement territory (`AGENTS.md` rule 9). This changes
`run_all_cases`'s execution order only — **no grading rule, gold case or
baseline is touched**, and the loop body is extracted verbatim. The owner
asked for the open issues to be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)