### PR TITLE
Record tokens/s per generation, and start a model history

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,7 +118,12 @@ docs/README.md             Documentation standard
 
 Ollama roles are configured via env vars; defaults are the second arg of
 `os.getenv` in `rag/chat_pdfs.py`. Precedence is environment > `settings.json`
-> module defaults. The environment wins for this run, including over a
+> module defaults. **Which models have actually been measured, on what and how
+fast, is [`docs/model-history.md`](docs/model-history.md)** — append a row
+there when you run the gate against a model, rather than deciding the next
+default from memory. It covers the fixed stack too (MinerU, jina-clip, the
+reranker), because a version change there has moved more cases than any
+generator swap this project has measured. The environment wins for this run, including over a
 choice saved in the web UI; a save does not persist that override as if the
 user had picked it (issue #79). Jina CLIP v2 and BGE Reranker v2 M3 are fixed.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@
 | `AGENTS.md` (root) | Operating contract for any agent or human working in this repo; `.claude/CLAUDE.md` and `.codex/AGENTS.md` are pointers to it and must stay pointers. |
 | `CONTRIBUTING.md` | How to branch, open PRs and issues, what a change must carry, how issues get closed. |
 | `harness/RUNBOOK.md` | An agent or person about to run a loop campaign: the procedure, the decision points, what each verdict means. Procedure only — the reasoning lives in `harness/README.md`. |
+| `docs/model-history.md` | Which models have been measured, on what corpus and how fast — append-only, one row per run, so a later choice comes from numbers instead of memory. |
 | `docs/design/*.md` | Current standing design decisions and their rationale; update them when architecture changes. |
 | Directory-local `README.md` | Only where a directory's purpose isn't obvious from its code — not one per folder by default. |
 

--- a/docs/model-history.md
+++ b/docs/model-history.md
@@ -1,0 +1,120 @@
+# Model history — what has been measured, on what, and how fast
+
+Append-only record of every model this project has run, so a later choice is
+made from numbers rather than from memory. Each row names the machine and the
+run artifact it came from; without those a figure is an anecdote.
+
+**Read the caveat before the tables.** The gold set has 32 search-set cases
+and 23 of them reach a generator. The design doc puts the threshold for a
+difference not attributable to chance at about **six net flips**, so a gap of
+one or two cases between two generators is inside the noise this project has
+already measured. These tables are a log, not a ranking.
+
+Run artifacts live under `tests/eval/runs/`, which is gitignored: the paths
+are cited so the machine that holds them can reproduce the reading, not
+because a reader can open them.
+
+---
+
+## The fixed stack
+
+Three of the five model roles are not configurable, and they decide more than
+the generator does. A generator swap moved two cases out of 23; the extractor
+version moved three (see "Stack drift" below).
+
+| Role | Model | Where it runs | Notes |
+|---|---|---|---|
+| PDF extraction | **MinerU 3.4.5** | `.venv-mineru`, GPU | Downloads its own models on first use. Its 2.x line produced a different output layout and different block types — not interchangeable, see #118. |
+| Text+image embedding | **jinaai/jina-clip-v2**, 512-dim Matryoshka | `.venv-mineru`, GPU, ~2.8 GiB | Fixed by design. CC BY-NC 4.0: local use is non-commercial. |
+| Reranking | **BAAI/bge-reranker-v2-m3** | product venv, GPU, ~1.5 GiB | Cross-encoder. Not an Ollama model. |
+| Query decomposition | Ollama, `chat` role | Ollama | The gate pins this to its own `AUX_MODEL` so a `--models` sweep does not also swap the decomposer. |
+| Answer generation | Ollama, `rag` role | Ollama | The only role the tables below vary. |
+
+---
+
+## Generators measured
+
+`gemma4:e4b` is the repo default. Cases are the 23 answered ones; the other
+42 never call a generator.
+
+| Model | Params / size | Answered cases passed | Median s/case | tokens/s | Run |
+|---|---|---|---|---|---|
+| `qwen3-coder-30b:latest` | 30B MoE, 10 GB | **21 / 23** | 41.7 | not recorded | `20260901T023915Z` |
+| `gemma4:e2b` | 7.2 GB | 20 / 23 | 38.7 | not recorded | `20260901T023915Z` |
+| `gemma4:e4b` *(default)* | 9.6 GB | 19 / 23 | 39.8 | not recorded | `20260901T023915Z` |
+| `qwen3:30b-a3b` | 30B MoE, 3B active, 18 GB | pending | | | in progress |
+| `qwen3:8b` | 8B dense, 5.2 GB | pending | | | in progress |
+| `mistral-small3.2:24b` | 24B dense, 15 GB | pending | | | in progress |
+| `gpt-oss:20b` | 20B MoE, 13 GB | not yet run | | | |
+| `granite4:small-h` | MoE, 19 GB | not yet run | | | |
+
+**Why the tokens/s column is empty above.** The gate recorded
+`elapsed_seconds` per case, which includes the retrieval every model shares —
+so it mostly measured how busy the card was, not how fast the model decoded.
+Ollama reports `eval_count` and `eval_duration` on its final chunk and the
+streaming path always collected them; the silent path the gate uses dropped
+them. Fixed 2026-09-01: every record now carries `eval_count`,
+`eval_duration_s`, `generation_seconds` and `tokens_per_second`, and the
+column fills from the next run onward. Earlier rows stay empty rather than
+being back-filled with a number nobody measured.
+
+### What the three-model comparison actually showed
+
+Paired over identical retrieved fragments, **21 of 23 cases gave the same
+verdict under all three models**. Only two discriminated:
+
+| Case | `gemma4:e2b` | `gemma4:e4b` | `qwen3-coder-30b` |
+|---|---|---|---|
+| `dpo-model-scale` | PASS | fail | PASS |
+| `planck-h0` | fail | fail | **PASS** |
+
+Two more (`planck-h0-tension`, `planck-sigma8-es`) fail under all three, which
+makes them system failures rather than model failures.
+
+The practical reading: **the generator is not where the remaining failures
+are**, and a 30B MoE that does not fit in 8 GB costs about 2 s per case more
+than a 2B that does. Full analysis in issue #134.
+
+---
+
+## Stack drift, which moved more than any generator swap
+
+Same generator (`gemma4:e4b`), same 32 search-set cases, different extractor
+version:
+
+| When | Stack | Search set |
+|---|---|---|
+| Reference (per #30's comment) | MinerU 2.x line | 27 / 32 |
+| 2026-09-01 | MinerU 3.4.5 | 26 / 32 |
+
+Three flips: one recovered (`dpo-pipeline-figure-es`), two lost
+(`dpo-model-scale`, `planck-h0`). The measured noise floor of this gate is
+**zero flips**, so three is not noise.
+
+One honest qualification, added after the three-model comparison: both "lost"
+cases are among the two that discriminate between generators, so they sit near
+a decision boundary. The drift is real; attributing those two specifically to
+MinerU's version is not supportable. See issue #107.
+
+---
+
+## Hardware these numbers came from
+
+RTX 4060 Laptop, 8 GB (7.6 GiB usable), Ryzen 9 8945HS, 30 GB RAM. Every run
+above used `OLLAMA_KEEP_ALIVE=0`, which was required to fit the pipeline on
+this card before #143 and changes timing — a run made that way is not
+comparable with ledger history that was not.
+
+---
+
+## How to add a row
+
+Run the gate, then read the artifact rather than the terminal:
+
+```bash
+python tests/eval/run_eval.py --models <model> [<model>...]
+```
+
+Aggregate `tokens_per_second` over records that have it, skipping those that
+do not — a missing key means the model reported no counts, and treating it as
+zero drags an average toward "slower" for a reason that is not real.

--- a/rag/engine/generation.py
+++ b/rag/engine/generation.py
@@ -190,19 +190,35 @@ def generar_respuesta(
     return respuesta_completa
 
 
-def generar_respuesta_silenciosa(pregunta: str, fragmentos: List[Dict[str, Any]], metricas: Optional[Dict[str, Any]] = None) -> str:
+def generar_respuesta_silenciosa(
+    pregunta: str,
+    fragmentos: List[Dict[str, Any]],
+    metricas: Optional[Dict[str, Any]] = None,
+    stats: Optional[Dict[str, Any]] = None,
+) -> str:
     """Generate a RAG response without terminal output or a debug dump.
 
     Args:
         pregunta: User question.
         fragmentos: Retrieved context fragments.
         metricas: Pipeline metrics (unused here, kept for API compatibility).
+        stats: Optional dict filled in place with what Ollama reported on the
+            final chunk -- ``eval_count``, ``eval_duration``, ``load_duration``
+            and the rest of ``_GEN_STATS_FIELDS``. Appended as a keyword rather
+            than folded into ``metricas`` because this function's signature is
+            part of the public API (``AGENTS.md`` rule 7) and every existing
+            caller passes ``metricas`` positionally.
+
+            The streaming path has always collected these; only the silent one
+            dropped them, which is why the evaluation gate -- the one caller
+            that most needs to compare generators -- could measure seconds per
+            case but not tokens per second.
 
     Returns:
         Complete response text.
     """
     mensaje_usuario = cfg._preparar_mensaje_usuario_rag(pregunta, fragmentos)
-    return cfg._generar_respuesta_stream(mensaje_usuario)
+    return cfg._generar_respuesta_stream(mensaje_usuario, stats=stats)
 
 
 def evaluar_pregunta_rag(

--- a/tests/eval/run_eval.py
+++ b/tests/eval/run_eval.py
@@ -565,6 +565,31 @@ def run_retrieval_case(
     return record
 
 
+def _decoding_metrics(stats: Dict[str, Any]) -> Dict[str, Any]:
+    """Tokens generated, decode time and tokens/s, when Ollama reported them.
+
+    Absent keys rather than zeros or nulls: a record with no counts means the
+    model did not report them, and writing 0.0 would make a later average over
+    the column silently wrong in the direction of "slower". Every consumer that
+    aggregates these has to skip records that lack them, and a missing key is
+    the one shape that cannot be summed by accident.
+
+    tokens_per_second is derived here rather than left to each reader: the
+    same division already lives in generation.generar_respuesta for the debug
+    dump, and two copies of one formula is how the two ends up disagreeing.
+    """
+    eval_count = stats.get("eval_count")
+    eval_duration = stats.get("eval_duration")
+    if not eval_count or not eval_duration:
+        return {}
+    return {
+        "eval_count": eval_count,
+        # Ollama reports durations in nanoseconds.
+        "eval_duration_s": round(eval_duration / 1e9, 3),
+        "tokens_per_second": round(eval_count / (eval_duration / 1e9), 2),
+    }
+
+
 def run_factual_case(
     rag,
     case: Dict[str, Any],
@@ -598,8 +623,11 @@ def run_factual_case(
     for model in models:
         rag.set_model_roles_runtime({"rag": model})
         t0 = time.perf_counter()
+        gen_stats: Dict[str, Any] = {}
         try:
-            answer = rag.generar_respuesta_silenciosa(case["question"], list(fragments))
+            answer = rag.generar_respuesta_silenciosa(
+                case["question"], list(fragments), stats=gen_stats
+            )
         except Exception as exc:
             # A dead or overloaded Ollama must not be reported as a quality
             # regression: the run is inconclusive, which is a different verdict
@@ -632,6 +660,12 @@ def run_factual_case(
             "passed": result["pass"],
             "reason": result["reason"],
             "elapsed_seconds": round(retrieval_elapsed + gen_elapsed, 2),
+            # Generation only, so models are comparable. elapsed_seconds
+            # includes the retrieval this case shares across every model, and
+            # on this corpus retrieval dominates it -- comparing generators by
+            # that number mostly compares how busy the card was.
+            "generation_seconds": round(gen_elapsed, 2),
+            **_decoding_metrics(gen_stats),
         }
         if not result["pass"]:
             record["answer"] = answer


### PR DESCRIPTION
## Summary

The gate could compare generators only by `elapsed_seconds`, which includes
the retrieval every model shares — on this corpus retrieval dominates it, so
that number mostly measured **how busy the card was**. Ollama reports
`eval_count` and `eval_duration` on its final chunk and the streaming path
always collected them; the silent path the gate uses dropped them. The one
caller that most needs to compare generators was the one that could not.

Each record now carries `generation_seconds`, `eval_count`,
`eval_duration_s` and `tokens_per_second`.

**Absent keys rather than zeros** when a model reports no counts: a 0.0 drags
a later average toward "slower" for a reason that is not real, and a missing
key is the one shape that cannot be summed by accident. The division lives in
one place — the same formula already existed in `generar_respuesta` for the
debug dump, and two copies is how the two end up disagreeing.

`docs/model-history.md` is the append-only log this makes possible. It records
**the fixed stack too** — MinerU, jina-clip, the reranker — because a version
change there moved three cases where a generator swap moved two; a table of
generators alone would imply the opposite.

## Test plan

- [x] `pytest` 952 passed, 2 skipped; `ruff check .` clean.
- [x] `generar_respuesta_silenciosa` keeps its signature compatible — `stats`
      is appended as a keyword, and every existing caller passes `metricas`
      positionally (rule 7).
- [x] Registered in `docs/README.md`'s table and pointed at from AGENTS.md §3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)