### PR TITLE
Add Study.quiz: questions the reader can be graded against (#140)

### DIFF
--- a/src/monkeygrab/README.md
+++ b/src/monkeygrab/README.md
@@ -9,8 +9,8 @@ Full rationale and phased rollout: [`docs/design/2026-07-26-monkeygrab-v2.md`](.
 ```
 domain/        entities, zero infrastructure imports    (Chunk, Fragment, ExtractedPage, ...)
 ports/         Protocols the application layer depends on (PdfExtractor, Embedder, VectorStore, ...)
-application/   use cases: IndexCorpus, Retrieve, Answer, + pure helpers (rrf_fusion, text_chunking,
-               context_assembly, keywords)
+application/   use cases: IndexCorpus, Retrieve, Answer, Study, + pure helpers (rrf_fusion,
+               text_chunking, context_assembly, keywords)
 config/        AppConfig — immutable, built once via from_env(), changed via with_overrides() (never mutated)
 adapters/      port implementations (MinerU, jina-clip, FAISS, Ollama, BM25, CrossEncoder)
 ```
@@ -57,6 +57,14 @@ them holds pipeline logic.
 split exists because a caller streaming to a web client sends the cited
 sources before the first token arrives, which it cannot do if preparing the
 prompt and generating from it are one call.
+
+`Study` is the other caller of the generator, and it produces structure where
+`Answer` produces prose: a summary, an outline, a quiz. All three take
+fragments the caller already retrieved and differ only in schema, prompt, and
+how strict the parse is. That last part is the design decision worth knowing
+before touching it — an outline truncates, a summary drops unusable sections,
+and a quiz refuses anything it cannot grade safely, because a wrong answer key
+is the only one of the three that misleads without looking wrong.
 
 `rag/engine/wiring.py` is the only bridge between the mutable runtime globals
 in `rag/chat_pdfs.py` and the immutable `AppConfig` this package takes. It

--- a/src/monkeygrab/application/study.py
+++ b/src/monkeygrab/application/study.py
@@ -1,10 +1,10 @@
 """Study -- structured artifacts over retrieved evidence, instead of prose.
 
 Issue #140. ``Answer`` streams prose for one question. This produces artifacts
-with parts: a summary now, an outline and a quiz once this shape is proven.
-The three share a path -- take fragments the caller already retrieved, ask the
-generator for structure, parse it, attach the evidence each part came from --
-and differ only in schema and prompt.
+with parts: a summary, an outline and a quiz. The three share a path -- take
+fragments the caller already retrieved, ask the generator for structure, parse
+it, attach the evidence each part came from -- and differ only in schema,
+prompt, and how strict the parse is (see below).
 
 Takes its ports and config through the call, reads nothing from module state
 (``AGENTS.md`` section 7 rule 2), and hard-fails rather than degrading
@@ -30,6 +30,14 @@ section with a heading and a body is usable; one with neither is not. The
 line is drawn at "can a reader use this", not at "does it match the schema
 exactly", because tightening past that point turns a cosmetic difference
 between models into an outage.
+
+The three artifacts draw that line in three places, and the difference is the
+cost of being wrong, not a matter of taste. An outline truncates: one cut off
+at three levels still navigates. A summary drops unusable sections but raises
+if none survive: a section a reader cannot read is visibly absent. A quiz is
+strictest, because it is the only one that can be wrong *without looking
+wrong* -- a key pointing at the wrong option grades the reader against a
+falsehood, and checking it is exactly what they could not do.
 """
 
 import json
@@ -42,6 +50,8 @@ from monkeygrab.domain.document_summary import (
     DocumentOutline,
     DocumentSummary,
     OutlineNode,
+    Quiz,
+    QuizQuestion,
     SummarySection,
 )
 from monkeygrab.domain.fragment import Fragment
@@ -93,6 +103,43 @@ _OUTLINE_SYSTEM_PROMPT = (
 # is what the prompt asks for; this is the guard for when it is ignored.
 _MAX_OUTLINE_DEPTH = 4
 _MAX_OUTLINE_NODES = 60
+
+
+# Asking for the key as an index into the options rather than as the correct
+# answer's text: a model that restates the text introduces a second copy that
+# can disagree with the option it names -- by a comma, by a truncation -- and
+# then nothing downstream can tell which of the two is the answer.
+_QUIZ_SYSTEM_PROMPT = (
+    "You write multiple-choice comprehension questions. You reply with a JSON "
+    "array and nothing else: no preamble, no explanation, no markdown fences. "
+    'Each element is an object with three keys: "prompt" (the question), '
+    '"options" (an array of three or four distinct answer strings) and '
+    '"correct_index" (the zero-based position in that array of the correct '
+    "option). Exactly one option is correct and the others must be plausible "
+    "but wrong. Ask only about what the provided material states; never draw "
+    "on your own knowledge, and if the material supports fewer questions than "
+    "requested, return fewer rather than inventing any."
+)
+
+# A quiz nobody asked the length of is not a quiz. The ceiling is a guard on
+# the model, not a product limit: past it the reply is long enough that
+# truncation, not question count, is what decides where it ends.
+_DEFAULT_QUESTION_COUNT = 5
+_MAX_QUESTION_COUNT = 20
+
+# Two is a coin toss and four is the conventional ceiling for a readable
+# question. Below the floor there is no choice to make; above the ceiling the
+# model starts padding with near-duplicates of the correct option.
+_MIN_OPTIONS = 2
+_MAX_OPTIONS = 6
+
+
+class MalformedQuizError(RuntimeError):
+    """The generator's reply held no question safe to grade a reader against.
+
+    Separate from the summary and outline errors so a caller offering several
+    artifacts can tell which one failed without parsing an error message.
+    """
 
 
 class MalformedOutlineError(RuntimeError):
@@ -162,6 +209,50 @@ def _parse_sections(raw: str) -> List[Dict[str, Any]]:
             f"no section carried a heading or a body ({len(decoded)} element(s) returned)"
         )
     return usable[:_MAX_SECTIONS]
+
+
+def _usable_question(element: Any) -> Optional[Dict[str, Any]]:
+    """The question's fields if it is safe to grade against, else ``None``.
+
+    Stricter than ``_parse_sections`` on purpose. A thin summary section is
+    thin and the reader can see that. A question whose key points at the wrong
+    option teaches something false with the authority of an answer key, and
+    the reader has no way to notice -- checking is precisely what they were
+    unable to do, which is why they are taking the quiz.
+
+    So every dropped case below is one where the artifact would still *look*
+    answerable. Nothing here is repaired: there is no evidence for what the
+    model meant, and a guessed key is the failure this function exists to
+    prevent.
+    """
+    if not isinstance(element, dict):
+        return None
+
+    prompt = str(element.get("prompt", "")).strip()
+    if not prompt:
+        return None
+
+    raw_options = element.get("options")
+    if not isinstance(raw_options, list):
+        return None
+    options = [str(option).strip() for option in raw_options if str(option).strip()]
+    if not _MIN_OPTIONS <= len(options) <= _MAX_OPTIONS:
+        return None
+    # Duplicates make the key ambiguous rather than wrong: a reader who picks
+    # the other identical option answered correctly and grades as incorrect.
+    if len(set(options)) != len(options):
+        return None
+
+    index = element.get("correct_index")
+    # `bool` is an `int` in Python, and `True` would index option 1 silently.
+    if isinstance(index, bool) or not isinstance(index, int):
+        return None
+    # Not `-len <= index < len`: a negative index is legal in Python and would
+    # quietly select from the end, but from a model it means nothing at all.
+    if not 0 <= index < len(options):
+        return None
+
+    return {"prompt": prompt, "options": options, "correct_index": index}
 
 
 class Study:
@@ -299,6 +390,92 @@ class Study:
         return DocumentOutline(nodes=nodes, source_document=_single_document(fragments))
 
 
+    def quiz(
+        self,
+        fragments: Sequence[Fragment],
+        config: AppConfig,
+        *,
+        language: Optional[str] = None,
+        question_count: int = _DEFAULT_QUESTION_COUNT,
+    ) -> Quiz:
+        """Write multiple-choice questions over ``fragments``.
+
+        Args:
+            fragments: Evidence to question, already ranked by the caller.
+            config: Read fresh on every call, as in ``summarize``.
+            language: Language for the questions. ``None`` follows the
+                material.
+            question_count: How many to ask for. The model may return fewer
+                if the material does not support that many, which is not an
+                error -- padding would mean inventing questions.
+
+        Returns:
+            A ``Quiz``. Empty input gives an empty quiz without calling the
+            generator.
+
+        Raises:
+            ValueError: ``question_count`` is outside 1..20. Checked before
+                the model is called, because a bad count is the caller's bug
+                and spending a generation on it hides that.
+            MalformedQuizError: The reply is not JSON, is not an array, or
+                held no question safe to grade against.
+            Exception: Whatever the chat model raises (hard-fail policy).
+        """
+        if not 1 <= question_count <= _MAX_QUESTION_COUNT:
+            raise ValueError(
+                f"question_count must be between 1 and {_MAX_QUESTION_COUNT}, got {question_count}"
+            )
+        if not fragments:
+            return Quiz(questions=(), source_document="")
+
+        context, _metrics = build_context_for_model(
+            list(fragments), config.flags.usar_optimizacion_contexto
+        )
+        instruction = (
+            f"Write {question_count} multiple-choice questions about the following material."
+        )
+        if language:
+            instruction += f" Write the questions and options in {language}."
+
+        raw = self._chat_model.generate(
+            f"{instruction}\n\n{context}", system=_QUIZ_SYSTEM_PROMPT
+        )
+
+        try:
+            decoded = json.loads(_strip_fence(raw))
+        except (json.JSONDecodeError, TypeError) as exc:
+            raise MalformedQuizError(
+                f"generator did not return JSON: {exc}. First 200 characters: {raw[:200]!r}"
+            ) from exc
+        if not isinstance(decoded, list):
+            raise MalformedQuizError(
+                f"expected a JSON array of questions, got {type(decoded).__name__}"
+            )
+
+        usable = [fields for fields in map(_usable_question, decoded) if fields is not None]
+        if not usable:
+            raise MalformedQuizError(
+                "no question carried a prompt, distinct options and an in-range key "
+                f"({len(decoded)} element(s) returned)"
+            )
+
+        # Same coarse attribution as summarize: the whole retrieval's pages
+        # per question. Asking the model which fragment it used would buy
+        # precision at the price of confident, wrong page numbers -- and here
+        # a reader follows the citation precisely when they doubt the key.
+        pages = _pages_of(fragments)
+        questions = tuple(
+            QuizQuestion(
+                prompt=fields["prompt"],
+                options=tuple(fields["options"]),
+                correct_index=fields["correct_index"],
+                source_pages=pages,
+            )
+            for fields in usable[:question_count]
+        )
+        return Quiz(questions=questions, source_document=_single_document(fragments))
+
+
 def _build_outline_nodes(elements: Any, depth: int, budget: List[int]) -> Tuple[OutlineNode, ...]:
     """Turn decoded JSON into nodes, bounded in both depth and total count.
 
@@ -360,5 +537,25 @@ def summary_to_dict(summary: DocumentSummary) -> Dict[str, Any]:
                 "source_pages": list(section.source_pages),
             }
             for section in summary.sections
+        ],
+    }
+
+
+def quiz_to_dict(quiz: Quiz) -> Dict[str, Any]:
+    """Plain-JSON view for an interface layer.
+
+    Lives here for the same reason ``summary_to_dict`` does: one shape for the
+    artifact, so the CLI and the web app cannot drift into two.
+    """
+    return {
+        "source_document": quiz.source_document,
+        "questions": [
+            {
+                "prompt": question.prompt,
+                "options": list(question.options),
+                "correct_index": question.correct_index,
+                "source_pages": list(question.source_pages),
+            }
+            for question in quiz.questions
         ],
     }

--- a/src/monkeygrab/domain/document_summary.py
+++ b/src/monkeygrab/domain/document_summary.py
@@ -91,3 +91,47 @@ class DocumentOutline:
     @property
     def is_empty(self) -> bool:
         return not self.nodes
+
+
+@dataclasses.dataclass(frozen=True)
+class QuizQuestion:
+    """One multiple-choice question, with the evidence its answer rests on.
+
+    Attributes:
+        prompt: The question text.
+        options: Answer choices, in the order they are shown. Order is part
+            of the artifact: ``correct_index`` points into it, so a caller
+            that reorders them silently invalidates the key.
+        correct_index: Position in ``options`` of the correct choice.
+        source_pages: Pages the question was written from, ascending and
+            deduplicated -- the same contract as ``SummarySection``, so a
+            reader can go and check the claim the question tests.
+    """
+
+    prompt: str
+    options: Tuple[str, ...]
+    correct_index: int
+    source_pages: Tuple[int, ...] = ()
+
+    @property
+    def correct_option(self) -> str:
+        """The text of the correct choice."""
+        return self.options[self.correct_index]
+
+
+@dataclasses.dataclass(frozen=True)
+class Quiz:
+    """A set of questions over one retrieval.
+
+    Attributes:
+        questions: In the order the generator produced them.
+        source_document: As in ``DocumentSummary`` -- "" when the evidence
+            spans more than one document.
+    """
+
+    questions: Tuple[QuizQuestion, ...]
+    source_document: str = ""
+
+    @property
+    def is_empty(self) -> bool:
+        return not self.questions

--- a/tests/unit/application/test_study_quiz.py
+++ b/tests/unit/application/test_study_quiz.py
@@ -1,0 +1,249 @@
+"""Study.quiz: what a question has to carry before it is worth asking.
+
+Issue #140. The summary parse asks "can a reader use this". A quiz needs a
+stricter question, because its failure mode is different in kind: a summary
+section that is thin is merely thin, while a question whose key points at the
+wrong option *teaches the reader something false*, and does it with the
+authority of an answer key. The reader has no way to tell it apart from a
+correct one -- that is the whole reason they are taking the quiz.
+
+So the line here is drawn at "is this question safe to grade", and everything
+below is about where exactly that falls.
+
+Against a doubled ``ChatModel``: no GPU, no Ollama, no network, so this runs
+in the fast gate's dependency-free job like the rest of ``application/``.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+for path in (str(ROOT), str(ROOT / "src")):
+    if path not in sys.path:
+        sys.path.insert(0, path)
+
+from monkeygrab.application.study import (  # noqa: E402
+    MalformedQuizError,
+    Study,
+    quiz_to_dict,
+)
+from monkeygrab.config.app_config import AppConfig  # noqa: E402
+from monkeygrab.domain.chunk_metadata import ChunkMetadata  # noqa: E402
+from monkeygrab.domain.fragment import Fragment  # noqa: E402
+
+
+class _FakeChatModel:
+    """Returns a canned reply and records what it was asked."""
+
+    def __init__(self, reply="[]"):
+        self.reply = reply
+        self.calls = []
+
+    def generate(self, prompt, *, system=None, images=()):
+        self.calls.append({"prompt": prompt, "system": system})
+        if isinstance(self.reply, Exception):
+            raise self.reply
+        return self.reply
+
+    def stream(self, prompt, *, system=None):  # pragma: no cover - unused here
+        raise NotImplementedError
+
+
+class _ExplodingChatModel:
+    def generate(self, *args, **kwargs):
+        raise AssertionError("the generator must not be called")
+
+    def stream(self, *args, **kwargs):  # pragma: no cover
+        raise NotImplementedError
+
+
+def _fragment(source="paper.pdf", page=1, text="Some retrieved text."):
+    return Fragment(doc=text, metadata=ChunkMetadata(source=source, page=page))
+
+
+_TWO_QUESTIONS = (
+    '[{"prompt": "What does BM25 rank?", '
+    '"options": ["Documents", "Images", "Users"], "correct_index": 0},'
+    ' {"prompt": "What fuses the two rankings?", '
+    '"options": ["RRF", "FAISS"], "correct_index": 0}]'
+)
+
+
+class TestTheHappyPath:
+    def test_questions_keep_the_generators_order(self):
+        study = Study(_FakeChatModel(_TWO_QUESTIONS))
+        quiz = study.quiz([_fragment()], AppConfig.from_env())
+        assert [q.prompt for q in quiz.questions] == [
+            "What does BM25 rank?",
+            "What fuses the two rankings?",
+        ]
+
+    def test_the_key_points_at_the_option_it_named(self):
+        study = Study(_FakeChatModel(_TWO_QUESTIONS))
+        quiz = study.quiz([_fragment()], AppConfig.from_env())
+        assert quiz.questions[0].correct_option == "Documents"
+
+    def test_each_question_carries_the_pages_the_evidence_came_from(self):
+        study = Study(_FakeChatModel(_TWO_QUESTIONS))
+        quiz = study.quiz(
+            [_fragment(page=7), _fragment(page=3), _fragment(page=7)],
+            AppConfig.from_env(),
+        )
+        assert all(q.source_pages == (3, 7) for q in quiz.questions)
+
+    def test_a_requested_language_reaches_the_prompt(self):
+        model = _FakeChatModel(_TWO_QUESTIONS)
+        Study(model).quiz([_fragment()], AppConfig.from_env(), language="Castellano")
+        assert "Castellano" in model.calls[0]["prompt"]
+
+    def test_the_requested_count_reaches_the_prompt(self):
+        model = _FakeChatModel(_TWO_QUESTIONS)
+        Study(model).quiz([_fragment()], AppConfig.from_env(), question_count=3)
+        assert "3" in model.calls[0]["prompt"]
+
+    def test_the_format_instruction_goes_in_the_system_prompt(self):
+        # Same split as summarize: format is a standing instruction about the
+        # reply, not part of the request, so it does not compete with the
+        # material for the model's attention in the user turn.
+        model = _FakeChatModel(_TWO_QUESTIONS)
+        Study(model).quiz([_fragment()], AppConfig.from_env())
+        assert "JSON" in (model.calls[0]["system"] or "")
+
+    def test_a_fenced_reply_is_unwrapped(self):
+        study = Study(_FakeChatModel(f"```json\n{_TWO_QUESTIONS}\n```"))
+        quiz = study.quiz([_fragment()], AppConfig.from_env())
+        assert len(quiz.questions) == 2
+
+
+class TestAnAnswerKeyItRefusesToTrust:
+    """The cases that separate this parse from the summary's.
+
+    Each of these would parse fine as data. They are dropped because grading a
+    reader against them would be wrong, not because the JSON is bad.
+    """
+
+    def test_an_out_of_range_key_drops_the_question_rather_than_repairing_it(self):
+        # Falling back to 0 would produce a question that looks answerable and
+        # grades the reader against an option the model never chose. There is
+        # no evidence for which option was meant, so there is nothing to fix.
+        study = Study(
+            _FakeChatModel(
+                '[{"prompt": "Bad key", "options": ["A", "B"], "correct_index": 5},'
+                ' {"prompt": "Good one", "options": ["A", "B"], "correct_index": 1}]'
+            )
+        )
+        quiz = study.quiz([_fragment()], AppConfig.from_env())
+        assert [q.prompt for q in quiz.questions] == ["Good one"]
+
+    def test_a_negative_key_is_not_read_as_a_python_index(self):
+        # -1 is a legal Python index and would silently select the last
+        # option. From the model it means nothing of the sort.
+        study = Study(
+            _FakeChatModel('[{"prompt": "Q", "options": ["A", "B"], "correct_index": -1}]')
+        )
+        with pytest.raises(MalformedQuizError):
+            study.quiz([_fragment()], AppConfig.from_env())
+
+    def test_a_non_integer_key_drops_the_question(self):
+        study = Study(
+            _FakeChatModel('[{"prompt": "Q", "options": ["A", "B"], "correct_index": "A"}]')
+        )
+        with pytest.raises(MalformedQuizError):
+            study.quiz([_fragment()], AppConfig.from_env())
+
+    def test_a_single_option_is_not_a_choice(self):
+        study = Study(_FakeChatModel('[{"prompt": "Q", "options": ["Only"], "correct_index": 0}]'))
+        with pytest.raises(MalformedQuizError):
+            study.quiz([_fragment()], AppConfig.from_env())
+
+    def test_duplicate_options_drop_the_question(self):
+        # Two identical choices make the key ambiguous: a reader picking the
+        # other "A" answered correctly and would be graded wrong.
+        study = Study(
+            _FakeChatModel('[{"prompt": "Q", "options": ["A", "A"], "correct_index": 0}]')
+        )
+        with pytest.raises(MalformedQuizError):
+            study.quiz([_fragment()], AppConfig.from_env())
+
+    def test_a_question_with_no_prompt_drops(self):
+        study = Study(_FakeChatModel('[{"prompt": "", "options": ["A", "B"], "correct_index": 0}]'))
+        with pytest.raises(MalformedQuizError):
+            study.quiz([_fragment()], AppConfig.from_env())
+
+
+class TestWhatItRefusesToGuess:
+    def test_malformed_json_raises_rather_than_returning_part_of_a_quiz(self):
+        study = Study(_FakeChatModel('[{"prompt": "Cut off", "options": ["A"'))
+        with pytest.raises(MalformedQuizError):
+            study.quiz([_fragment()], AppConfig.from_env())
+
+    def test_a_json_object_instead_of_an_array_raises(self):
+        study = Study(_FakeChatModel('{"prompt": "Just one", "options": ["A", "B"]}'))
+        with pytest.raises(MalformedQuizError):
+            study.quiz([_fragment()], AppConfig.from_env())
+
+    def test_a_generator_failure_propagates_untouched(self):
+        study = Study(_FakeChatModel(RuntimeError("ollama is down")))
+        with pytest.raises(RuntimeError, match="ollama is down"):
+            study.quiz([_fragment()], AppConfig.from_env())
+
+
+class TestBounds:
+    def test_more_questions_than_asked_for_are_truncated(self):
+        reply = "[" + ",".join(
+            f'{{"prompt": "Q{i}", "options": ["A", "B"], "correct_index": 0}}' for i in range(40)
+        ) + "]"
+        study = Study(_FakeChatModel(reply))
+        quiz = study.quiz([_fragment()], AppConfig.from_env(), question_count=5)
+        assert len(quiz.questions) == 5
+
+    def test_fewer_questions_than_asked_for_is_not_an_error(self):
+        # The material may not support five questions. Padding would mean
+        # inventing them, which is the one thing the prompt forbids.
+        study = Study(_FakeChatModel(_TWO_QUESTIONS))
+        quiz = study.quiz([_fragment()], AppConfig.from_env(), question_count=5)
+        assert len(quiz.questions) == 2
+
+    def test_a_nonsensical_count_is_rejected_before_the_model_is_called(self):
+        study = Study(_ExplodingChatModel())
+        with pytest.raises(ValueError):
+            study.quiz([_fragment()], AppConfig.from_env(), question_count=0)
+
+
+class TestSourceAttribution:
+    def test_one_document_is_named(self):
+        study = Study(_FakeChatModel(_TWO_QUESTIONS))
+        quiz = study.quiz(
+            [_fragment(source="planck.pdf"), _fragment(source="planck.pdf", page=2)],
+            AppConfig.from_env(),
+        )
+        assert quiz.source_document == "planck.pdf"
+
+    def test_several_documents_name_none_rather_than_the_first(self):
+        study = Study(_FakeChatModel(_TWO_QUESTIONS))
+        quiz = study.quiz(
+            [_fragment(source="a.pdf"), _fragment(source="b.pdf")], AppConfig.from_env()
+        )
+        assert quiz.source_document == ""
+
+
+class TestEmptyInput:
+    def test_no_fragments_gives_an_empty_quiz_without_calling_the_model(self):
+        quiz = Study(_ExplodingChatModel()).quiz([], AppConfig.from_env())
+        assert quiz.is_empty
+        assert quiz.source_document == ""
+
+
+class TestTheInterfaceView:
+    def test_the_dict_view_is_plain_json(self):
+        import json
+
+        study = Study(_FakeChatModel(_TWO_QUESTIONS))
+        quiz = study.quiz([_fragment(page=4)], AppConfig.from_env())
+        payload = quiz_to_dict(quiz)
+        assert json.loads(json.dumps(payload)) == payload
+        assert payload["questions"][0]["options"] == ["Documents", "Images", "Users"]
+        assert payload["questions"][0]["correct_index"] == 0
+        assert payload["questions"][0]["source_pages"] == [4]


### PR DESCRIPTION
## Summary

MonkeyGrab can now turn a corpus into a quiz, the third of the three artifacts
#140 asked for. The summary and the outline landed in #141 and #142; this
completes the set in the core.

`Study.quiz()` takes fragments the caller already retrieved, asks the generator
for multiple-choice questions as JSON, and returns a `Quiz` of `QuizQuestion`s
— each with its options, the index of the correct one, and the pages the
evidence came from.

**The design decision worth reviewing is how strict the parse is.** It is
stricter than `summarize` and `outline`, and deliberately so: the three fail
differently. An outline truncated at three levels still navigates. A summary
missing a section is visibly missing it. But a question whose key points at the
wrong option grades the reader against a falsehood *with the authority of an
answer key* — and verifying it is exactly what that reader was unable to do,
which is why they opened a quiz in the first place.

So a question is dropped, never repaired, when:

- `correct_index` is out of range, negative, non-integer, or a `bool`
  (`True` would silently index option 1; `-1` is a legal Python index that
  would quietly select the last option, and means nothing coming from a model)
- its options number fewer than two, more than six, or repeat one another
  (duplicates make the key ambiguous: a reader picking the other identical
  option answered correctly and would grade as wrong)
- it carries no prompt

Repairing any of those means guessing what the model meant and then shipping
the guess as an answer key. If no question survives, `MalformedQuizError` —
same boundary `summarize` draws, one notch tighter.

`correct_index` rather than the correct answer's text: a model that restates
the text introduces a second copy that can disagree with the option it names,
and nothing downstream can then tell which of the two is the answer.

## Issue

Part of #140. Does not close it: `Study.outline` and `Study.quiz` are both
implemented in the core but not reachable from the CLI or the web app yet.
That wiring follows in its own PR, as summaries did in #144.

## Test plan

- `tests/unit/application/test_study_quiz.py` — 23 cases against a doubled
  `ChatModel`. No GPU, no Ollama, no network, so it runs in the fast gate's
  dependency-free job like the rest of `application/`. The bulk of them are
  the answer-key cases above, one per way a question can look answerable and
  not be.
- Full local suite: **989 passed, 2 skipped**. `ruff check .` clean.
- Full gate not run and not needed: this touches neither retrieval nor
  generation of answers — no gold case exercises `Study`, and no existing
  path changed behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)