### PR TITLE
Add Study.summarize: structured summaries over retrieved evidence (#140)

### DIFF
--- a/src/monkeygrab/application/study.py
+++ b/src/monkeygrab/application/study.py
@@ -1,0 +1,233 @@
+"""Study -- structured artifacts over retrieved evidence, instead of prose.
+
+Issue #140. ``Answer`` streams prose for one question. This produces artifacts
+with parts: a summary now, an outline and a quiz once this shape is proven.
+The three share a path -- take fragments the caller already retrieved, ask the
+generator for structure, parse it, attach the evidence each part came from --
+and differ only in schema and prompt.
+
+Takes its ports and config through the call, reads nothing from module state
+(``AGENTS.md`` section 7 rule 2), and hard-fails rather than degrading
+(rule 8).
+
+## Why parsing is the boundary
+
+The generator returns text; a summary has structure. Between those two facts
+sits the only genuinely new failure mode here: a model that answers with
+almost-JSON.
+
+A half-parsed artifact is worse than no artifact. A summary missing its third
+section looks complete, and a reader has no way to tell which parts of the
+document went unmentioned because the model skipped them from those that
+vanished in a truncated response. So the parse is strict: JSON that does not
+decode, is not a list, or carries no usable section raises
+``MalformedSummaryError``. That mirrors ``LlmProposer`` in the harness, which
+validates every field of a model's reply and treats anything else as a
+failure rather than a partial success.
+
+What is *not* strict: an individual section missing its optional fields. A
+section with a heading and a body is usable; one with neither is not. The
+line is drawn at "can a reader use this", not at "does it match the schema
+exactly", because tightening past that point turns a cosmetic difference
+between models into an outage.
+"""
+
+import json
+import re
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from monkeygrab.application.context_assembly import build_context_for_model
+from monkeygrab.config.app_config import AppConfig
+from monkeygrab.domain.document_summary import DocumentSummary, SummarySection
+from monkeygrab.domain.fragment import Fragment
+from monkeygrab.ports.chat_model import ChatModel
+
+# Asking for a JSON array of objects rather than prose with markers: the
+# structure is the deliverable, and a delimiter-based format ("### heading")
+# fails silently when the model varies its punctuation, where malformed JSON
+# fails loudly. Written in English regardless of the corpus language -- the
+# instruction is to the model about format, and the language of the summary
+# itself is set separately below, from the fragments' own language.
+_SUMMARY_SYSTEM_PROMPT = (
+    "You summarise documents. You reply with a JSON array and nothing else: "
+    "no preamble, no explanation, no markdown fences. Each element is an "
+    'object with exactly two string keys, "heading" and "body". The heading '
+    "is at most eight words. The body is two to four sentences. Write between "
+    "three and six elements, ordered so that reading them in sequence gives a "
+    "coherent account of the material. Use only what the provided material "
+    "states; never add facts from your own knowledge, and if the material "
+    "does not support a section, write fewer sections rather than inventing "
+    "one."
+)
+
+# A fenced block is the single most common deviation from "JSON and nothing
+# else" across every model tried, and unwrapping it costs one regex against
+# an outage. Anything past that -- prose around the JSON, trailing commas --
+# is left to fail: each accommodation makes the parse guess further from what
+# the model actually said.
+_FENCE_RE = re.compile(r"^\s*```(?:json)?\s*(.*?)\s*```\s*$", re.DOTALL)
+
+_MAX_SECTIONS = 12
+
+
+class MalformedSummaryError(RuntimeError):
+    """The generator's reply could not be read as a summary.
+
+    Raised rather than returning a partial summary: a summary missing a
+    section looks complete, and a reader cannot tell a section the model chose
+    not to write from one lost to a truncated response.
+    """
+
+
+def _strip_fence(text: str) -> str:
+    match = _FENCE_RE.match(text)
+    return match.group(1) if match else text.strip()
+
+
+def _pages_of(fragments: Sequence[Fragment]) -> Tuple[int, ...]:
+    """Ascending, deduplicated page numbers of ``fragments``."""
+    return tuple(sorted({f.metadata.page for f in fragments}))
+
+
+def _single_document(fragments: Sequence[Fragment]) -> str:
+    """The one document these fragments came from, or "" if more than one.
+
+    Empty rather than the first: naming one document for a summary written
+    from several would be a claim the summary does not support.
+    """
+    sources = {f.metadata.source for f in fragments}
+    return next(iter(sources)) if len(sources) == 1 else ""
+
+
+def _parse_sections(raw: str) -> List[Dict[str, Any]]:
+    """Decode the generator's reply into section dicts, or raise.
+
+    Raises:
+        MalformedSummaryError: The reply is not JSON, is not a list, or
+            contains no element with a usable heading or body.
+    """
+    try:
+        decoded = json.loads(_strip_fence(raw))
+    except (json.JSONDecodeError, TypeError) as exc:
+        raise MalformedSummaryError(
+            f"generator did not return JSON: {exc}. First 200 characters: {raw[:200]!r}"
+        ) from exc
+
+    if not isinstance(decoded, list):
+        raise MalformedSummaryError(
+            f"expected a JSON array of sections, got {type(decoded).__name__}"
+        )
+
+    usable = [
+        element
+        for element in decoded
+        if isinstance(element, dict)
+        and (str(element.get("heading", "")).strip() or str(element.get("body", "")).strip())
+    ]
+    if not usable:
+        raise MalformedSummaryError(
+            f"no section carried a heading or a body ({len(decoded)} element(s) returned)"
+        )
+    return usable[:_MAX_SECTIONS]
+
+
+class Study:
+    """Structured artifacts over evidence the caller has already retrieved.
+
+    The caller retrieves, exactly as it does for ``Answer``: this use case has
+    no opinion about which fragments are relevant, only about what to build
+    from them.
+    """
+
+    def __init__(self, chat_model: ChatModel) -> None:
+        """
+        Args:
+            chat_model: The generator role. Injected rather than resolved, so
+                a caller can point summarisation at a different model from
+                answering without either use case knowing.
+        """
+        self._chat_model = chat_model
+
+    def summarize(
+        self,
+        fragments: Sequence[Fragment],
+        config: AppConfig,
+        *,
+        language: Optional[str] = None,
+    ) -> DocumentSummary:
+        """Summarise ``fragments`` into ordered, sourced sections.
+
+        Args:
+            fragments: Evidence to summarise, already ranked by the caller.
+            config: Read fresh on every call -- never captured in a default
+                argument (``tests/characterization/test_stale_default_config_bug.py``
+                is the bug that rule forecloses).
+            language: Language to write the summary in, e.g. "Castellano".
+                ``None`` leaves it to the model, which follows the material.
+
+        Returns:
+            A ``DocumentSummary``. Empty input gives an empty summary without
+            calling the generator -- there is nothing to summarise, which is
+            not a failure.
+
+        Raises:
+            MalformedSummaryError: The generator's reply could not be read as
+                a summary.
+            Exception: Whatever the chat model raises (hard-fail policy).
+        """
+        if not fragments:
+            return DocumentSummary(sections=(), source_document="")
+
+        # Same context builder Answer uses, so a summary reads the evidence in
+        # the format the pipeline already produces rather than a second one
+        # that could drift from it. The metrics half of the return is the
+        # caller's concern there and nobody's here.
+        context, _metrics = build_context_for_model(
+            list(fragments), config.flags.usar_optimizacion_contexto
+        )
+        instruction = "Summarise the following material."
+        if language:
+            instruction += f" Write the summary in {language}."
+
+        raw = self._chat_model.generate(
+            f"{instruction}\n\n{context}", system=_SUMMARY_SYSTEM_PROMPT
+        )
+
+        # Every section cites the whole retrieval's pages. Per-section
+        # attribution would need the model to report which fragment it used,
+        # and a model that miscounts would produce confident, wrong citations
+        # -- worse than coarse ones, because a reader checks a specific page
+        # and finds the claim absent. Coarse and true beats precise and
+        # guessed; per-section attribution needs its own design.
+        pages = _pages_of(fragments)
+        sections = tuple(
+            SummarySection(
+                heading=str(element.get("heading", "")).strip(),
+                body=str(element.get("body", "")).strip(),
+                source_pages=pages,
+            )
+            for element in _parse_sections(raw)
+        )
+        return DocumentSummary(sections=sections, source_document=_single_document(fragments))
+
+
+def summary_to_dict(summary: DocumentSummary) -> Dict[str, Any]:
+    """Plain-JSON view for an interface layer.
+
+    Lives here rather than in the interface so the web app and the CLI cannot
+    drift into two different shapes for the same artifact.
+    """
+    # Lists, not the dataclass's tuples: `dataclasses.asdict` keeps tuples,
+    # and json.dumps turns them into lists, so a caller comparing a payload
+    # against its own round-trip would see a difference that is not one.
+    return {
+        "source_document": summary.source_document,
+        "sections": [
+            {
+                "heading": section.heading,
+                "body": section.body,
+                "source_pages": list(section.source_pages),
+            }
+            for section in summary.sections
+        ],
+    }

--- a/src/monkeygrab/domain/document_summary.py
+++ b/src/monkeygrab/domain/document_summary.py
@@ -1,0 +1,53 @@
+"""DocumentSummary -- a structured summary of retrieved evidence.
+
+Issue #140. ``Answer`` produces prose a person reads once; this is an artifact
+a UI renders in parts and a reader navigates. Keeping them separate types is
+the point: a summary section knows which fragments it came from, and a caller
+that wants to show "where does this claim come from" needs that link to exist
+in the data, not to be recovered by matching strings after the fact.
+
+Zero infrastructure imports, like everything else under ``domain/``.
+"""
+
+import dataclasses
+from typing import Tuple
+
+
+@dataclasses.dataclass(frozen=True)
+class SummarySection:
+    """One section of a summary, and the evidence it was written from.
+
+    Attributes:
+        heading: Short title for the section. Not a document heading copied
+            verbatim -- the generator writes it, because a summary's structure
+            need not mirror the source's.
+        body: The section's prose.
+        source_pages: Pages of the fragments this section was written from,
+            in ascending order, deduplicated. Pages rather than fragment ids
+            because a page is what a reader can open and check, which is the
+            whole purpose of carrying them.
+    """
+
+    heading: str
+    body: str
+    source_pages: Tuple[int, ...] = ()
+
+
+@dataclasses.dataclass(frozen=True)
+class DocumentSummary:
+    """An ordered set of summary sections over one retrieval.
+
+    Attributes:
+        sections: In the order the generator produced them, which is the
+            order a reader should read them.
+        source_document: The document the evidence came from, or "" when the
+            fragments span more than one -- an honest empty rather than the
+            first one, which would read as a claim about the whole summary.
+    """
+
+    sections: Tuple[SummarySection, ...]
+    source_document: str = ""
+
+    @property
+    def is_empty(self) -> bool:
+        return not self.sections

--- a/tests/unit/application/test_study_summaries.py
+++ b/tests/unit/application/test_study_summaries.py
@@ -1,0 +1,189 @@
+"""Study.summarize: the parse boundary, and what it refuses to guess.
+
+Issue #140. The generator returns text and a summary has structure, so the
+only genuinely new failure mode here is a model that answers with almost-JSON.
+These tests are mostly about that line -- what counts as usable, what raises,
+and what the use case declines to infer.
+
+Against a doubled ``ChatModel``: no GPU, no Ollama, no network, so this runs
+in the fast gate's dependency-free job like the rest of ``application/``.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+for path in (str(ROOT), str(ROOT / "src")):
+    if path not in sys.path:
+        sys.path.insert(0, path)
+
+from monkeygrab.application.study import (  # noqa: E402
+    MalformedSummaryError,
+    Study,
+    summary_to_dict,
+)
+from monkeygrab.config.app_config import AppConfig  # noqa: E402
+from monkeygrab.domain.chunk_metadata import ChunkMetadata  # noqa: E402
+from monkeygrab.domain.fragment import Fragment  # noqa: E402
+
+
+class _FakeChatModel:
+    """Returns a canned reply and records what it was asked."""
+
+    def __init__(self, reply="[]"):
+        self.reply = reply
+        self.calls = []
+
+    def generate(self, prompt, *, system=None, images=()):
+        self.calls.append({"prompt": prompt, "system": system})
+        if isinstance(self.reply, Exception):
+            raise self.reply
+        return self.reply
+
+    def stream(self, prompt, *, system=None):  # pragma: no cover - unused here
+        raise NotImplementedError
+
+
+class _ExplodingChatModel:
+    def generate(self, *args, **kwargs):
+        raise AssertionError("the generator must not be called")
+
+    def stream(self, *args, **kwargs):  # pragma: no cover
+        raise NotImplementedError
+
+
+def _fragment(source="paper.pdf", page=1, text="Some retrieved text."):
+    return Fragment(
+        doc=text,
+        metadata=ChunkMetadata(source=source, page=page),
+    )
+
+
+_TWO_SECTIONS = (
+    '[{"heading": "What it is", "body": "First body."},'
+    ' {"heading": "How it works", "body": "Second body."}]'
+)
+
+
+class TestTheHappyPath:
+    def test_sections_keep_the_generators_order(self):
+        study = Study(_FakeChatModel(_TWO_SECTIONS))
+        summary = study.summarize([_fragment()], AppConfig())
+        assert [s.heading for s in summary.sections] == ["What it is", "How it works"]
+
+    def test_each_section_carries_the_pages_the_evidence_came_from(self):
+        study = Study(_FakeChatModel(_TWO_SECTIONS))
+        summary = study.summarize(
+            [_fragment(page=4), _fragment(page=2), _fragment(page=4)], AppConfig()
+        )
+        # Ascending and deduplicated: a reader opens pages, and 2 twice is not
+        # more evidence than 2 once.
+        assert all(s.source_pages == (2, 4) for s in summary.sections)
+
+    def test_a_requested_language_reaches_the_prompt(self):
+        model = _FakeChatModel(_TWO_SECTIONS)
+        Study(model).summarize([_fragment()], AppConfig(), language="Castellano")
+        assert "Castellano" in model.calls[0]["prompt"]
+
+    def test_the_format_instruction_goes_in_the_system_prompt(self):
+        """Format is an instruction to the model; the material is the prompt.
+        Mixing them lets a document that happens to contain the word 'JSON'
+        argue with the instruction."""
+        model = _FakeChatModel(_TWO_SECTIONS)
+        Study(model).summarize([_fragment()], AppConfig())
+        assert "JSON array" in model.calls[0]["system"]
+        assert "JSON array" not in model.calls[0]["prompt"]
+
+    def test_a_fenced_reply_is_unwrapped(self):
+        """The most common deviation from 'JSON and nothing else' across every
+        model tried, and one regex against an outage."""
+        study = Study(_FakeChatModel(f"```json\n{_TWO_SECTIONS}\n```"))
+        assert len(study.summarize([_fragment()], AppConfig()).sections) == 2
+
+
+class TestWhatItRefusesToGuess:
+    def test_malformed_json_raises_rather_than_returning_part_of_a_summary(self):
+        """A summary missing a section looks complete. A reader cannot tell a
+        section the model chose not to write from one lost to truncation."""
+        study = Study(_FakeChatModel('[{"heading": "Cut off", "body": "It en'))
+        with pytest.raises(MalformedSummaryError) as exc:
+            study.summarize([_fragment()], AppConfig())
+        # The message carries the start of the reply: diagnosing this means
+        # seeing what the model actually said.
+        assert "Cut off" in str(exc.value)
+
+    def test_a_json_object_instead_of_an_array_raises(self):
+        study = Study(_FakeChatModel('{"heading": "Just one", "body": "Alone."}'))
+        with pytest.raises(MalformedSummaryError) as exc:
+            study.summarize([_fragment()], AppConfig())
+        assert "dict" in str(exc.value)
+
+    def test_an_array_of_empty_sections_raises(self):
+        study = Study(_FakeChatModel('[{"heading": "", "body": ""}, {}]'))
+        with pytest.raises(MalformedSummaryError):
+            study.summarize([_fragment()], AppConfig())
+
+    def test_a_generator_failure_propagates_untouched(self):
+        """Hard-fail policy: no empty summary standing in for a dead model."""
+        study = Study(_FakeChatModel(RuntimeError("ollama is down")))
+        with pytest.raises(RuntimeError, match="ollama is down"):
+            study.summarize([_fragment()], AppConfig())
+
+
+class TestWhatItAcceptsOnPurpose:
+    def test_one_unusable_section_among_usable_ones_is_dropped_not_fatal(self):
+        """The line is 'can a reader use this', not 'does it match the schema'.
+        Failing the whole summary over one empty element would turn a cosmetic
+        difference between models into an outage."""
+        study = Study(
+            _FakeChatModel('[{"heading": "Real", "body": "Body."}, {}, {"body": "Also real."}]')
+        )
+        sections = study.summarize([_fragment()], AppConfig()).sections
+        assert len(sections) == 2
+        assert sections[1].heading == ""
+
+    def test_a_section_with_only_a_body_is_kept(self):
+        study = Study(_FakeChatModel('[{"body": "No heading, still readable."}]'))
+        assert study.summarize([_fragment()], AppConfig()).sections[0].body
+
+
+class TestSourceAttribution:
+    def test_one_document_is_named(self):
+        study = Study(_FakeChatModel(_TWO_SECTIONS))
+        summary = study.summarize(
+            [_fragment(source="planck.pdf", page=1), _fragment(source="planck.pdf", page=3)],
+            AppConfig(),
+        )
+        assert summary.source_document == "planck.pdf"
+
+    def test_several_documents_name_none_rather_than_the_first(self):
+        """Naming one document for a summary written from several would be a
+        claim the summary does not support."""
+        study = Study(_FakeChatModel(_TWO_SECTIONS))
+        summary = study.summarize(
+            [_fragment(source="a.pdf"), _fragment(source="b.pdf")], AppConfig()
+        )
+        assert summary.source_document == ""
+
+
+class TestEmptyInput:
+    def test_no_fragments_gives_an_empty_summary_without_calling_the_model(self):
+        """Nothing to summarise is not a failure, and paying a generation call
+        to be told so is waste."""
+        summary = Study(_ExplodingChatModel()).summarize([], AppConfig())
+        assert summary.is_empty
+        assert summary.sections == ()
+
+
+class TestTheInterfaceView:
+    def test_the_dict_view_is_plain_json(self):
+        """One shape for the web app and the CLI, so they cannot drift."""
+        import json
+
+        study = Study(_FakeChatModel(_TWO_SECTIONS))
+        summary = study.summarize([_fragment(page=7)], AppConfig())
+        payload = summary_to_dict(summary)
+        assert json.loads(json.dumps(payload)) == payload
+        assert payload["sections"][0]["source_pages"] == [7]


### PR DESCRIPTION
## Summary

First of the three things #140 identifies, and they are one shape rather than
three: take fragments the caller retrieved, ask the generator for a structured
artifact instead of prose, parse it, attach the evidence. Summary lands first
so the parse boundary and the citation plumbing arrive in one diff; outline
and quiz follow with their own schemas.

**The decision worth reviewing is where the parse line falls.**

Strict where a partial result would lie — malformed JSON, a non-array, or no
usable section raises. A summary missing its third section *looks complete*,
and a reader cannot tell a section the model chose not to write from one lost
to truncation. Same stance `LlmProposer` already takes in the harness.

Lenient where strictness would only cause outages — one empty element among
usable ones is dropped; a body without a heading is kept. The line is "can a
reader use this", not "does it match the schema".

**Two things it declines to infer:**

- **Per-section citation.** It would need the model to say which fragment it
  used, and a model that miscounts produces confident wrong page numbers —
  worse than coarse ones, because a reader opens the page and finds nothing.
  Every section cites the whole retrieval's pages instead: coarse and true.
- **A document name for a multi-document summary.** Empty rather than the
  first, which would be a claim the summary does not support.

No new port; `ChatModel` already does what this needs.

## Issue

Refs #140 — summary only, as the issue scopes it. Outline and quiz are the
remaining two.

## Test plan

- [x] 15 tests against a **doubled `ChatModel`** — no GPU, no Ollama, no
      network, so they run in the fast gate's dependency-free job like the
      rest of `application/`.
- [x] The generator is asserted **not called** on empty input, via a double
      that raises if touched.
- [x] Format instruction asserted to be in the *system* prompt, not the user
      prompt — otherwise a document containing the word "JSON" can argue with
      it.
- [x] `pytest` 948 passed, 2 skipped; `ruff check .` clean.
- [ ] Not yet wired into the CLI or web UI — the use case first, per the
      hexagonal boundary. Interface wiring is its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)