### PR TITLE
Add Study.outline: the heading tree, with two bounds (#140)

### DIFF
--- a/src/monkeygrab/application/study.py
+++ b/src/monkeygrab/application/study.py
@@ -38,7 +38,12 @@ from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 from monkeygrab.application.context_assembly import build_context_for_model
 from monkeygrab.config.app_config import AppConfig
-from monkeygrab.domain.document_summary import DocumentSummary, SummarySection
+from monkeygrab.domain.document_summary import (
+    DocumentOutline,
+    DocumentSummary,
+    OutlineNode,
+    SummarySection,
+)
 from monkeygrab.domain.fragment import Fragment
 from monkeygrab.ports.chat_model import ChatModel
 
@@ -68,6 +73,34 @@ _SUMMARY_SYSTEM_PROMPT = (
 _FENCE_RE = re.compile(r"^\s*```(?:json)?\s*(.*?)\s*```\s*$", re.DOTALL)
 
 _MAX_SECTIONS = 12
+
+# Asking for a nested JSON structure directly rather than markdown headings
+# with "#" levels: the nesting is what the caller wants, and reconstructing it
+# from prefix counts means re-deriving structure the model already knew and
+# threw away.
+_OUTLINE_SYSTEM_PROMPT = (
+    "You produce document outlines. You reply with a JSON array and nothing "
+    "else: no preamble, no explanation, no markdown fences. Each element is an "
+    'object with a string key "title" and an optional key "children" holding '
+    "an array of the same shape. Titles are at most ten words and contain no "
+    "prose. Nest no deeper than three levels. Describe only the structure the "
+    "provided material actually has; never invent a section it does not "
+    "contain."
+)
+
+# A model that nests without limit turns one bad reply into an outline nobody
+# can render and, before that, into unbounded recursion in the parser. Three
+# is what the prompt asks for; this is the guard for when it is ignored.
+_MAX_OUTLINE_DEPTH = 4
+_MAX_OUTLINE_NODES = 60
+
+
+class MalformedOutlineError(RuntimeError):
+    """The generator's reply could not be read as an outline.
+
+    Separate from ``MalformedSummaryError`` so a caller offering both can tell
+    which artifact failed without parsing an error message.
+    """
 
 
 class MalformedSummaryError(RuntimeError):
@@ -209,6 +242,104 @@ class Study:
             for element in _parse_sections(raw)
         )
         return DocumentSummary(sections=sections, source_document=_single_document(fragments))
+
+    def outline(
+        self,
+        fragments: Sequence[Fragment],
+        config: AppConfig,
+        *,
+        language: Optional[str] = None,
+    ) -> DocumentOutline:
+        """Build a heading tree over ``fragments``.
+
+        Args:
+            fragments: Evidence to outline, already ranked by the caller.
+            config: Read fresh on every call, as in ``summarize``.
+            language: Language for the headings. ``None`` follows the material.
+
+        Returns:
+            A ``DocumentOutline``. Empty input gives an empty outline without
+            calling the generator.
+
+        Raises:
+            MalformedOutlineError: The reply is not JSON, is not an array, or
+                describes no titled node.
+            Exception: Whatever the chat model raises (hard-fail policy).
+        """
+        if not fragments:
+            return DocumentOutline(nodes=(), source_document="")
+
+        context, _metrics = build_context_for_model(
+            list(fragments), config.flags.usar_optimizacion_contexto
+        )
+        instruction = "Outline the structure of the following material."
+        if language:
+            instruction += f" Write the headings in {language}."
+
+        raw = self._chat_model.generate(
+            f"{instruction}\n\n{context}", system=_OUTLINE_SYSTEM_PROMPT
+        )
+
+        try:
+            decoded = json.loads(_strip_fence(raw))
+        except (json.JSONDecodeError, TypeError) as exc:
+            raise MalformedOutlineError(
+                f"generator did not return JSON: {exc}. First 200 characters: {raw[:200]!r}"
+            ) from exc
+        if not isinstance(decoded, list):
+            raise MalformedOutlineError(
+                f"expected a JSON array of nodes, got {type(decoded).__name__}"
+            )
+
+        nodes = _build_outline_nodes(decoded, depth=1, budget=[_MAX_OUTLINE_NODES])
+        if not nodes:
+            raise MalformedOutlineError(
+                f"no node carried a title ({len(decoded)} element(s) returned)"
+            )
+        return DocumentOutline(nodes=nodes, source_document=_single_document(fragments))
+
+
+def _build_outline_nodes(elements: Any, depth: int, budget: List[int]) -> Tuple[OutlineNode, ...]:
+    """Turn decoded JSON into nodes, bounded in both depth and total count.
+
+    Two bounds because they fail differently. Depth stops a model that nests
+    without end, which would otherwise recurse until the interpreter gives up.
+    The node budget stops a model that returns a thousand siblings, which
+    parses fine and produces an outline nobody can read.
+
+    Both truncate rather than raise. An outline is a navigational aid: one cut
+    off at three levels is still usable, where a summary missing a section is
+    not -- which is why this differs from ``_parse_sections`` deliberately.
+
+    Args:
+        elements: Decoded JSON, expected to be a list of dicts.
+        depth: Current nesting level, 1 at the top.
+        budget: Single-element list used as a mutable counter across the
+            recursion, decremented per node kept.
+    """
+    if not isinstance(elements, list) or depth > _MAX_OUTLINE_DEPTH:
+        return ()
+
+    nodes: List[OutlineNode] = []
+    for element in elements:
+        if budget[0] <= 0:
+            break
+        if not isinstance(element, dict):
+            continue
+        title = str(element.get("title", "")).strip()
+        if not title:
+            # A node with no title is not a heading. Its children, if any, are
+            # dropped with it: re-parenting them would invent a structure the
+            # model did not describe.
+            continue
+        budget[0] -= 1
+        nodes.append(
+            OutlineNode(
+                title=title,
+                children=_build_outline_nodes(element.get("children"), depth + 1, budget),
+            )
+        )
+    return tuple(nodes)
 
 
 def summary_to_dict(summary: DocumentSummary) -> Dict[str, Any]:

--- a/src/monkeygrab/domain/document_summary.py
+++ b/src/monkeygrab/domain/document_summary.py
@@ -51,3 +51,43 @@ class DocumentSummary:
     @property
     def is_empty(self) -> bool:
         return not self.sections
+
+
+@dataclasses.dataclass(frozen=True)
+class OutlineNode:
+    """One heading in a document outline, with its children.
+
+    A tree rather than a flat list carrying depth numbers: the nesting IS the
+    artifact, and a flat representation makes every consumer rebuild it, each
+    in its own slightly different way.
+
+    Attributes:
+        title: The heading text.
+        children: Sub-headings, in reading order. A leaf has none.
+    """
+
+    title: str
+    children: Tuple["OutlineNode", ...] = ()
+
+    @property
+    def depth(self) -> int:
+        """How many levels this node spans, itself included."""
+        return 1 + max((child.depth for child in self.children), default=0)
+
+
+@dataclasses.dataclass(frozen=True)
+class DocumentOutline:
+    """The heading tree of one retrieval.
+
+    Attributes:
+        nodes: Top-level headings, in reading order.
+        source_document: As in ``DocumentSummary`` -- "" when the evidence
+            spans more than one document, rather than naming one of them.
+    """
+
+    nodes: Tuple[OutlineNode, ...]
+    source_document: str = ""
+
+    @property
+    def is_empty(self) -> bool:
+        return not self.nodes

--- a/tests/unit/application/test_study_summaries.py
+++ b/tests/unit/application/test_study_summaries.py
@@ -20,6 +20,7 @@ for path in (str(ROOT), str(ROOT / "src")):
         sys.path.insert(0, path)
 
 from monkeygrab.application.study import (  # noqa: E402
+    MalformedOutlineError,
     MalformedSummaryError,
     Study,
     summary_to_dict,
@@ -187,3 +188,71 @@ class TestTheInterfaceView:
         payload = summary_to_dict(summary)
         assert json.loads(json.dumps(payload)) == payload
         assert payload["sections"][0]["source_pages"] == [7]
+
+
+class TestOutline:
+    """The tree, and the two bounds that keep a bad reply from being unbounded."""
+
+    _NESTED = (
+        '[{"title": "Introduction"},'
+        ' {"title": "Method", "children": ['
+        '   {"title": "Data"}, {"title": "Model"}]}]'
+    )
+
+    def test_nesting_is_preserved(self):
+        outline = Study(_FakeChatModel(self._NESTED)).outline([_fragment()], AppConfig())
+        assert [n.title for n in outline.nodes] == ["Introduction", "Method"]
+        assert [c.title for c in outline.nodes[1].children] == ["Data", "Model"]
+
+    def test_depth_is_reported_from_the_tree(self):
+        outline = Study(_FakeChatModel(self._NESTED)).outline([_fragment()], AppConfig())
+        assert outline.nodes[0].depth == 1
+        assert outline.nodes[1].depth == 2
+
+    def test_nesting_deeper_than_the_limit_is_truncated_not_fatal(self):
+        """An outline is a navigational aid: one cut off at three levels is
+        still usable, unlike a summary missing a section. Truncating is the
+        deliberate difference from _parse_sections."""
+        deep = '[{"title": "L1", "children": [{"title": "L2", "children": ['
+        deep += '{"title": "L3", "children": [{"title": "L4", "children": ['
+        deep += '{"title": "L5"}]}]}]}]}]'
+        outline = Study(_FakeChatModel(deep)).outline([_fragment()], AppConfig())
+        assert outline.nodes[0].depth == 4
+
+    def test_a_flood_of_siblings_is_capped(self):
+        """Parses fine, produces an outline nobody can read."""
+        flood = "[" + ",".join(f'{{"title": "H{i}"}}' for i in range(200)) + "]"
+        outline = Study(_FakeChatModel(flood)).outline([_fragment()], AppConfig())
+        assert 0 < len(outline.nodes) <= 60
+
+    def test_an_untitled_node_is_dropped_with_its_children(self):
+        """Re-parenting them would invent a structure the model did not
+        describe."""
+        reply = '[{"title": "Kept"}, {"children": [{"title": "Orphan"}]}]'
+        outline = Study(_FakeChatModel(reply)).outline([_fragment()], AppConfig())
+        titles = [n.title for n in outline.nodes]
+        assert titles == ["Kept"]
+        assert not any(c.title == "Orphan" for n in outline.nodes for c in n.children)
+
+    def test_malformed_json_raises_its_own_error_type(self):
+        """Distinct from MalformedSummaryError so a caller offering both can
+        tell which artifact failed without parsing a message."""
+        with pytest.raises(MalformedOutlineError):
+            Study(_FakeChatModel("not json at all")).outline([_fragment()], AppConfig())
+
+    def test_an_array_with_no_titled_node_raises(self):
+        with pytest.raises(MalformedOutlineError):
+            Study(_FakeChatModel('[{"children": []}, {}]')).outline([_fragment()], AppConfig())
+
+    def test_empty_input_does_not_call_the_generator(self):
+        outline = Study(_ExplodingChatModel()).outline([], AppConfig())
+        assert outline.is_empty
+
+    def test_the_language_request_reaches_the_prompt(self):
+        model = _FakeChatModel(self._NESTED)
+        Study(model).outline([_fragment()], AppConfig(), language="Valencià")
+        assert "Valencià" in model.calls[0]["prompt"]
+
+    def test_a_generator_failure_propagates(self):
+        with pytest.raises(RuntimeError, match="down"):
+            Study(_FakeChatModel(RuntimeError("down"))).outline([_fragment()], AppConfig())


### PR DESCRIPTION
## Summary

Second of #140's three artifacts, on the path `summarize` established.

A **tree**, not a flat list with depth numbers: the nesting is the artifact,
and a flat form makes every consumer rebuild it, each slightly differently.

**Two bounds, because a bad reply fails in two ways.** Depth stops a model
that nests without end — that one recurses until the interpreter gives up. A
node budget stops a model that returns two hundred siblings — that one parses
fine and produces an outline nobody can read.

**Both truncate rather than raise, and that is the deliberate difference from
`summarize`.** An outline is a navigational aid: one cut off at three levels
is still usable. A summary missing a section looks complete and misleads. Same
use case, opposite call, for a reason that is about the reader and not about
the schema.

An untitled node is dropped **with its children** rather than re-parenting
them, which would invent structure the model did not describe.

## Issue

Refs #140. Quiz is the remaining one.

## Test plan

- [x] 10 new tests (25 in the file), doubled `ChatModel`, no GPU or Ollama.
- [x] Both bounds tested by exceeding them: five nesting levels truncate to
      four; 200 siblings cap at 60.
- [x] The orphan case asserts the children are gone, not re-parented.
- [x] `MalformedOutlineError` is its own type — a caller offering both
      artifacts can tell which failed without parsing a message.
- [x] `pytest` 958 passed, 2 skipped; `ruff check .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)