### PR TITLE
Default MINERU_MODEL_SOURCE to a source that works on a fresh install (#118)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,8 +32,8 @@
 # ── MinerU (PDF/table extraction, external CLI, not a Python dependency) ────
 #MINERU_BIN=                                    # path to the mineru executable; defaults to .venv-mineru/Scripts/mineru.exe (Windows) or .venv-mineru/bin/mineru (Linux/Mac), whichever exists
 #MINERU_CACHE_DIR=                              # extraction cache directory; defaults to <repo_root>/.mineru_cache
-#MINERU_MODEL_SOURCE=local                      # forwarded to the MinerU CLI. MinerU 2.x: "local" reuses the already-downloaded HuggingFace cache without attempting a download.
-#                                               # MinerU 3.x: "local" instead means "read paths from a local models config file" and CRASHES without one (issue #118) -- use "huggingface" for a first run, which downloads the models.
+#MINERU_MODEL_SOURCE=huggingface                # forwarded to the MinerU CLI; downloads the extraction models once, then reuses them.
+#                                               # Set "local" only for an air-gapped install, with the models config file MinerU 3.x expects: there it means "read paths from that file", not "reuse the HF cache" as it did in 2.x, and it crashes without one (issue #118).
 
 
 # ── Ollama connection ───────────────────────────────────────────────────────

--- a/README.md
+++ b/README.md
@@ -230,14 +230,16 @@ interpreter at `.venv-mineru/Scripts/python.exe` (Windows) or
 `.venv-mineru/bin/python` (Linux/Mac), at the project root, following each
 project's own install instructions.
 
-> [!IMPORTANT]
-> **MinerU 3.x needs `MINERU_MODEL_SOURCE=huggingface` on a first run.** The
-> default, `local`, meant "reuse the already-downloaded HuggingFace cache" in
-> 2.x; in 3.x it means "read paths from a local models config file" and fails
-> without one, so nothing indexes (issue #118). Set it once so MinerU
-> downloads its models; the default works from then on. MinerU also names its
-> output directory after the backend that ran (`hybrid_auto/` rather than
-> 2.x's `auto/`) — the adapter finds it either way. That interpreter needs a CUDA GPU: Jina
+> [!NOTE]
+> **MinerU downloads its extraction models on first use.** That is what
+> `MINERU_MODEL_SOURCE=huggingface`, the default, does; it reuses them
+> afterwards. Set `local` only for an air-gapped install, and note it means
+> "read paths from a local models config file" in MinerU 3.x rather than
+> "reuse the HuggingFace cache" as it did in 2.x — it was the default until
+> issue #118, where it turned out to extract nothing on a fresh install.
+> MinerU also names its output directory after the backend that ran
+> (`hybrid_auto/` rather than 2.x's `auto/`) — the adapter finds it either
+> way. That interpreter needs a CUDA GPU: Jina
 CLIP v2 can run on CPU (that is how the roughly 100 seconds per document
 figure was measured, impractical for indexing), but this project's worker
 refuses to start it there. That is the same "no silent fallbacks" policy

--- a/src/monkeygrab/adapters/extraction/mineru_extractor.py
+++ b/src/monkeygrab/adapters/extraction/mineru_extractor.py
@@ -65,6 +65,20 @@ logger = logging.getLogger(__name__)
 _THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 _PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(_THIS_DIR))))
 
+# Forwarded to the MinerU CLI as MINERU_MODEL_SOURCE (issue #118). "local"
+# was the default and means two different things across MinerU's major
+# versions: in 2.x it reused the already-downloaded HuggingFace cache, and in
+# 3.x it means "read paths from a local models config file" and dereferences
+# None without one -- so `pip install mineru[core]` followed by a first run
+# extracted nothing at all, which is not a default, it is a trap. A default
+# has to work on the installation the project's own instructions produce.
+#
+# "huggingface" downloads the models once and reuses them afterwards. An
+# air-gapped install sets MINERU_MODEL_SOURCE=local explicitly, alongside the
+# config file 3.x needs -- an opt-in for a deliberate setup rather than the
+# state everyone lands in by accident.
+_DEFAULT_MODEL_SOURCE = "huggingface"
+
 # Bumped whenever SECTION 2's block-to-text/image mapping changes shape.
 # Folded into the cache key so every cached extraction from a previous
 # version of this adapter is treated as a miss instead of being replayed
@@ -447,7 +461,7 @@ class MineruExtractor:
         self,
         mineru_bin: Optional[str] = None,
         cache_dir: Optional[str] = None,
-        model_source: str = "local",
+        model_source: str = _DEFAULT_MODEL_SOURCE,
         timeout_seconds: int = 1800,
     ):
         """Args:
@@ -518,7 +532,7 @@ class MineruImageExtractor:
         self,
         mineru_bin: Optional[str] = None,
         cache_dir: Optional[str] = None,
-        model_source: str = "local",
+        model_source: str = _DEFAULT_MODEL_SOURCE,
         timeout_seconds: int = 1800,
     ):
         """Args: same as ``MineruExtractor.__init__``."""

--- a/tests/unit/adapters/test_mineru_extractor.py
+++ b/tests/unit/adapters/test_mineru_extractor.py
@@ -105,7 +105,7 @@ def test_extract_builds_the_correct_mineru_command(monkeypatch, tmp_path):
     assert Path(cmd[cmd.index("-o") + 1]).parent == cache_dir
 
 
-def test_model_source_defaults_to_local(monkeypatch, tmp_path):
+def test_model_source_defaults_to_a_source_that_works_on_a_fresh_install(monkeypatch, tmp_path):
     pdf = _make_pdf(tmp_path)
     bin_path = _make_bin(tmp_path)
     seen_env = {}
@@ -120,7 +120,13 @@ def test_model_source_defaults_to_local(monkeypatch, tmp_path):
 
     MineruExtractor(mineru_bin=str(bin_path), cache_dir=str(tmp_path / "cache")).extract(str(pdf))
 
-    assert seen_env["MINERU_MODEL_SOURCE"] == "local"
+    # Changed from "local" in issue #118, deliberately. "local" means two
+    # different things across MinerU's major versions: in 2.x it reused the
+    # already-downloaded HuggingFace cache, and in 3.x it means "read a local
+    # models config file" and crashes without one -- so the shipped default
+    # extracted nothing on the installation `pip install mineru[core]`
+    # produces today. An air-gapped setup opts back in explicitly.
+    assert seen_env["MINERU_MODEL_SOURCE"] == "huggingface"
 
 
 def test_model_source_is_configurable(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

`local` meant two different things across MinerU's major versions: reuse the
HuggingFace cache (2.x), or read a local models config file (3.x, what
`pip install mineru[core]` gives you today) — where it dereferences `None`
without one. A fresh install following this project's own instructions
extracted **nothing**.

A default has to work on the installation the instructions produce. It is now
`huggingface`, which downloads the models once and reuses them. Air-gapped
setups opt back into `local` explicitly, with the config file 3.x expects.

This is the half #119 deliberately left as owner territory.

## Issue

Fixes #118 (the other half shipped in #119).

## Test plan

- [x] `pytest` 913 passed, 2 skipped; `ruff check .` clean.
- [x] The unit test asserting `"local"` is **updated, not deleted**, and now
      carries why the contract moved. It is not a characterization test.
- [x] `README.md` and `.env.example` updated in the same change; both now
      describe `local` as the air-gapped opt-in rather than the default.
- [~] **Partially verified on the real stack.** A live extraction with the new
      default got past model resolution and into processing — the old failure
      was `'NoneType' object has no attribute 'get'` before any work started,
      and that is gone. It then hit a CUDA OOM because a harness campaign had
      the card: my fault for running both, and exactly what the runbook I
      wrote warns against. The clean end-to-end run is the evidence #118's
      closure criterion asks for and I will post it there once the card frees
      up.

## Protected zone

A shipped configuration default (`AGENTS.md` rules 5/6). Changing it is the
whole point of this PR, and the owner asked for the open issues to be closed.
No pipeline flag, grading rule or gold case is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)