### PR TITLE
Let a refreshed baseline displace an aged one (#107)

### DIFF
--- a/harness/RUNBOOK.md
+++ b/harness/RUNBOOK.md
@@ -176,8 +176,9 @@ its own history.
 **`WARNING that high-water entry was NOT measured on a stack comparable to this launch's`**
 The entry your candidates will be judged against ran on a different (or
 unrecorded) stack. It can hold passes the current stack cannot reach, which
-reads as a regression no candidate can fix. A refresh campaign on the current
-stack is what replaces it — issue #107, still open for exactly that.
+reads as a regression no candidate can fix. **Run a refresh campaign** before
+paying for a real one: section 8. After it, this warning stops appearing,
+because a verified entry exists to be the baseline instead.
 
 **`N entry(ies) carry no stack fingerprint (written before ledger schema v3)`**
 Historical entries, usable but unverifiable. Not a problem by itself; it
@@ -299,13 +300,47 @@ measurement's actual resolution.
 - **Stage 1 is a single-field sweep from a fixed reference**, not a
   compounding hill climb. Two accepted single-field changes cannot combine
   within a run.
-- **An aged baseline is visible but not fixed.** Drift is now recorded and
-  reported (#107 option 2); making an aged high water reachable again needs a
-  refresh campaign, which is still open work.
+- **An aged baseline is displaced by a refresh campaign, not by editing
+  history.** Drift is recorded and reported (#107 option 2), and once this
+  stack has one complete comparable entry of its own, history that never said
+  what it ran on stops being the high water (#107 option 1). Section 8 is the
+  procedure.
 
 ---
 
-## 8. Closing a campaign
+## 8. Refreshing an aged baseline
+
+Run this when the launch line warns that the high water was not measured on a
+stack comparable to this one. It is an ordinary grid campaign; what makes it a
+refresh is why you are running it and that you let it finish.
+
+```bash
+python -m harness.cli --proposer grid --patience 3
+```
+
+Nothing else. The campaign measures the reference and the grid on the current
+stack and writes complete entries carrying this stack's fingerprint. From the
+first such entry, `loop._historical_high_water` drops the unverified pool: the
+August entry still *pairs* — it is still counted as a comparable state — but it
+is no longer eligible to be the baseline your candidates are judged against.
+
+**What to check afterwards.** Re-run `--status`. The warning should be gone and
+`high water` should name an iteration from this campaign. If it still names the
+old one, the new entries are not verified against this launch: either they came
+back `inconclusive` (Ollama, the index) or the fingerprint could not be read,
+which `--status` reports on its own line.
+
+**What this deliberately does not do.** It never edits or removes a ledger
+entry. The ledger is append-only and an aged entry is still evidence of what
+that stack did — it just stops being the standard a different stack is held to.
+Displacement is also conditional: with nothing measured on this stack, the old
+entries remain the baseline, because discarding them with nothing to put in
+their place would throw away issue #92's evidence over a drift nobody has
+demonstrated.
+
+---
+
+## 9. Closing a campaign
 
 1. The ledger and `report.json` are the evidence. `tests/eval/runs/` and
    `harness/ledger/` are gitignored — cite paths explicitly as local, never

--- a/harness/loop.py
+++ b/harness/loop.py
@@ -427,12 +427,45 @@ def _historical_high_water(
     latest iteration so repeated measurements of one configuration converge.
     Computed once at loop start from PRIOR history only -- entries written by
     the current run never move the pairing baseline mid-campaign.
+
+    ## Verified history displaces unverified (issue #107, option 1)
+
+    The fingerprint (option 2) stops an entry measured on a *provably
+    different* stack from pairing. It does nothing about the entries that
+    actually aged: everything written before schema v3 carries no fingerprint,
+    compares ``UNKNOWN``, and keeps pairing forever -- and those are precisely
+    the August entries holding passes this stack cannot reach. Left alone,
+    every campaign ends ``rejected_regression`` against a high water nobody can
+    climb back to, with no bug to fix.
+
+    So once this stack has measured a comparable state of its own, history that
+    never said what it ran on stops being the baseline. That is what makes a
+    refresh campaign work: run the grid on the current stack, and from its
+    first complete entry the aged high water is out of the pool.
+
+    The displacement is deliberately conditional on a verified entry existing.
+    Discarding unverified history with nothing measured to put in its place
+    would throw away the evidence issue #92 was built on over a stack drift
+    nobody has demonstrated -- and a launch that cannot read its own stack
+    verifies nothing, so it behaves exactly as it did before #107.
     """
+    comparable = [
+        entry
+        for entry in entries
+        if is_comparable_search_set_entry(entry, comparable_view, launch_environment)
+    ]
+    verified = [
+        entry
+        for entry in comparable
+        if environment_mod.compare(entry.environment_fingerprint, launch_environment)
+        == environment_mod.MATCH
+    ]
+    pool = verified or comparable
+
     best: Optional[ledger_mod.LedgerEntry] = None
-    for entry in entries:
-        if is_comparable_search_set_entry(entry, comparable_view, launch_environment):
-            if best is None or entry.objective_adjusted >= best.objective_adjusted:
-                best = entry
+    for entry in pool:
+        if best is None or entry.objective_adjusted >= best.objective_adjusted:
+            best = entry
     return best
 
 

--- a/harness/tests/test_loop.py
+++ b/harness/tests/test_loop.py
@@ -1134,14 +1134,39 @@ def test_the_report_says_when_the_launch_environment_could_not_be_read(tmp_path)
     assert report["environment"]["readable"] is False
 
 
-def test_the_launch_line_says_when_the_high_water_itself_is_unverified(tmp_path):
-    """The exact #107 situation: an aged entry outscores every verified one, so
-    the count of unverified states is not the fact that decides -- which entry
-    pairing will actually use is."""
+def test_a_refreshed_baseline_takes_over_from_a_higher_aged_one(tmp_path):
+    """The exact #107 situation, now resolved rather than only reported.
+
+    This used to assert the opposite: the aged 30 won and the launch line said
+    so, which was accurate and useless -- the operator was told the baseline
+    was unreachable and had no way to replace it. Option 1 is that way: once a
+    comparable state has been measured on this stack, the entry that never said
+    what it ran on stops being the baseline, even though it scores higher.
+
+    The count of comparable states does not change. Both still pair; only one
+    is eligible to be the high water.
+    """
     from harness import ledger as ledger_mod
 
     _seed_entry(tmp_path, 1, 30, _ONE_PASS, environment_fingerprint=None)
     _seed_entry(tmp_path, 2, 25, _ONE_PASS, environment_fingerprint=_STACK_TODAY)
+    info = loop.describe_ledger_comparability(
+        AppConfig(), list(ledger_mod.read_history(tmp_path)), launch_environment=_STACK_TODAY
+    )
+    assert info["comparable_search_set_states"] == 2
+    assert info["high_water_objective_adjusted"] == 25
+    assert info["high_water_environment_verified"] is True
+
+
+def test_the_launch_line_says_when_the_high_water_itself_is_unverified(tmp_path):
+    """With nothing measured on this stack there is nothing to displace with,
+    so the aged entry is still the baseline -- and the launch line has to say
+    that it was never verified, because that is the warning telling the
+    operator a refresh campaign is what they need."""
+    from harness import ledger as ledger_mod
+
+    _seed_entry(tmp_path, 1, 30, _ONE_PASS, environment_fingerprint=None)
+    _seed_entry(tmp_path, 2, 25, _ONE_PASS, environment_fingerprint=None)
     info = loop.describe_ledger_comparability(
         AppConfig(), list(ledger_mod.read_history(tmp_path)), launch_environment=_STACK_TODAY
     )
@@ -1160,3 +1185,94 @@ def test_a_verified_high_water_is_reported_as_verified(tmp_path):
     )
     assert info["high_water_objective_adjusted"] == 30
     assert info["high_water_environment_verified"] is True
+
+
+# ---------------------------------------------------------------------------
+# Issue #107, option 1: a refreshed baseline displaces the aged one.
+#
+# Option 2 (the fingerprint) landed already and stops an entry measured on a
+# *provably different* stack from pairing. It does nothing about the entries
+# that actually aged: everything written before schema v3 carries no
+# fingerprint at all, compares UNKNOWN, and keeps pairing forever. Those are
+# exactly the August entries holding passes this stack cannot reach.
+#
+# So the rule these tests pin: once this stack has measured a comparable state
+# of its own, history that never said what it ran on stops being the baseline.
+# Before that first verified entry nothing changes, because discarding the
+# unverified history with nothing to put in its place is how #92's evidence
+# would be thrown away for a stack drift nobody has demonstrated.
+# ---------------------------------------------------------------------------
+
+_STACK_NOW = {
+    "schema": 1,
+    "packages": {"isolated": {"mineru": "3.4.5"}, "product": {"torch": "2.9.0"}},
+}
+
+
+def _high_water_of(tmp_path, launch_environment):
+    import dataclasses
+
+    from harness import ledger as ledger_mod
+
+    entries = list(ledger_mod.read_history(tmp_path))
+    view = loop._comparable_config_view(dataclasses.asdict(AppConfig()))
+    return loop._historical_high_water(entries, view, launch_environment)
+
+
+def _records(passed_ids, failed_ids=()):
+    return (
+        [{"id": i, "case_type": "factual_number", "passed": True, "elapsed_seconds": 200.0}
+         for i in passed_ids]
+        + [{"id": i, "case_type": "factual_number", "passed": False, "elapsed_seconds": 200.0}
+           for i in failed_ids]
+    )
+
+
+def test_unverified_history_still_pairs_when_nothing_has_been_verified(tmp_path):
+    # Unchanged behaviour, and the reason the displacement is conditional:
+    # this is #92's evidence and there is nothing measured to replace it with.
+    _seed_entry(tmp_path, 1, 2, _records(("a", "b")), environment_fingerprint=None)
+
+    assert _high_water_of(tmp_path, _STACK_NOW).iteration == 1
+
+
+def test_a_verified_entry_displaces_a_higher_unverified_one(tmp_path):
+    # The whole point: the aged entry scores better and still loses, because
+    # it never said which stack produced that score.
+    _seed_entry(tmp_path, 1, 2, _records(("a", "b")), environment_fingerprint=None)
+    _seed_entry(tmp_path, 2, 1, _records(("a",), ("b",)), environment_fingerprint=_STACK_NOW)
+
+    high_water = _high_water_of(tmp_path, _STACK_NOW)
+    assert high_water.iteration == 2
+    assert high_water.objective_adjusted == 1
+
+
+def test_among_verified_entries_the_best_still_wins(tmp_path):
+    # Displacement changes which pool is eligible, not how the best is chosen.
+    _seed_entry(tmp_path, 1, 1, _records(("a",), ("b",)), environment_fingerprint=_STACK_NOW)
+    _seed_entry(tmp_path, 2, 2, _records(("a", "b")), environment_fingerprint=_STACK_NOW)
+
+    assert _high_water_of(tmp_path, _STACK_NOW).iteration == 2
+
+
+def test_an_entry_from_a_different_stack_verifies_nothing(tmp_path):
+    # DIFFERS was already excluded from pairing; it must also not count as the
+    # verified evidence that displaces unverified history, or a campaign run
+    # on the wrong stack would silently discard the ledger.
+    other_stack = {
+        "schema": 1,
+        "packages": {"isolated": {"mineru": "2.1.0"}, "product": {"torch": "2.9.0"}},
+    }
+    _seed_entry(tmp_path, 1, 2, _records(("a", "b")), environment_fingerprint=None)
+    _seed_entry(tmp_path, 2, 3, _records(("a", "b")), environment_fingerprint=other_stack)
+
+    assert _high_water_of(tmp_path, _STACK_NOW).iteration == 1
+
+
+def test_a_launch_that_cannot_read_its_own_stack_verifies_nothing(tmp_path):
+    # With no launch fingerprint every comparison is UNKNOWN, so there is no
+    # verified pool and the ledger must behave exactly as it did before #107.
+    _seed_entry(tmp_path, 1, 2, _records(("a", "b")), environment_fingerprint=None)
+    _seed_entry(tmp_path, 2, 1, _records(("a",), ("b",)), environment_fingerprint=_STACK_NOW)
+
+    assert _high_water_of(tmp_path, None).iteration == 1


### PR DESCRIPTION
## Summary

Option 2 of #107 landed already: every entry records the stack it measured on,
and an entry from a provably different stack no longer pairs. That made the
drift **visible** and left it **unfixed** — which is exactly what the RUNBOOK
described as open work:

> making an aged high water reachable again needs a refresh campaign, which is
> still open work

**The gap is that `UNKNOWN` is not `DIFFERS`, deliberately.** Entries written
before schema v3 carry no fingerprint at all, so they compare `UNKNOWN` and keep
pairing forever — and those are precisely the August entries holding passes this
stack cannot reach. The operator was told the baseline was unreachable and given
no way to replace it.

So: **once this stack has measured one complete comparable state of its own,
history that never said what it ran on stops being eligible as the high water.**
A refresh campaign is then an ordinary grid run — `python -m harness.cli
--proposer grid` — and from its first complete entry the aged high water is out
of the pool. RUNBOOK §8 is the procedure and what to check afterwards.

Nothing is edited or removed. The ledger stays append-only, and the old entry
still counts as a comparable state; it just stops being the standard a
different stack is held to.

Two guards on the displacement, both tested:

- **Conditional on a verified entry existing.** With nothing measured on this
  stack the old entries remain the baseline. Discarding them with nothing to put
  in their place would throw away issue #92's evidence over a drift nobody has
  demonstrated.
- **A launch that cannot read its own stack verifies nothing**, so it behaves
  exactly as it did before #107. Same for an entry that compares `DIFFERS` — it
  was already excluded from pairing and must not count as the evidence that
  displaces, or a campaign run on the wrong stack would silently discard the
  ledger.

## One test had to change

`test_the_launch_line_says_when_the_high_water_itself_is_unverified` asserted
the opposite: the aged 30 wins over the verified 25, and the launch line says
so. Its own docstring called that "the exact #107 situation" — it pinned the
symptom this issue exists to remove. Accurate, and useless: it told the operator
the baseline was unreachable with no way out.

It is now two tests: the displacement, and the case where nothing has been
verified yet, where the warning is still the right answer.

## Issue

Fixes #107 — option 1, on top of the option 2 already in `harness/environment.py`.
The issue's own leaning was "(1)+(2)".

## Test plan

- 5 new cases in `harness/tests/test_loop.py` pinning the rule at
  `_historical_high_water`: unverified history still pairs when nothing is
  verified; a verified entry displaces a **higher** unverified one; among
  verified entries the best still wins; a `DIFFERS` entry verifies nothing; a
  launch with no readable fingerprint verifies nothing.
- Verified red before the change: `test_a_verified_entry_displaces_a_higher_unverified_one`
  failed with `assert 1 == 2` on the unmodified `loop.py`.
- Harness suite: **229 passed**. Full local suite: **1037 passed, 2 skipped**.
  `ruff check .` clean.
- No gate run needed: this is harness pairing logic and touches nothing the
  product runs. `harness/tests/test_harness_boundaries.py` still passes, so the
  gate files remain untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)