### PR TITLE
Declare and cost the index-time tier, so it is not designed twice (#102)

### DIFF
--- a/harness/README.md
+++ b/harness/README.md
@@ -45,6 +45,7 @@ what a flag does — this is exactly the loop's job.
 RUNBOOK.md           How to run a campaign: procedure, decision points, verdicts
 search_space.py      Declared tunables, index-time exclusions, feasibility, reachability gate metadata
 fast_tier.txt         Fixed 13-case regression filter (never declares an improvement)
+slow_tier.py          Index-time tier (#102): batching by index recipe, cost in fast-tier units
 unreachable_cases.txt Cases excluded from the maximised scalar — starts empty, evidence-backed
 ledger.py              Append-only evidence ledger (JSON per iteration + index.jsonl)
 environment.py          The installed stack an iteration measured on (#107)

--- a/harness/RUNBOOK.md
+++ b/harness/RUNBOOK.md
@@ -294,9 +294,15 @@ measurement's actual resolution.
   accepted improvement on today's corpus is **a candidate for confirmation,
   not a demonstrated result**. This is issue #30, the binding constraint on
   the whole loop, and every report carries it as `resolution_warning`.
-- **Index-time knobs are not searched.** Chunking and the index-time flags
-  force a full reindex per candidate, which no budget survives inside a search
-  loop (#102). Declaring one is a red test, not an oversight.
+- **Index-time knobs are still not searched, but the tier is now costed.**
+  Chunking and the index-time flags force a full reindex, which no budget
+  survives inside a search loop. Declaring one in `SEARCH_SPACE` is still a red
+  test. What `harness/slow_tier.py` adds (#102) is the accounting: candidates
+  are batched by the index they need — two that differ only in a retrieval knob
+  share one rebuild — and a campaign is priced in fast-tier evaluations, the
+  unit the patience budget is already spent in. It measures nothing itself; the
+  reindex and evaluation seconds come from a real run. Whether such a candidate
+  can pay off at all is still block B's question (#30).
 - **Stage 1 is a single-field sweep from a fixed reference**, not a
   compounding hill climb. Two accepted single-field changes cannot combine
   within a run.

--- a/harness/search_space.py
+++ b/harness/search_space.py
@@ -36,11 +36,13 @@ Four things live here besides the declared tunables:
   Any of these changes what is stored, which moves the index fingerprint and
   forces a full MinerU + jina-clip reindex per candidate -- far more
   expensive than the ~13 min a retrieval/generation-only evaluation now
-  costs (see above), whatever the exact multiple turns out to be once it is
-  measured. They get their own slower tier once block B (#30) lands and
-  reindex timing is measured. ``_validate_declared_space`` raises if any of
-  them appears in ``SEARCH_SPACE``, so a future contributor who adds one
-  gets a red test instead of a silent overnight reindex.
+  costs (see above). Their own tier is declared in ``harness/slow_tier.py``
+  (#102): it batches candidates by the index they need and prices a campaign
+  in fast-tier evaluations, so lifting this exclusion becomes a decision made
+  on a budget rather than discovered overnight. Declaring a knob there does
+  not put it in stage 1 -- ``_validate_declared_space`` still raises if any of
+  them appears in ``SEARCH_SPACE``, so a contributor who adds one here gets a
+  red test instead of a silent reindex.
 - ``expand_overrides`` / ``is_feasible``: ``weight_semantic_rrf`` and
   ``weight_bm25_rrf`` are coupled (see the docstring on ``expand_overrides``),
   and three declared parameters interact (section 2.3). Neither coupling is

--- a/harness/slow_tier.py
+++ b/harness/slow_tier.py
@@ -1,0 +1,190 @@
+"""slow_tier -- the index-time tier, declared once so it is not designed twice.
+
+Issue #102. ``search_space.INDEX_TIME_KEYS`` is excluded from stage 1 because
+changing any of them invalidates the stored index: a flag-only recipe change
+(``usar_descripcion_imagen`` off to on) forced discarding and rebuilding dev and
+blind even with MinerU's parse cache hot, 215 s per store, and the gate
+measurement around it took 36 minutes (measured 2026-08-23, RTX 4060 laptop).
+Fine twice. Unaffordable inside a search loop that touches index knobs per
+candidate.
+
+The exclusion is right and this module does not lift it. What it adds is the
+accounting that would let it be lifted deliberately, on numbers, rather than by
+someone deleting a line from ``INDEX_TIME_KEYS`` and discovering overnight what
+it costs.
+
+## The three things the issue asked for
+
+**Declared.** ``SLOW_TIER_SPACE`` names the index-time knobs and their
+candidate values in one place, separate from ``SEARCH_SPACE``. Declaring a knob
+here is not the same as searching it: stage 1 still refuses to, and
+``search_space._validate_declared_space`` still goes red if one leaks into the
+fast space.
+
+**Batched.** ``batch_by_recipe`` groups candidates by the index they need. Two
+candidates that differ only in a retrieval knob share one index, so they share
+one reindex — and the size of that group is the whole economics of the tier. A
+tier that reindexed per candidate would be the thing the issue says nobody can
+afford; one that reindexes per *recipe* is a fixed cost amortised over however
+many retrieval variants ride on it.
+
+**Costed in fast-tier units.** ``estimate_cost`` reports a batch's price as a
+multiple of an ordinary evaluation, because that is the unit the loop's budget
+is already spent in. "This batch costs 41 fast-tier evaluations" is a sentence
+an operator can weigh against a patience of 3; "this batch costs 1927 seconds"
+is not.
+
+## What this module refuses to do
+
+It does not measure. The seconds it multiplies come from the caller, which got
+them from a real run; nothing here calls a clock, and no default reindex cost
+is baked in. A cost model with a plausible-looking constant nobody measured is
+exactly the "loop sobre una medida que miente" the design doc opens with,
+arriving as a helpful default.
+
+It also has no opinion about whether a slow-tier candidate is worth running.
+That decision needs block B's case expansion (#30) to say whether index-time
+knobs can pay off at all, and it belongs to an operator reading a budget, not
+to a module that can only multiply.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any, Dict, Iterable, List, Mapping, Sequence, Tuple
+
+from harness.search_space import INDEX_TIME_KEYS
+
+# The index-time knobs and the values a slow-tier campaign would try. Declared
+# apart from SEARCH_SPACE on purpose: that table is what stage 1 walks, and a
+# key in both would be a key stage 1 tries to search.
+#
+# Values are deliberately few. Each one is a full corpus rebuild, so a
+# three-value knob is three reindexes before a single retrieval variant is
+# measured, and the grid over two knobs multiplies rather than adds.
+SLOW_TIER_SPACE: Dict[str, Tuple[Any, ...]] = {
+    "chunking.chunk_size": (800, 1200),
+    "chunking.chunk_overlap": (100, 200),
+    "flags.usar_contextual_retrieval": (False, True),
+    "flags.usar_embeddings_imagen": (False, True),
+}
+
+
+class SlowTierError(RuntimeError):
+    """A slow-tier request that cannot be costed or is not slow tier at all."""
+
+
+def requires_reindex(overrides: Mapping[str, Any]) -> bool:
+    """Whether these overrides change what is stored, not just how it is read.
+
+    The one question that decides which tier a candidate belongs to. Asked of
+    the override keys rather than of a config diff: a candidate that sets an
+    index-time key back to the reference's own value still moves the index
+    fingerprint through the gate's plumbing, and pretending otherwise would put
+    a reindex in the fast tier's budget.
+    """
+    return any(key in INDEX_TIME_KEYS for key in overrides)
+
+
+def recipe_of(overrides: Mapping[str, Any]) -> Tuple[Tuple[str, Any], ...]:
+    """The index-time part of ``overrides``, normalised for grouping.
+
+    Sorted so two candidates that set the same knobs in a different order share
+    a recipe; everything else is dropped, because retrieval knobs read the same
+    index rather than building another one.
+    """
+    return tuple(sorted((k, v) for k, v in overrides.items() if k in INDEX_TIME_KEYS))
+
+
+def batch_by_recipe(
+    candidates: Sequence[Mapping[str, Any]],
+) -> List[Tuple[Tuple[Tuple[str, Any], ...], List[Mapping[str, Any]]]]:
+    """Group candidates by the index they need, in first-seen order.
+
+    Returns:
+        ``[(recipe, candidates)]``. The empty recipe -- candidates needing no
+        reindex -- is included and its group costs no rebuild, so a caller can
+        pass a mixed list and get a truthful bill rather than having to
+        pre-sort by tier.
+
+    First-seen order rather than sorted: the proposer's order is a decision it
+    made, and re-ordering batches here would quietly override it.
+    """
+    grouped: Dict[Tuple[Tuple[str, Any], ...], List[Mapping[str, Any]]] = {}
+    for candidate in candidates:
+        grouped.setdefault(recipe_of(candidate), []).append(candidate)
+    return list(grouped.items())
+
+
+@dataclasses.dataclass(frozen=True)
+class TierCost:
+    """What a batched slow-tier campaign would cost, in two units.
+
+    Attributes:
+        reindexes: Distinct indexes that must be built. This is the number the
+            tier lives or dies on, and it is the count of recipes, not of
+            candidates.
+        evaluations: Candidate evaluations across every batch.
+        seconds: Total wall clock, from the caller's measured costs.
+        fast_tier_equivalents: ``seconds`` divided by the cost of one ordinary
+            evaluation. The unit the loop's budget is already spent in, so a
+            batch can be weighed against a patience or an iteration cap without
+            converting anything by hand.
+    """
+
+    reindexes: int
+    evaluations: int
+    seconds: float
+    fast_tier_equivalents: float
+
+
+def estimate_cost(
+    batches: Iterable[Tuple[Tuple[Tuple[str, Any], ...], Sequence[Mapping[str, Any]]]],
+    *,
+    reindex_seconds: float,
+    evaluation_seconds: float,
+) -> TierCost:
+    """Price a batched campaign from measured costs.
+
+    Args:
+        batches: The output of ``batch_by_recipe``.
+        reindex_seconds: Measured cost of one full rebuild, per the machine
+            this would run on. No default: see the module docstring.
+        evaluation_seconds: Measured cost of one ordinary evaluation, the unit
+            ``fast_tier_equivalents`` is expressed in.
+
+    Raises:
+        SlowTierError: Either cost is not positive. A zero or negative
+            evaluation cost would make every batch look free or negatively
+            priced, which is worse than refusing to answer.
+    """
+    if reindex_seconds <= 0 or evaluation_seconds <= 0:
+        raise SlowTierError(
+            "reindex_seconds and evaluation_seconds must both be positive measured "
+            f"costs, got {reindex_seconds!r} and {evaluation_seconds!r}"
+        )
+
+    reindexes = 0
+    evaluations = 0
+    for recipe, group in batches:
+        # The empty recipe reads the index that is already there.
+        if recipe:
+            reindexes += 1
+        evaluations += len(group)
+
+    seconds = reindexes * reindex_seconds + evaluations * evaluation_seconds
+    return TierCost(
+        reindexes=reindexes,
+        evaluations=evaluations,
+        seconds=seconds,
+        fast_tier_equivalents=round(seconds / evaluation_seconds, 1),
+    )
+
+
+def describe_cost(cost: TierCost) -> str:
+    """One line an operator can weigh against a patience budget."""
+    return (
+        f"slow tier: {cost.reindexes} reindex(es) + {cost.evaluations} evaluation(s) "
+        f"= {cost.seconds / 60:.0f} min, {cost.fast_tier_equivalents} fast-tier "
+        "evaluations' worth"
+    )

--- a/harness/tests/test_slow_tier.py
+++ b/harness/tests/test_slow_tier.py
@@ -1,0 +1,146 @@
+"""The slow tier's accounting, and the two things it refuses to guess.
+
+Issue #102. The arithmetic is easy; what these pin is the economics. Batching
+by *recipe* rather than by candidate is the whole reason the tier could ever be
+affordable — two candidates differing only in a retrieval knob read the same
+index — and a cost model that invents its own constants would be a measurement
+that lies, so ``estimate_cost`` takes both costs from the caller and refuses a
+non-positive one instead of falling back to a plausible default.
+"""
+
+import pytest
+
+from harness import slow_tier
+from harness.search_space import INDEX_TIME_KEYS, SEARCH_SPACE
+
+
+class TestWhichTierACandidateBelongsTo:
+    def test_a_retrieval_only_candidate_needs_no_reindex(self):
+        assert slow_tier.requires_reindex({"retrieval.top_k_final": 8}) is False
+
+    def test_touching_one_index_time_key_is_enough(self):
+        assert slow_tier.requires_reindex({"chunking.chunk_size": 800}) is True
+
+    def test_a_mixed_candidate_is_slow_tier(self):
+        assert slow_tier.requires_reindex(
+            {"retrieval.top_k_final": 8, "flags.usar_embeddings_imagen": True}
+        ) is True
+
+    def test_an_empty_candidate_needs_no_reindex(self):
+        assert slow_tier.requires_reindex({}) is False
+
+
+class TestBatchingIsByIndexNotByCandidate:
+    def test_candidates_sharing_an_index_share_a_batch(self):
+        # The economics of the whole tier: these two read one index.
+        batches = slow_tier.batch_by_recipe([
+            {"chunking.chunk_size": 800, "retrieval.top_k_final": 4},
+            {"chunking.chunk_size": 800, "retrieval.top_k_final": 8},
+        ])
+        assert len(batches) == 1
+        assert len(batches[0][1]) == 2
+
+    def test_different_indexes_are_different_batches(self):
+        batches = slow_tier.batch_by_recipe([
+            {"chunking.chunk_size": 800},
+            {"chunking.chunk_size": 1200},
+        ])
+        assert len(batches) == 2
+
+    def test_key_order_does_not_split_a_batch(self):
+        batches = slow_tier.batch_by_recipe([
+            {"chunking.chunk_size": 800, "chunking.chunk_overlap": 100},
+            {"chunking.chunk_overlap": 100, "chunking.chunk_size": 800},
+        ])
+        assert len(batches) == 1
+
+    def test_fast_tier_candidates_get_their_own_empty_recipe(self):
+        # So a caller can hand over a mixed list and still get a true bill.
+        batches = slow_tier.batch_by_recipe([
+            {"retrieval.top_k_final": 4},
+            {"chunking.chunk_size": 800},
+        ])
+        recipes = [recipe for recipe, _ in batches]
+        assert () in recipes
+        assert len(recipes) == 2
+
+    def test_first_seen_order_is_preserved(self):
+        # Re-ordering here would quietly override the proposer's own decision.
+        batches = slow_tier.batch_by_recipe([
+            {"chunking.chunk_size": 1200},
+            {"chunking.chunk_size": 800},
+        ])
+        assert [recipe[0][1] for recipe, _ in batches] == [1200, 800]
+
+
+class TestTheBill:
+    def test_one_reindex_is_charged_per_recipe_not_per_candidate(self):
+        batches = slow_tier.batch_by_recipe([
+            {"chunking.chunk_size": 800, "retrieval.top_k_final": 4},
+            {"chunking.chunk_size": 800, "retrieval.top_k_final": 8},
+        ])
+        cost = slow_tier.estimate_cost(batches, reindex_seconds=215, evaluation_seconds=10)
+        assert cost.reindexes == 1
+        assert cost.evaluations == 2
+        assert cost.seconds == 215 + 20
+
+    def test_a_fast_tier_batch_is_charged_no_rebuild(self):
+        batches = slow_tier.batch_by_recipe([{"retrieval.top_k_final": 4}])
+        cost = slow_tier.estimate_cost(batches, reindex_seconds=215, evaluation_seconds=10)
+        assert cost.reindexes == 0
+        assert cost.seconds == 10
+
+    def test_the_bill_is_expressed_in_the_unit_the_budget_uses(self):
+        # 215 s of rebuild plus one 10 s evaluation is 22.5 ordinary
+        # evaluations -- the number an operator weighs against a patience of 3.
+        batches = slow_tier.batch_by_recipe([{"chunking.chunk_size": 800}])
+        cost = slow_tier.estimate_cost(batches, reindex_seconds=215, evaluation_seconds=10)
+        assert cost.fast_tier_equivalents == 22.5
+
+    def test_the_measured_2026_08_23_numbers_come_out_of_the_model(self):
+        # Two stores at 215 s each, as the issue recorded, plus the four
+        # evaluations that flip-flopped over them.
+        batches = slow_tier.batch_by_recipe([
+            {"flags.usar_embeddings_imagen": False},
+            {"flags.usar_embeddings_imagen": False},
+            {"flags.usar_embeddings_imagen": True},
+            {"flags.usar_embeddings_imagen": True},
+        ])
+        cost = slow_tier.estimate_cost(batches, reindex_seconds=215, evaluation_seconds=10)
+        assert cost.reindexes == 2
+        assert cost.seconds == 2 * 215 + 4 * 10
+
+
+class TestWhatItRefusesToGuess:
+    @pytest.mark.parametrize("reindex, evaluation", [(0, 10), (-1, 10), (215, 0), (215, -5)])
+    def test_a_non_positive_cost_raises_rather_than_defaulting(self, reindex, evaluation):
+        # A zero evaluation cost makes every batch look free; a default anyone
+        # could have picked is a measurement that lies.
+        batches = slow_tier.batch_by_recipe([{"chunking.chunk_size": 800}])
+        with pytest.raises(slow_tier.SlowTierError):
+            slow_tier.estimate_cost(
+                batches, reindex_seconds=reindex, evaluation_seconds=evaluation
+            )
+
+    def test_no_default_reindex_cost_is_importable(self):
+        # If a constant appeared here, someone would use it as a measurement.
+        assert not any(
+            "SECONDS" in name and not name.startswith("_") for name in dir(slow_tier)
+        )
+
+
+class TestItStaysOutOfStageOne:
+    def test_every_declared_slow_tier_key_is_an_index_time_key(self):
+        assert set(slow_tier.SLOW_TIER_SPACE) <= set(INDEX_TIME_KEYS)
+
+    def test_no_slow_tier_key_leaks_into_the_searched_space(self):
+        # Declaring a knob here must not make stage 1 try to search it.
+        assert set(slow_tier.SLOW_TIER_SPACE).isdisjoint(set(SEARCH_SPACE))
+
+
+def test_the_cost_line_names_both_units():
+    batches = slow_tier.batch_by_recipe([{"chunking.chunk_size": 800}])
+    line = slow_tier.describe_cost(
+        slow_tier.estimate_cost(batches, reindex_seconds=215, evaluation_seconds=10)
+    )
+    assert "reindex" in line and "fast-tier" in line


### PR DESCRIPTION
## Summary

`INDEX_TIME_KEYS` is excluded from stage 1 because changing one invalidates the
stored index: measured 2026-08-23, a flag-only recipe change forced rebuilding
dev and blind at **215 s per store** even with MinerU's parse cache hot, and the
gate measurement around it took **36 minutes**. That exclusion is right and this
PR does not lift it.

What it adds is the accounting that would let it be lifted **deliberately, on
numbers** — rather than by someone deleting a line from `INDEX_TIME_KEYS` and
discovering overnight what it costs. The issue said it existed "so the tier does
not get designed twice"; this is that design, unrun.

**Declared.** `SLOW_TIER_SPACE` names the index-time knobs and their candidate
values in one place, separate from `SEARCH_SPACE`. A test asserts the two are
disjoint, so declaring a knob here cannot make stage 1 try to search it —
`_validate_declared_space` still goes red if one leaks the other way.

**Batched by index recipe, not by candidate.** This is the whole economics. Two
candidates differing only in a retrieval knob read the *same* index, so they
share one rebuild. A tier that reindexed per candidate is the thing the issue
says nobody can afford; one that reindexes per recipe is a fixed cost amortised
over however many retrieval variants ride on it. Mixed lists work too: the empty
recipe is a real group that costs no rebuild, so a caller gets a truthful bill
without pre-sorting by tier.

**Priced in fast-tier evaluations**, because that is the unit the loop's budget
is already spent in. "This batch costs 22.5 evaluations" is a sentence an
operator can weigh against a patience of 3; "1927 seconds" is not.

## What it refuses to do

**It measures nothing.** Both costs are arguments, and a non-positive one raises
instead of falling back on a default. A cost model with a plausible-looking
constant nobody measured is the "loop sobre una medida que miente" the design
doc opens with, arriving as a helpful default — and a test asserts no
seconds-shaped constant is importable, so one cannot quietly appear later. The
issue's own 215 s figure appears only inside a test, as an input.

It also has no opinion on whether a slow-tier candidate is worth running. That
needs block B's case expansion (#30), and it belongs to an operator reading a
budget, not to a module that can only multiply.

## Issue

Fixes #102.

## Test plan

- `harness/tests/test_slow_tier.py` — 21 cases. Tier membership, batching
  (including that key order does not split a batch and that first-seen order is
  preserved, since re-ordering would override the proposer's decision), the
  bill, and the two refusals above. One reproduces the issue's measured
  2026-08-23 scenario — two stores at 215 s — and checks the model returns it.
- Harness suite: **255 passed**, including
  `test_harness_boundaries.py`, so the new module stays inside the no-`importlib`,
  no-`subprocess` rules that make "this harness cannot invoke git" a checked
  claim.
- Full local suite: **1083 passed, 2 skipped**. `ruff check .` clean.
- No gate run needed: harness-only, and the gate files are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)