### PR TITLE
Report tokens per answer, so an inline reasoner reads as expensive (#146)

### DIFF
--- a/docs/model-history.md
+++ b/docs/model-history.md
@@ -37,16 +37,41 @@ version moved three (see "Stack drift" below).
 `gemma4:e4b` is the repo default. Cases are the 23 answered ones; the other
 42 never call a generator.
 
-| Model | Params / size | Answered cases passed | Median s/case | tokens/s | Run |
-|---|---|---|---|---|---|
-| `qwen3-coder-30b:latest` | 30B MoE, 10 GB | **21 / 23** | 41.7 | not recorded | `20260901T023915Z` |
-| `gemma4:e2b` | 7.2 GB | 20 / 23 | 38.7 | not recorded | `20260901T023915Z` |
-| `gemma4:e4b` *(default)* | 9.6 GB | 19 / 23 | 39.8 | not recorded | `20260901T023915Z` |
-| `qwen3:30b-a3b` | 30B MoE, 3B active, 18 GB | pending | | | in progress |
-| `qwen3:8b` | 8B dense, 5.2 GB | pending | | | in progress |
-| `mistral-small3.2:24b` | 24B dense, 15 GB | pending | | | in progress |
-| `gpt-oss:20b` | 20B MoE, 13 GB | not yet run | | | |
-| `granite4:small-h` | MoE, 19 GB | not yet run | | | |
+| Model | Params / size | Answered cases passed | Median s/case | tokens/s | tokens/answer | s/answer | Run |
+|---|---|---|---|---|---|---|---|
+| `qwen3-coder-30b:latest` | 30B MoE, 10 GB | **21 / 23** | 41.7 | not recorded | not recorded | not recorded | `20260901T023915Z` |
+| `gemma4:e2b` | 7.2 GB | 20 / 23 | 38.7 | not recorded | not recorded | not recorded | `20260901T023915Z` |
+| `gemma4:e4b` *(default)* | 9.6 GB | 19 / 23 | 39.8 | not recorded | not recorded | not recorded | `20260901T023915Z` |
+| `qwen3:30b-a3b` | 30B MoE, 3B active, 18 GB | pending | | | | | in progress |
+| `qwen3:8b` | 8B dense, 5.2 GB | pending | | | | | in progress |
+| `mistral-small3.2:24b` | 24B dense, 15 GB | pending | | | | | in progress |
+| `gpt-oss:20b` | 20B MoE, 13 GB | not yet run | | | | | |
+| `granite4:small-h` | MoE, 19 GB | not yet run | | | | | |
+
+**Speed is not latency, and this is the column that says so.** `tokens/s` is
+how fast a model decodes; `s/answer` is how long the user waits, and it is
+tokens divided by that rate. A model that reasons inline spends its budget
+before it starts answering, so the two columns can rank the same pair of models
+in opposite orders. Measured 2026-09-01, one representative prompt, `think:
+false`, `num_predict: 96`, `temperature: 0`:
+
+| Model | tokens/s | tokens used | s/answer |
+|---|---|---|---|
+| `qwen3-coder-30b:latest` | 43.5 | 5 | **0.11** |
+| `qwen3:30b-a3b` | 38.2 | 96 | **2.51** |
+
+Fourteen per cent apart on the column this table used to show; twenty-three
+times apart on the wait. Both answered correctly. `think: false` controls
+Ollama's *thinking channel* — the separate field a model emits its trace into —
+and does not stop a model whose chat template reasons inline from doing it in
+the body of the answer. Qwen3 does exactly that. Full analysis in issue #146.
+
+The second consequence is worse than the wait. At `num_predict: 96` the
+reasoning consumed the whole budget, and the answer survived by luck; a longer
+preamble truncates into something that grades as a plain `FAIL`,
+indistinguishable from the model not knowing. So a high `tokens/answer` is not
+only a cost, it is a **truncation risk**, and that is the number to check first
+when a capable model grades badly.
 
 **Why the tokens/s column is empty above.** The gate recorded
 `elapsed_seconds` per case, which includes the retrieval every model shares —
@@ -115,6 +140,19 @@ Run the gate, then read the artifact rather than the terminal:
 python tests/eval/run_eval.py --models <model> [<model>...]
 ```
 
-Aggregate `tokens_per_second` over records that have it, skipping those that
-do not — a missing key means the model reported no counts, and treating it as
-zero drags an average toward "slower" for a reason that is not real.
+Then let the tool read the artifact and print the row:
+
+```bash
+python tools/diagnostics/model_history_row.py tests/eval/runs/<artifact>.json
+```
+
+It reports the median of `tokens_per_second`, `eval_count` and their quotient
+per model, skipping records that lack the counts — a missing key means the
+model reported none, and treating it as zero drags the average toward "faster
+and cheaper" for a reason that is not real. When a model's medians come from
+fewer records than it answered, the row says so in the `tokens/answer` cell:
+three medians over two generations deserve less trust than over twenty-three,
+and a table that hides its denominator stops saying which it is.
+
+The median rather than the mean, because one runaway generation should not
+move a figure that goes into an append-only table.

--- a/tests/unit/test_model_history_row.py
+++ b/tests/unit/test_model_history_row.py
@@ -1,0 +1,93 @@
+"""The three numbers a model-history row reports, and what it refuses to say.
+
+Issue #146. The interesting behaviour here is not the arithmetic, it is what
+happens to records that carry no token statistics: they are skipped, never read
+as zero. Counting a model's unreported generation as "0 tokens" would make it
+the cheapest model in the table for the one reason that is not a measurement.
+"""
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from tools.diagnostics.model_history_row import format_rows, summarise  # noqa: E402
+
+
+def _record(model, passed=True, rate=None, count=None):
+    record = {"model": model, "passed": passed}
+    if rate is not None:
+        record["tokens_per_second"] = rate
+    if count is not None:
+        record["eval_count"] = count
+    return record
+
+
+class TestTheThreeNumbers:
+    def test_latency_is_the_tokens_divided_by_the_rate(self):
+        # The whole point of #146: 96 tokens at 38.2 tok/s is 2.51 s, and the
+        # table only ever showed the 38.2.
+        summary = summarise([_record("m", rate=38.2, count=96)])["m"]
+        assert summary["tokens_per_answer"] == 96
+        assert round(summary["seconds_per_answer"], 2) == 2.51
+
+    def test_a_faster_decoder_can_be_the_slower_model(self):
+        summary = summarise(
+            [_record("reasoner", rate=38.2, count=96), _record("terse", rate=43.5, count=5)]
+        )
+        assert summary["reasoner"]["tokens_per_second"] < summary["terse"]["tokens_per_second"]
+        assert summary["reasoner"]["seconds_per_answer"] > summary["terse"]["seconds_per_answer"]
+
+    def test_the_median_is_used_so_one_runaway_does_not_move_the_row(self):
+        records = [_record("m", rate=40, count=10) for _ in range(4)]
+        records.append(_record("m", rate=40, count=4000))
+        assert summarise(records)["m"]["tokens_per_answer"] == 10
+
+
+class TestWhatItRefusesToCount:
+    def test_records_without_statistics_are_skipped_not_read_as_zero(self):
+        summary = summarise([_record("m", rate=40, count=20), _record("m")])["m"]
+        assert summary["tokens_per_answer"] == 20
+        assert summary["answered"] == 2
+        assert summary["measured"] == 1
+
+    def test_a_model_that_reported_nothing_yields_no_figures(self):
+        summary = summarise([_record("m"), _record("m")])["m"]
+        assert summary["measured"] == 0
+        assert summary["tokens_per_answer"] is None
+        assert summary["seconds_per_answer"] is None
+
+    def test_a_rate_without_a_count_gives_no_latency(self):
+        # Half a pair cannot produce the number this tool exists to report.
+        summary = summarise([_record("m", rate=40)])["m"]
+        assert summary["measured"] == 0
+
+    def test_records_with_no_model_are_ignored(self):
+        assert summarise([{"passed": True}]) == {}
+
+
+class TestTheRow:
+    def test_an_unmeasured_column_says_so_rather_than_showing_a_number(self):
+        rows = format_rows(summarise([_record("m")]), "run-1")
+        assert "not recorded" in rows
+        assert "0" not in rows.split("|")[4]
+
+    def test_a_partial_denominator_is_shown(self):
+        # Three medians over 1 of 2 records deserve less trust than over 23,
+        # and the row has to say which it is.
+        rows = format_rows(summarise([_record("m", rate=40, count=20), _record("m")]), "run-1")
+        assert "*(of 1)*" in rows
+
+    def test_pass_counts_use_every_answered_case_not_only_measured_ones(self):
+        rows = format_rows(
+            summarise([_record("m", passed=True, rate=40, count=20), _record("m", passed=False)]),
+            "run-1",
+        )
+        assert "1 / 2" in rows
+
+    def test_a_model_with_nothing_measured_does_not_say_of_zero(self):
+        # "not recorded *(of 0)*" states the same absence twice.
+        rows = format_rows(summarise([_record("m")]), "run-1")
+        assert "*(of 0)*" not in rows

--- a/tools/diagnostics/model_history_row.py
+++ b/tools/diagnostics/model_history_row.py
@@ -1,0 +1,145 @@
+"""Turn a gate run artifact into the `docs/model-history.md` row for each model.
+
+Issue #146. The history table had one speed column, tokens/s, and that column
+ranks models in the wrong order.
+
+Latency per answer is tokens divided by rate, and a model that reasons inline
+spends tokens the flag was supposed to suppress. Measured 2026-09-01 on one
+representative prompt with `think: false`, `num_predict: 96`: `qwen3:30b-a3b`
+used 96 tokens at 38.2 tok/s (2.51 s) where `qwen3-coder-30b` used 5 at 43.5
+(0.11 s). Fourteen per cent apart on the column the table shows, twenty-three
+times apart on the wait the user actually sits through.
+
+So this reports three numbers per model, and the third is the one to read:
+
+    tokens/s          how fast it decodes
+    tokens/answer     how much it decides to say
+    s/answer          the product of the two -- the wait
+
+Aggregation is the median, not the mean: one truncated or one runaway
+generation should not move the figure that goes in a durable table.
+
+Records missing the counts are skipped rather than read as zero, matching
+`run_eval.record_generation_stats`, which omits the keys entirely when Ollama
+reports none. Counting those as zero would drag tokens/answer toward "cheap"
+for a reason that is not real.
+
+Usage:
+    python tools/diagnostics/model_history_row.py tests/eval/runs/<artifact>.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+def _median(values: List[float]) -> Optional[float]:
+    return statistics.median(values) if values else None
+
+
+def summarise(results: List[Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
+    """Per-model figures for the history table.
+
+    Args:
+        results: The artifact's ``results`` list, one record per case per model.
+
+    Returns:
+        Model name -> figures. ``answered`` counts the records that reached a
+        generator at all; ``measured`` counts the subset that also carried
+        token statistics, and the two differ whenever a model reported none.
+        Both are reported because a median over three records deserves less
+        trust than one over twenty-three, and hiding the denominator is how a
+        table stops saying that.
+    """
+    per_model: Dict[str, Dict[str, Any]] = {}
+    for record in results:
+        model = record.get("model")
+        if not model:
+            continue
+        entry = per_model.setdefault(
+            model,
+            {"answered": 0, "passed": 0, "rates": [], "counts": [], "seconds": []},
+        )
+        entry["answered"] += 1
+        if record.get("passed"):
+            entry["passed"] += 1
+        rate, count = record.get("tokens_per_second"), record.get("eval_count")
+        # Both or neither: a rate without a count cannot give a latency, and
+        # pairing them per record keeps the three medians describing the same
+        # generations rather than three different subsets.
+        if rate and count:
+            entry["rates"].append(float(rate))
+            entry["counts"].append(int(count))
+            entry["seconds"].append(float(count) / float(rate))
+
+    for entry in per_model.values():
+        entry["measured"] = len(entry["counts"])
+        entry["tokens_per_second"] = _median(entry["rates"])
+        entry["tokens_per_answer"] = _median([float(c) for c in entry["counts"]])
+        entry["seconds_per_answer"] = _median(entry["seconds"])
+        for key in ("rates", "counts", "seconds"):
+            del entry[key]
+    return per_model
+
+
+def _cell(value: Optional[float], digits: int) -> str:
+    return "not recorded" if value is None else f"{value:.{digits}f}".rstrip("0").rstrip(".")
+
+
+def format_rows(per_model: Dict[str, Dict[str, Any]], run_id: str) -> str:
+    """Markdown rows, ready to paste under the generators table."""
+    lines = [
+        "| Model | Answered cases passed | tokens/s | tokens/answer | s/answer | Run |",
+        "|---|---|---|---|---|---|",
+    ]
+    for model in sorted(per_model):
+        e = per_model[model]
+        # The denominator qualifies a median. With nothing measured there is no
+        # median to qualify, and "not recorded *(of 0)*" says it twice.
+        partial = 0 < e["measured"] < e["answered"]
+        suffix = f" *(of {e['measured']})*" if partial else ""
+        lines.append(
+            f"| `{model}` | {e['passed']} / {e['answered']} | "
+            f"{_cell(e['tokens_per_second'], 1)} | "
+            f"{_cell(e['tokens_per_answer'], 0)}{suffix} | "
+            f"{_cell(e['seconds_per_answer'], 2)} | `{run_id}` |"
+        )
+    return "\n".join(lines)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("artifact", type=Path, help="Gate run JSON under tests/eval/runs/")
+    args = parser.parse_args(argv)
+
+    payload = json.loads(args.artifact.read_text(encoding="utf-8"))
+    results = payload.get("results") or []
+    per_model = summarise(results)
+    if not per_model:
+        print(f"{args.artifact}: no per-model records found", file=sys.stderr)
+        return 1
+
+    run_id = (payload.get("run") or {}).get("id") or args.artifact.stem
+    print(format_rows(per_model, run_id))
+
+    unmeasured = [m for m, e in per_model.items() if not e["measured"]]
+    if unmeasured:
+        # Said out loud rather than left as an empty cell: artifacts written
+        # before #145 carry no token statistics at all, and an empty column
+        # there means "not recorded", never "fast".
+        print(
+            f"\nNo token statistics for: {', '.join(sorted(unmeasured))}. "
+            "Runs before 2026-09-01 predate them; leave those cells empty "
+            "rather than back-filling a number nobody measured.",
+            file=sys.stderr,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

`docs/model-history.md` had one speed column, `tokens/s`, and that column ranks
models in the wrong order.

Latency per answer is tokens ÷ rate, and the table only ever showed the rate.
Measured 2026-09-01, one representative prompt, `think: false`,
`num_predict: 96`:

| Model | tokens/s | tokens used | s/answer |
|---|---|---|---|
| `qwen3-coder-30b:latest` | 43.5 | 5 | **0.11** |
| `qwen3:30b-a3b` | 38.2 | 96 | **2.51** |

Fourteen per cent apart on the column shown, twenty-three times apart on the
wait. Both answered correctly. The faster-looking model is the slower one.

This is **option 3** of the issue — the one it argued for, on the grounds that
the other two need this measurement before they can be evaluated at all.
Nothing to configure, and a model that reasons inline becomes visible as
expensive rather than as fast.

`eval_count` has been recorded per generation since #145, so the data was
already being written and never read. What this adds:

- `tools/diagnostics/model_history_row.py` — reads a run artifact, prints the
  markdown row per model with `tokens/s`, `tokens/answer` and their quotient.
- Two columns in the generators table, plus the **"speed is not latency"**
  caveat the issue asked to sit beside the existing "speed is not quality".
- The truncation half written down, because it is the worse one: at
  `num_predict: 96` the reasoning consumed the whole budget and the answer
  survived by luck. A longer preamble truncates into a plain `FAIL`
  indistinguishable from the model not knowing — the exact confusion the
  `think=False` docstring exists to prevent, arriving through a door the flag
  does not cover. A high `tokens/answer` is therefore a truncation risk, not
  just a cost, and it is the first number to check when a capable model grades
  badly.

Two aggregation choices, both about not lying in a durable table: **medians**,
so one runaway generation cannot move a row; and records without counts are
**skipped, never read as zero** — that would make an unreported model the
cheapest in the table for the one reason that is not a measurement. When a
model's medians come from fewer records than it answered, the row prints the
denominator.

## Issue

Fixes #146.

## Test plan

- `tests/unit/test_model_history_row.py` — 11 cases. The arithmetic is the
  easy part; most of them are about what is *not* counted (missing counts, a
  rate without a count, a model that reported nothing) and about the row saying
  "not recorded" rather than showing a number.
- **Verified against a real artifact**, `tests/eval/runs/20260901T023915Z`:
  pass counts come out **21/23, 20/23, 19/23**, matching the rows already in
  the doc by hand — so the tool reads the artifact the same way the table's
  author did. The token columns correctly read "not recorded": that run
  predates #145.
- Full local suite: **1031 passed, 2 skipped**. `ruff check .` clean.
- Full gate not run and not needed: this reads artifacts, it does not change
  retrieval or generation. The columns fill from the next gate run onward;
  earlier rows stay empty rather than back-filled with a number nobody
  measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)