### PR TITLE
Bring the three Study artifacts to the web UI (#140)

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,10 @@ get an error instead of a quiz. A wrong key is the one failure here that would
 not look like one.
 
 The **web UI** adds document upload, per-role model assignment, the pipeline
-toggles, and an inline PDF viewer that opens cited sources at the right page.
+toggles, an inline PDF viewer that opens cited sources at the right page, and a
+**Study** panel with the same three artifacts as the CLI — pick a document,
+pick summary, outline or quiz. Quiz answers stay hidden until you ask for them,
+so the panel can be used to test yourself rather than just to read.
 Ollama is started automatically if it is installed but not running. Three fixed
 language stores — English, Castellano, Valencià — map to `rag/docs/{en,es,ca}/`.
 The `es` and `ca` stores ship with a few sample articles so a fresh clone has

--- a/rag/web/app.py
+++ b/rag/web/app.py
@@ -921,6 +921,69 @@ def api_topics():
     return jsonify({"ok": True, "topics": docs_data})
 
 
+# The three Study artifacts share one route because they share one shape:
+# pick a document, load its chunks, ask the generator for structure. Three
+# routes would have been three copies of the document lookup and three places
+# for the error contract to drift apart.
+_STUDY_KINDS = ("summary", "outline", "quiz")
+
+
+@app.route("/api/study", methods=["POST"])
+def api_study():
+    """Build a summary, an outline or a quiz over one indexed document.
+
+    Body: ``{"kind": "summary"|"outline"|"quiz", "document": str,
+    "language": str|None, "question_count": int|None}``.
+
+    A malformed generator reply comes back as 422 with ``kind: "malformed"``,
+    separate from a 500: the model ignored the format, which is actionable
+    (another model may not) and is not the server failing. The quiz raises
+    rather than returning questions whose answer key could not be verified,
+    so an empty panel here means "not safe to grade", never "nothing found".
+    """
+    data = request.get_json(silent=True) or {}
+    kind = str(data.get("kind") or "summary").strip().lower()
+    if kind not in _STUDY_KINDS:
+        return jsonify({"ok": False, "error": f"kind must be one of {', '.join(_STUDY_KINDS)}"}), 400
+
+    documento = str(data.get("document") or "").strip()
+    if not documento:
+        return jsonify({"ok": False, "error": "document is required"}), 400
+
+    idioma = data.get("language") or None
+    coll = _get_collection()
+    if documento not in rag_engine.obtener_documentos_indexados(coll):
+        return jsonify({"ok": False, "error": f"{documento} is not indexed"}), 404
+
+    fragmentos = rag_engine.fragmentos_de_documento(documento)
+    if not fragmentos:
+        return jsonify({"ok": False, "error": f"{documento} has no indexed fragments"}), 409
+
+    try:
+        if kind == "summary":
+            artifact = rag_engine.resumir_fragmentos(fragmentos, idioma=idioma)
+        elif kind == "outline":
+            artifact = rag_engine.esquema_de_fragmentos(fragmentos, idioma=idioma)
+        else:
+            count = data.get("question_count")
+            kwargs = {"idioma": idioma}
+            if count is not None:
+                kwargs["num_preguntas"] = int(count)
+            artifact = rag_engine.cuestionario_de_fragmentos(fragmentos, **kwargs)
+    except (
+        rag_engine.MalformedSummaryError,
+        rag_engine.MalformedOutlineError,
+        rag_engine.MalformedQuizError,
+    ) as exc:
+        return jsonify({"ok": False, "kind": "malformed", "error": str(exc)[:400]}), 422
+    except ValueError as exc:
+        return jsonify({"ok": False, "error": str(exc)}), 400
+    except Exception as exc:  # noqa: BLE001
+        return jsonify({"ok": False, "error": str(exc)[:400]}), 500
+
+    return jsonify({"ok": True, "kind": kind, "artifact": artifact})
+
+
 @app.route("/api/reindex", methods=["POST"])
 def api_reindex():
     """Re-index everything with the current pipeline settings.

--- a/rag/web/frontend/src/App.tsx
+++ b/rag/web/frontend/src/App.tsx
@@ -1419,7 +1419,9 @@ export default function App() {
       { id: 'outline', label: T.studyOutline },
       { id: 'quiz', label: T.studyQuiz },
     ];
-    const pages = studyResult?.sections?.flatMap(x => x.source_pages ?? [])
+    // Annotated: the chain of ?? over two optional arrays leaves tsc inferring
+    // never[], which then makes the numeric sort below an error.
+    const pages: number[] = studyResult?.sections?.flatMap(x => x.source_pages ?? [])
       ?? studyResult?.questions?.flatMap(x => x.source_pages ?? []) ?? [];
     const uniquePages = Array.from(new Set(pages)).sort((a, b) => a - b);
 

--- a/rag/web/frontend/src/App.tsx
+++ b/rag/web/frontend/src/App.tsx
@@ -131,6 +131,15 @@ const STRINGS = {
     indexingFailed: 'La indexación no pudo completarse.',
     noResults: 'No se encontró información relevante en los documentos.',
     tabModels: 'Modelos',
+    tabStudy: 'Estudiar',
+    studyPick: 'Elige un documento',
+    studySummary: 'Resumen', studyOutline: 'Esquema', studyQuiz: 'Cuestionario',
+    studyRun: 'Generar', studyWorking: 'Trabajando sobre {doc}...',
+    studyEmpty: 'Elige un documento y qué quieres hacer con él.',
+    studyPages: 'Páginas', studyAnswer: 'Respuesta', studyShowAnswers: 'Ver respuestas',
+    studyMalformed: 'El modelo no respetó el formato. Prueba otra vez, o con otro modelo.',
+    studyFailed: 'No se pudo generar: {error}',
+    studyNoDocs: 'No hay documentos indexados todavía.',
     storesLabel: 'Almacén vectorial',
     storeNotIndexed: 'sin indexar',
     storeEmptyHint: 'Almacén vacío. Sube PDFs y reindexa para activarlo.',
@@ -200,6 +209,15 @@ const STRINGS = {
     indexingFailed: 'Indexing could not be completed.',
     noResults: 'No relevant information found in the documents.',
     tabModels: 'Models',
+    tabStudy: 'Study',
+    studyPick: 'Pick a document',
+    studySummary: 'Summary', studyOutline: 'Outline', studyQuiz: 'Quiz',
+    studyRun: 'Generate', studyWorking: 'Working on {doc}...',
+    studyEmpty: 'Pick a document and what you want done with it.',
+    studyPages: 'Pages', studyAnswer: 'Answer', studyShowAnswers: 'Show answers',
+    studyMalformed: 'The model did not follow the format. Try again, or another model.',
+    studyFailed: 'Could not generate: {error}',
+    studyNoDocs: 'Nothing indexed yet.',
     storesLabel: 'Vector store',
     storeNotIndexed: 'not indexed',
     storeEmptyHint: 'Empty store. Upload PDFs and re-index to activate it.',
@@ -269,6 +287,15 @@ const STRINGS = {
     indexingFailed: "La indexació no s'ha pogut completar.",
     noResults: "No s'ha trobat informació rellevant als documents.",
     tabModels: 'Models',
+    tabStudy: 'Estudiar',
+    studyPick: 'Tria un document',
+    studySummary: 'Resum', studyOutline: 'Esquema', studyQuiz: 'Qüestionari',
+    studyRun: 'Generar', studyWorking: 'Treballant sobre {doc}...',
+    studyEmpty: 'Tria un document i què vols que en faça.',
+    studyPages: 'Pàgines', studyAnswer: 'Resposta', studyShowAnswers: 'Veure respostes',
+    studyMalformed: 'El model no ha respectat el format. Prova una altra vegada, o amb un altre model.',
+    studyFailed: 'No s\'ha pogut generar: {error}',
+    studyNoDocs: 'Encara no hi ha documents indexats.',
     storesLabel: 'Magatzem vectorial',
     storeNotIndexed: 'sense indexar',
     storeEmptyHint: 'Magatzem buit. Puja PDFs i reindexa per a activar-lo.',
@@ -310,6 +337,16 @@ function fill(tpl: string, vars: Record<string, string | number>): string {
 // =============================================================================
 
 const API_BASE = '/api';
+
+type StudyKind = 'summary' | 'outline' | 'quiz';
+
+interface OutlineNode { title: string; children: OutlineNode[]; }
+interface StudyArtifact {
+  source_document?: string;
+  sections?: { heading: string; body: string; source_pages: number[] }[];
+  nodes?: OutlineNode[];
+  questions?: { prompt: string; options: string[]; correct_index: number; source_pages: number[] }[];
+}
 
 const api = {
   init: () =>
@@ -395,6 +432,17 @@ const api = {
 
   deleteDoc: (filename: string) =>
     fetch(`${API_BASE}/docs/${encodeURIComponent(filename)}`, { method: 'DELETE' }).then(r => r.json()),
+
+  // One call for the three artifacts, mirroring the single route. The status
+  // code is kept: 422 means the model ignored the format, which the panel
+  // reports differently from a server failure because the user's next move
+  // differs too (retry or change model, versus check the backend).
+  study: (kind: StudyKind, document: string, language: string, questionCount?: number) =>
+    fetch(`${API_BASE}/study`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ kind, document, language, question_count: questionCount }),
+    }).then(async r => ({ status: r.status, body: await r.json() })),
 };
 
 // =============================================================================
@@ -714,8 +762,16 @@ export default function App() {
   const [pdfViewer, setPdfViewer] = useState<{ doc: string; page: number; mode: 'full' | 'split' } | null>(null);
   // Full-area overlay panels (Models / Pipeline) shown in the main column, like
   // the PDF viewer. Opening one closes any open PDF; closing returns to chat.
-  const [mainPanel, setMainPanel] = useState<'models' | 'pipeline' | null>(null);
-  const openMainPanel = useCallback((panel: 'models' | 'pipeline') => {
+  const [mainPanel, setMainPanel] = useState<'models' | 'pipeline' | 'study' | null>(null);
+  const [studyKind, setStudyKind] = useState<StudyKind>('summary');
+  const [studyDoc, setStudyDoc] = useState<string>('');
+  const [studyBusy, setStudyBusy] = useState(false);
+  const [studyResult, setStudyResult] = useState<StudyArtifact | null>(null);
+  const [studyError, setStudyError] = useState<string | null>(null);
+  // Answers hidden by default: a quiz whose key is on screen from the first
+  // render is a summary with extra steps.
+  const [studyRevealed, setStudyRevealed] = useState(false);
+  const openMainPanel = useCallback((panel: 'models' | 'pipeline' | 'study') => {
     setPdfViewer(null);
     setMainPanel(panel);
     if (window.innerWidth < 768) setIsSidebarOpen(false);
@@ -1319,6 +1375,171 @@ export default function App() {
     </div>
   );
 
+  const runStudy = async () => {
+    if (!studyDoc || studyBusy) return;
+    setStudyBusy(true);
+    setStudyError(null);
+    setStudyResult(null);
+    setStudyRevealed(false);
+    try {
+      const langName = lang === 'en' ? 'English' : lang === 'ca' ? 'Valencià' : 'Castellano';
+      const { status, body } = await api.study(studyKind, studyDoc, langName);
+      if (status === 200 && body.ok) {
+        setStudyResult(body.artifact as StudyArtifact);
+      } else if (status === 422) {
+        // Told apart from a server failure on purpose: the user's next move is
+        // "try again or change model", not "check the backend".
+        setStudyError(T.studyMalformed);
+      } else {
+        setStudyError(fill(T.studyFailed, { error: String(body.error ?? status) }));
+      }
+    } catch (e) {
+      setStudyError(fill(T.studyFailed, { error: String(e) }));
+    } finally {
+      setStudyBusy(false);
+    }
+  };
+
+  const renderOutlineNodes = (nodes: OutlineNode[], depth = 0) => (
+    <ul className={depth === 0 ? 'space-y-1' : 'space-y-1 mt-1'}>
+      {nodes.map((node, i) => (
+        <li key={`${depth}-${i}-${node.title}`} style={{ paddingLeft: depth * 18 }}>
+          <span className={depth === 0 ? 'text-[var(--text)] font-semibold' : 'text-[var(--text-muted)]'}>
+            {node.title}
+          </span>
+          {node.children?.length ? renderOutlineNodes(node.children, depth + 1) : null}
+        </li>
+      ))}
+    </ul>
+  );
+
+  const renderStudyPanel = () => {
+    const kinds: { id: StudyKind; label: string }[] = [
+      { id: 'summary', label: T.studySummary },
+      { id: 'outline', label: T.studyOutline },
+      { id: 'quiz', label: T.studyQuiz },
+    ];
+    const pages = studyResult?.sections?.flatMap(x => x.source_pages ?? [])
+      ?? studyResult?.questions?.flatMap(x => x.source_pages ?? []) ?? [];
+    const uniquePages = Array.from(new Set(pages)).sort((a, b) => a - b);
+
+    return (
+      <div className="space-y-6 max-w-3xl">
+        <div className="space-y-2">
+          <label className="block text-[10px] font-bold text-[var(--text-muted)] uppercase tracking-widest">
+            {T.studyPick}
+          </label>
+          {documents.length === 0 ? (
+            <p className="text-sm text-[var(--text-muted)]">{T.studyNoDocs}</p>
+          ) : (
+            <select
+              value={studyDoc}
+              onChange={e => { setStudyDoc(e.target.value); setStudyResult(null); setStudyError(null); }}
+              className="w-full bg-[var(--surface)] border border-[var(--border)] px-3 py-2 text-sm text-[var(--text)]"
+            >
+              <option value="">—</option>
+              {documents.map(doc => <option key={doc} value={doc}>{doc}</option>)}
+            </select>
+          )}
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          {kinds.map(k => (
+            <button
+              key={k.id}
+              type="button"
+              onClick={() => { setStudyKind(k.id); setStudyResult(null); setStudyError(null); }}
+              className={`px-3 py-2 text-xs font-semibold border transition-colors ${
+                studyKind === k.id
+                  ? 'bg-[var(--surface-2)] text-[var(--text)] border-[var(--border)]'
+                  : 'bg-[var(--surface)] text-[var(--text-muted)] border-[var(--border)] hover:text-[var(--text)]'
+              }`}
+            >
+              {k.label}
+            </button>
+          ))}
+          <button
+            type="button"
+            onClick={runStudy}
+            disabled={!studyDoc || studyBusy}
+            className="px-4 py-2 text-xs font-semibold border border-[var(--border)] bg-[var(--surface-2)] text-[var(--text)] disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            {studyBusy ? fill(T.studyWorking, { doc: studyDoc }) : T.studyRun}
+          </button>
+        </div>
+
+        {studyError && (
+          <div className="border border-[var(--border)] bg-[var(--surface)] p-4 text-sm text-[var(--text)]">
+            {studyError}
+          </div>
+        )}
+
+        {!studyResult && !studyError && !studyBusy && (
+          <p className="text-sm text-[var(--text-muted)]">{T.studyEmpty}</p>
+        )}
+
+        {studyResult && (
+          <div className="border border-[var(--border)] bg-[var(--surface)] p-5 space-y-4">
+            {studyResult.source_document && (
+              <div className="text-[10px] font-bold text-[var(--text-muted)] uppercase tracking-widest">
+                {studyResult.source_document}
+              </div>
+            )}
+
+            {studyResult.sections?.map((section, i) => (
+              <div key={i} className="space-y-1">
+                {section.heading && <h3 className="t-h3 text-[var(--text)]">{section.heading}</h3>}
+                <p className="text-sm text-[var(--text-muted)] leading-relaxed">{section.body}</p>
+              </div>
+            ))}
+
+            {studyResult.nodes && renderOutlineNodes(studyResult.nodes)}
+
+            {studyResult.questions && (
+              <div className="space-y-5">
+                {studyResult.questions.map((q, i) => (
+                  <div key={i} className="space-y-1.5">
+                    <p className="text-sm font-semibold text-[var(--text)]">{i + 1}. {q.prompt}</p>
+                    <ul className="space-y-1">
+                      {q.options.map((option, j) => (
+                        <li
+                          key={j}
+                          className={`text-sm pl-4 ${
+                            studyRevealed && j === q.correct_index
+                              ? 'text-[var(--text)] font-semibold'
+                              : 'text-[var(--text-muted)]'
+                          }`}
+                        >
+                          {String.fromCharCode(97 + j)}) {option}
+                          {studyRevealed && j === q.correct_index && ` — ${T.studyAnswer}`}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ))}
+                {!studyRevealed && (
+                  <button
+                    type="button"
+                    onClick={() => setStudyRevealed(true)}
+                    className="px-3 py-2 text-xs font-semibold border border-[var(--border)] bg-[var(--surface-2)] text-[var(--text)]"
+                  >
+                    {T.studyShowAnswers}
+                  </button>
+                )}
+              </div>
+            )}
+
+            {uniquePages.length > 0 && (
+              <div className="pt-2 text-xs text-[var(--text-muted)] border-t border-[var(--border)]">
+                {T.studyPages}: {uniquePages.join(', ')}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    );
+  };
+
   const renderPipelinePanel = () => (
     <div className="mx-auto w-full max-w-4xl space-y-4">
       {(settingsError || isReindexing) && (
@@ -1475,6 +1696,12 @@ export default function App() {
             >
               {T.tabPipeline}
             </button>
+            <button
+              className={`flex-1 py-2 text-xs font-semibold transition-all ${mainPanel === 'study' ? 'bg-[var(--surface-2)] text-[var(--text)]' : 'text-[var(--text-muted)] hover:text-[var(--text)]'}`}
+              onClick={() => openMainPanel('study')}
+            >
+              {T.tabStudy}
+            </button>
           </div>
         </div>
 
@@ -1602,7 +1829,9 @@ export default function App() {
                 {mainPanel === 'models'
                   ? <Ollama className="w-5 h-5 flex-shrink-0 text-[var(--text)]" />
                   : <Database className="w-5 h-5 flex-shrink-0" />}
-                <h2 className="t-h2 text-[var(--text)] truncate">{mainPanel === 'models' ? T.tabModels : T.tabPipeline}</h2>
+                <h2 className="t-h2 text-[var(--text)] truncate">
+                  {mainPanel === 'models' ? T.tabModels : mainPanel === 'study' ? T.tabStudy : T.tabPipeline}
+                </h2>
               </div>
               <button
                 type="button"
@@ -1615,7 +1844,7 @@ export default function App() {
               </button>
             </header>
             <div className="flex-1 overflow-y-auto p-6 md:p-8 custom-scrollbar">
-              {mainPanel === 'models' ? renderModelsPanel() : renderPipelinePanel()}
+              {mainPanel === 'models' ? renderModelsPanel() : mainPanel === 'study' ? renderStudyPanel() : renderPipelinePanel()}
             </div>
           </div>
         )}

--- a/tests/test_web_study_route.py
+++ b/tests/test_web_study_route.py
@@ -1,0 +1,153 @@
+"""/api/study: one route, three artifacts, and the status codes that separate them.
+
+Issue #140. The core builds the artifacts and the CLI already calls them; this
+is the web layer's half. What matters here is not that a summary comes back —
+that is the core's job and is tested there — but that the four ways this can
+fail come back as four different answers.
+
+The one worth stating: a generator that ignores the format is **422**, not 500.
+It is not the server failing, it is the model replying in a shape the parse
+refuses, and a UI should tell the user "try again, or another model" rather
+than "something broke". For the quiz that distinction carries more: the core
+raises rather than hand back questions whose answer key it could not verify, so
+422 there means "not safe to grade you against", never "nothing found".
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from monkeygrab.application.study import (  # noqa: E402
+    MalformedOutlineError,
+    MalformedQuizError,
+    MalformedSummaryError,
+)
+from rag.web import app as web  # noqa: E402
+
+
+@pytest.fixture
+def client():
+    web.app.config["TESTING"] = True
+    with web.app.test_client() as c:
+        yield c
+
+
+@pytest.fixture
+def stub(monkeypatch):
+    """Point the route at doubles: no FAISS, no Ollama, no GPU."""
+    state = {"fragments": [{"doc": "text"}], "raises": {}, "calls": []}
+
+    monkeypatch.setattr(web, "_get_collection", lambda: object())
+    monkeypatch.setattr(
+        web.rag_engine, "obtener_documentos_indexados", lambda coll: ["paper.pdf"]
+    )
+    monkeypatch.setattr(
+        web.rag_engine, "fragmentos_de_documento", lambda name: state["fragments"]
+    )
+
+    def _artifact(kind, marker):
+        def call(fragmentos, **kwargs):
+            state["calls"].append((kind, kwargs))
+            if kind in state["raises"]:
+                raise state["raises"][kind]
+            return {"marker": marker}
+
+        return call
+
+    monkeypatch.setattr(web.rag_engine, "resumir_fragmentos", _artifact("summary", "s"))
+    monkeypatch.setattr(web.rag_engine, "esquema_de_fragmentos", _artifact("outline", "o"))
+    monkeypatch.setattr(web.rag_engine, "cuestionario_de_fragmentos", _artifact("quiz", "q"))
+    return state
+
+
+def _post(client, **body):
+    body.setdefault("document", "paper.pdf")
+    return client.post("/api/study", json=body)
+
+
+class TestTheThreeArtifacts:
+    @pytest.mark.parametrize("kind, marker", [("summary", "s"), ("outline", "o"), ("quiz", "q")])
+    def test_each_kind_reaches_its_own_engine_call(self, client, stub, kind, marker):
+        response = _post(client, kind=kind)
+
+        assert response.status_code == 200
+        assert response.json["artifact"] == {"marker": marker}
+        assert response.json["kind"] == kind
+        assert [c[0] for c in stub["calls"]] == [kind]
+
+    def test_summary_is_the_default_kind(self, client, stub):
+        assert _post(client).json["kind"] == "summary"
+
+    def test_the_language_reaches_the_engine(self, client, stub):
+        _post(client, kind="outline", language="Valencià")
+        assert stub["calls"][0][1]["idioma"] == "Valencià"
+
+    def test_the_question_count_reaches_the_quiz_only_when_asked(self, client, stub):
+        _post(client, kind="quiz", question_count=7)
+        assert stub["calls"][0][1]["num_preguntas"] == 7
+
+    def test_an_omitted_count_leaves_the_core_default_alone(self, client, stub):
+        # Passing None through would override the use case's own default with
+        # a value the caller never chose.
+        _post(client, kind="quiz")
+        assert "num_preguntas" not in stub["calls"][0][1]
+
+
+class TestTheFourWaysThisFails:
+    def test_an_unknown_kind_is_rejected_before_any_work(self, client, stub):
+        response = _post(client, kind="haiku")
+        assert response.status_code == 400
+        assert stub["calls"] == []
+
+    def test_a_missing_document_is_rejected_before_any_work(self, client, stub):
+        response = client.post("/api/study", json={"kind": "summary"})
+        assert response.status_code == 400
+        assert stub["calls"] == []
+
+    def test_an_unindexed_document_is_404_not_500(self, client, stub):
+        response = _post(client, document="no-existe.pdf")
+        assert response.status_code == 404
+        assert stub["calls"] == []
+
+    def test_a_document_with_no_fragments_is_409(self, client, stub):
+        stub["fragments"] = []
+        response = _post(client)
+        assert response.status_code == 409
+        assert stub["calls"] == []
+
+    @pytest.mark.parametrize(
+        "kind, error",
+        [
+            ("summary", MalformedSummaryError("not json")),
+            ("outline", MalformedOutlineError("not json")),
+            ("quiz", MalformedQuizError("no usable question")),
+        ],
+    )
+    def test_a_malformed_reply_is_422_and_says_so(self, client, stub, kind, error):
+        stub["raises"][kind] = error
+        response = _post(client, kind=kind)
+
+        # 422 rather than 500: the model ignored the format, the server did not
+        # break, and the UI should offer a retry rather than an apology.
+        assert response.status_code == 422
+        assert response.json["kind"] == "malformed"
+
+    def test_a_bad_question_count_is_400_not_500(self, client, stub):
+        stub["raises"]["quiz"] = ValueError("question_count must be between 1 and 20, got 0")
+        response = _post(client, kind="quiz", question_count=0)
+        assert response.status_code == 400
+
+    def test_an_unexpected_failure_is_500(self, client, stub):
+        stub["raises"]["summary"] = RuntimeError("ollama is down")
+        response = _post(client, kind="summary")
+        assert response.status_code == 500
+        assert response.json["ok"] is False
+
+
+def test_the_route_is_registered():
+    assert "/api/study" in {str(rule) for rule in web.app.url_map.iter_rules()}


### PR DESCRIPTION
## Summary

`Study` built three artifacts and only the CLI could call them, so half the
product could not reach a feature the other half shipped. This adds the web
half: a **Study** panel with the same summary / outline / quiz, over one new
route.

`POST /api/study` serves all three, because they share one shape — pick a
document, load its chunks, ask the generator for structure. Three routes would
have been three copies of the document lookup and three places for the error
contract to drift apart.

**The status codes are the part worth reviewing.** A generator that ignores the
format is **422**, not 500: the server did not break, the model replied in a
shape the parse refuses, and the user's next move is "retry, or change model",
not "check the backend". The panel says exactly that. `404` for an unindexed
document and `409` for one with no chunks are told apart for the same reason —
each has a different answer.

For the quiz, that distinction carries further: the core raises rather than
hand back questions whose answer key it could not verify, so 422 there means
"not safe to grade you against", never "nothing found".

In the panel, quiz answers stay hidden behind **Ver respuestas**. A quiz whose
key is on screen from the first render is a summary with extra steps.

## Two things this turned up

- **React error #310** — the first version put `runStudy` behind `useCallback`
  below three early returns (`isIndexing`, `initError`, `!isInitialized`), so
  the hook count changed between renders and the app rendered a black screen.
  It is a plain function now, like the `render*Panel` helpers beside it.
- **The Spanish strings had drifted into Argentine voseo** ("Elegí", "querés"),
  copied from Daimon's register. This repo is Ignacio's and had no voseo in it
  before — peninsular now.

## Issue

Part of #140, which closed on the CLI half. This removes the "the web UI is not
wired" caveat that closure recorded.

## Test plan

- `tests/test_web_study_route.py` — 17 cases against doubles: each kind reaches
  its own engine call, the language and question count are passed through (and
  an omitted count does **not** override the core's default), and each of the
  five failure modes returns its own status.
- **Verified in a browser against the real stack** — Flask on :5000, six papers
  in a real FAISS store, Ollama with `gemma4:e4b`:
  - Outline returns the actual section tree of `attention-transformers.pdf`
    (Abstract → Model Architecture → Why Self-Attention → Positional Encoding →
    Results → Conclusion), correctly nested.
  - Quiz returns five questions whose keys are factually right — Transformer for
    "which architecture drops recurrence and convolutions", positional encodings
    for "how does it use sequence order".
  - "Ver respuestas" reveals all five and removes itself.
- Full local suite: **1049 passed, 2 skipped**. `ruff check .` clean.
  `pnpm run build` clean.
- Full gate not run and not needed: no retrieval or answer-generation path
  changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)