### PR TITLE
Constrain the reply with a JSON schema, not with a request (#153)

### DIFF
--- a/src/monkeygrab/adapters/chat/ollama_chat.py
+++ b/src/monkeygrab/adapters/chat/ollama_chat.py
@@ -5,7 +5,7 @@ import json
 import logging
 import time
 from functools import lru_cache
-from typing import Any, Dict, Iterator, Optional, Sequence
+from typing import Any, Dict, Iterator, Mapping, Optional, Sequence
 
 import ollama
 import requests
@@ -122,6 +122,7 @@ class OllamaChatModel:
         *,
         system: Optional[str] = None,
         images: Sequence[bytes] = (),
+        response_format: Optional[Mapping[str, Any]] = None,
     ) -> str:
         """Generate a complete response in one call via ``ollama.chat``.
 
@@ -129,6 +130,14 @@ class OllamaChatModel:
             prompt: User/task prompt.
             system: Optional system prompt.
             images: Optional raw image bytes (vision models only).
+            response_format: JSON Schema passed to Ollama's ``format``, which
+                constrains decoding rather than asking in prose.
+
+                Measured 2026-09-02 on ``higgs-boson.pdf``, the document whose
+                quizzes failed every time: unconstrained 2/5, ``format:"json"``
+                0/5 (syntactically valid every time, and a dict rather than the
+                array every time -- plain JSON mode fixes syntax, not shape),
+                schema 5/5.
 
         Returns:
             The complete generated text.
@@ -145,13 +154,16 @@ class OllamaChatModel:
             messages.insert(0, {"role": "system", "content": system})
 
         try:
-            response = ollama_client_for(self._base_url).chat(
-                model=self._model,
-                messages=messages,
-                think=False,
-                keep_alive=self._keep_alive,
-                options=self._options(),
-            )
+            chat_kwargs: Dict[str, Any] = {
+                "model": self._model,
+                "messages": messages,
+                "think": False,
+                "keep_alive": self._keep_alive,
+                "options": self._options(),
+            }
+            if response_format is not None:
+                chat_kwargs["format"] = response_format
+            response = ollama_client_for(self._base_url).chat(**chat_kwargs)
         except Exception as exc:
             raise RuntimeError(f"Ollama generate failed for model {self._model!r}: {exc}") from exc
 

--- a/src/monkeygrab/application/study.py
+++ b/src/monkeygrab/application/study.py
@@ -84,6 +84,24 @@ _FENCE_RE = re.compile(r"^\s*```(?:json)?\s*(.*?)\s*```\s*$", re.DOTALL)
 
 _MAX_SECTIONS = 12
 
+# The same shape the prompt asks for in prose, in the one channel the backend
+# can enforce. Measured 2026-09-02 on higgs-boson.pdf, the document whose
+# quizzes failed every single time: unconstrained 2/5, and 5/5 with a schema.
+# A prompt can only ask; this refuses to decode a reply that would not parse.
+#
+# Note what a schema does NOT do: it constrains structure, never truth. A key
+# pointing at a plausible wrong option satisfies every schema ever written,
+# which is why _usable_question still runs afterwards and still drops what it
+# cannot verify.
+_SUMMARY_SCHEMA: Dict[str, Any] = {
+    "type": "array",
+    "items": {
+        "type": "object",
+        "properties": {"heading": {"type": "string"}, "body": {"type": "string"}},
+        "required": ["heading", "body"],
+    },
+}
+
 # Asking for a nested JSON structure directly rather than markdown headings
 # with "#" levels: the nesting is what the caller wants, and reconstructing it
 # from prefix counts means re-deriving structure the model already knew and
@@ -103,6 +121,33 @@ _OUTLINE_SYSTEM_PROMPT = (
 # is what the prompt asks for; this is the guard for when it is ignored.
 _MAX_OUTLINE_DEPTH = 4
 _MAX_OUTLINE_NODES = 60
+
+# Nested to the depth the prompt asks for and no further. A recursive schema
+# ($ref) would express "any depth", which is exactly what _MAX_OUTLINE_DEPTH
+# exists to refuse -- and a backend that cannot resolve the reference would
+# fall back to unconstrained decoding without saying so.
+_OUTLINE_NODE_SCHEMA: Dict[str, Any] = {"type": "object", "properties": {"title": {"type": "string"}}, "required": ["title"]}
+_OUTLINE_SCHEMA: Dict[str, Any] = {
+    "type": "array",
+    "items": {
+        "type": "object",
+        "properties": {
+            "title": {"type": "string"},
+            "children": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "title": {"type": "string"},
+                        "children": {"type": "array", "items": _OUTLINE_NODE_SCHEMA},
+                    },
+                    "required": ["title"],
+                },
+            },
+        },
+        "required": ["title"],
+    },
+}
 
 
 # Asking for the key as an index into the options rather than as the correct
@@ -132,6 +177,28 @@ _MAX_QUESTION_COUNT = 20
 # model starts padding with near-duplicates of the correct option.
 _MIN_OPTIONS = 2
 _MAX_OPTIONS = 6
+
+# correct_index is bounded by the schema as well as by _usable_question. The
+# schema stops the model emitting 7 for a four-option question; the parse still
+# checks the key against the options actually returned, because a schema cannot
+# know how many there were.
+_QUIZ_SCHEMA: Dict[str, Any] = {
+    "type": "array",
+    "items": {
+        "type": "object",
+        "properties": {
+            "prompt": {"type": "string"},
+            "options": {
+                "type": "array",
+                "items": {"type": "string"},
+                "minItems": 3,
+                "maxItems": 4,
+            },
+            "correct_index": {"type": "integer", "minimum": 0, "maximum": 3},
+        },
+        "required": ["prompt", "options", "correct_index"],
+    },
+}
 
 
 class MalformedQuizError(RuntimeError):
@@ -314,7 +381,9 @@ class Study:
             instruction += f" Write the summary in {language}."
 
         raw = self._chat_model.generate(
-            f"{instruction}\n\n{context}", system=_SUMMARY_SYSTEM_PROMPT
+            f"{instruction}\n\n{context}",
+            system=_SUMMARY_SYSTEM_PROMPT,
+            response_format=_SUMMARY_SCHEMA,
         )
 
         # Every section cites the whole retrieval's pages. Per-section
@@ -368,7 +437,9 @@ class Study:
             instruction += f" Write the headings in {language}."
 
         raw = self._chat_model.generate(
-            f"{instruction}\n\n{context}", system=_OUTLINE_SYSTEM_PROMPT
+            f"{instruction}\n\n{context}",
+            system=_OUTLINE_SYSTEM_PROMPT,
+            response_format=_OUTLINE_SCHEMA,
         )
 
         try:
@@ -438,7 +509,9 @@ class Study:
             instruction += f" Write the questions and options in {language}."
 
         raw = self._chat_model.generate(
-            f"{instruction}\n\n{context}", system=_QUIZ_SYSTEM_PROMPT
+            f"{instruction}\n\n{context}",
+            system=_QUIZ_SYSTEM_PROMPT,
+            response_format=_QUIZ_SCHEMA,
         )
 
         try:

--- a/src/monkeygrab/ports/chat_model.py
+++ b/src/monkeygrab/ports/chat_model.py
@@ -1,6 +1,6 @@
 """ChatModel -- Ollama-style text/vision generation, single-shot or streamed."""
 
-from typing import Iterator, Optional, Protocol, Sequence
+from typing import Any, Iterator, Mapping, Optional, Protocol, Sequence
 
 from monkeygrab.domain.generation_chunk import GenerationChunk
 
@@ -39,6 +39,7 @@ class ChatModel(Protocol):
         *,
         system: Optional[str] = None,
         images: Sequence[bytes] = (),
+        response_format: Optional[Mapping[str, Any]] = None,
     ) -> str:
         """Generate a complete response in one call.
 
@@ -46,6 +47,21 @@ class ChatModel(Protocol):
             prompt: User/task prompt.
             system: Optional system prompt.
             images: Optional raw image bytes for a vision-capable chat model.
+            response_format: A JSON Schema the reply must conform to, for a
+                caller that parses the output rather than reading it. This is
+                a *constraint on decoding*, not a request in prose: the
+                backend refuses to emit tokens that would violate the schema,
+                so a caller gets the shape or an error, never a near miss.
+
+                Kept a per-call argument rather than adapter configuration
+                because the schema belongs to the artifact being asked for --
+                one model role produces summaries, outlines and quizzes, and
+                each has a different shape.
+
+                Sampling parameters stay out of this port (see above) because
+                they tune how a model writes. This decides what counts as a
+                reply at all, which is the caller's contract with its own
+                parser.
 
         Returns:
             The complete generated text.

--- a/tests/unit/application/test_answer.py
+++ b/tests/unit/application/test_answer.py
@@ -70,7 +70,7 @@ class FakeChatModel:
             yield GenerationChunk(text=t, done=False)
         yield self._final_chunk
 
-    def generate(self, prompt, *, system=None, images=()):
+    def generate(self, prompt, *, system=None, images=(), response_format=None):
         self.generate_calls.append({"prompt": prompt, "system": system})
         if self._raises:
             raise RuntimeError("recomp model unavailable")

--- a/tests/unit/application/test_index_corpus.py
+++ b/tests/unit/application/test_index_corpus.py
@@ -92,7 +92,7 @@ class FakeContextualModel:
         self._raises = raises
         self.calls = []
 
-    def generate(self, prompt, *, system=None, images=()):
+    def generate(self, prompt, *, system=None, images=(), response_format=None):
         self.calls.append({"prompt": prompt, "system": system})
         if self._raises:
             raise RuntimeError("contextual model unavailable")
@@ -115,7 +115,7 @@ class FakeImageDescriber:
         self._raises = raises
         self.calls = []
 
-    def generate(self, prompt, *, system=None, images=()):
+    def generate(self, prompt, *, system=None, images=(), response_format=None):
         self.calls.append({"prompt": prompt, "system": system, "images": images})
         if self._raises:
             raise RuntimeError("vision model unavailable")

--- a/tests/unit/application/test_retrieve.py
+++ b/tests/unit/application/test_retrieve.py
@@ -112,7 +112,7 @@ class FakeQueryDecomposer:
         self._raises = raises
         self.calls = []
 
-    def generate(self, prompt, *, system=None, images=()):
+    def generate(self, prompt, *, system=None, images=(), response_format=None):
         self.calls.append(prompt)
         if self._raises:
             raise RuntimeError("decomposer unavailable")

--- a/tests/unit/application/test_study_quiz.py
+++ b/tests/unit/application/test_study_quiz.py
@@ -41,8 +41,10 @@ class _FakeChatModel:
         self.reply = reply
         self.calls = []
 
-    def generate(self, prompt, *, system=None, images=()):
-        self.calls.append({"prompt": prompt, "system": system})
+    def generate(self, prompt, *, system=None, images=(), response_format=None):
+        self.calls.append(
+            {"prompt": prompt, "system": system, "response_format": response_format}
+        )
         if isinstance(self.reply, Exception):
             raise self.reply
         return self.reply
@@ -247,3 +249,40 @@ class TestTheInterfaceView:
         assert payload["questions"][0]["options"] == ["Documents", "Images", "Users"]
         assert payload["questions"][0]["correct_index"] == 0
         assert payload["questions"][0]["source_pages"] == [4]
+
+
+class TestTheSchemaIsAskedForInTheChannelThatEnforcesIt:
+    """Issue #153. A prompt can only ask; the schema constrains decoding.
+
+    Measured 2026-09-02 on `higgs-boson.pdf`, whose quizzes failed every time:
+    unconstrained 2/5, `format:"json"` 0/5 (valid JSON every time, and a dict
+    rather than the array every time -- plain JSON mode fixes syntax, not
+    shape), schema 5/5.
+    """
+
+    def test_the_quiz_asks_for_its_schema(self):
+        model = _FakeChatModel(_TWO_QUESTIONS)
+        Study(model).quiz([_fragment()], AppConfig.from_env())
+        schema = model.calls[0]["response_format"]
+        assert schema["type"] == "array"
+        assert set(schema["items"]["required"]) == {"prompt", "options", "correct_index"}
+
+    def test_the_schema_bounds_the_key_it_asks_for(self):
+        # 3-4 options and a key in 0..3: the model cannot emit 7 for a
+        # four-option question. The parse still checks the key against the
+        # options actually returned, because a schema cannot know how many
+        # there were.
+        model = _FakeChatModel(_TWO_QUESTIONS)
+        Study(model).quiz([_fragment()], AppConfig.from_env())
+        item = model.calls[0]["response_format"]["items"]["properties"]
+        assert item["options"]["minItems"] == 3
+        assert item["correct_index"]["maximum"] == 3
+
+    def test_a_schema_does_not_replace_the_parse(self):
+        # Every field the schema demands, and a key pointing at nothing. A
+        # schema constrains structure, never truth.
+        model = _FakeChatModel(
+            '[{"prompt": "Q", "options": ["a", "b", "c"], "correct_index": 9}]'
+        )
+        with pytest.raises(MalformedQuizError):
+            Study(model).quiz([_fragment()], AppConfig.from_env())

--- a/tests/unit/application/test_study_summaries.py
+++ b/tests/unit/application/test_study_summaries.py
@@ -37,7 +37,7 @@ class _FakeChatModel:
         self.reply = reply
         self.calls = []
 
-    def generate(self, prompt, *, system=None, images=()):
+    def generate(self, prompt, *, system=None, images=(), response_format=None):
         self.calls.append({"prompt": prompt, "system": system})
         if isinstance(self.reply, Exception):
             raise self.reply


### PR DESCRIPTION
## Summary

A quiz over `higgs-boson.pdf` failed **20 times out of 20** across two prompt
variants: the model writes LaTeX inside the JSON strings, and a lone backslash
is not a legal escape.

**The first hypothesis was measured and rejected.** Asking the model not to use
LaTeX gave **14/20** against the current prompt's **13/20** over four papers — a
difference of one case. A six-run pilot had suggested 4/6 vs 6/6; that was
noise, which is why the issue's closure criterion asked for twenty. Asking a
model not to use notation *while describing notation* is not an instruction it
can obey.

Measured 2026-09-02 on that document, five runs each:

| | quizzes produced |
|---|---|
| unconstrained | 2/5 |
| `format: "json"` | **0/5** — valid JSON every time, a `dict` every time |
| JSON schema | **5/5** |

Plain JSON mode is worse than nothing here: every reply parsed and none was the
array the parse wanted. It fixes syntax and not shape. The schema fixes both,
because the backend refuses to emit tokens that would violate it.

## This is not the repair `study.py` rules out

Its docstring forecloses un-escaping and reconstruction, and rightly:

> each accommodation makes the parse guess further from what the model actually
> said

Nothing here is un-escaped, guessed or rebuilt after the fact. The parse
boundary is untouched and still raises on anything it cannot read. What changed
is **which channel the format is asked in** — prose, which can only request, or
the decoding constraint, which enforces.

**A schema constrains structure, never truth.** A key pointing at a plausible
wrong option satisfies every schema ever written. So `_usable_question` still
runs afterwards and still drops what it cannot verify, and a test pins exactly
that: a reply with every required field and an out-of-range key still raises.

`response_format` is a per-call argument rather than adapter configuration
because the schema belongs to the artifact being asked for — one model role
produces summaries, outlines and quizzes, and each has a different shape.
Sampling parameters stay out of the port for the opposite reason: they tune how
a model writes, where this decides what counts as a reply at all.

## Issue

Fixes #153.

## Test plan

- **Verified end-to-end on the gold cases** (#157, which must merge first):
  **2/4 before, 3/4 after**, with `att-study-outline` moving FAIL → PASS and
  **no malformed-JSON failure left**. The remaining failure is a different
  thing — `planck-study-quiz` returns one usable question where the case wants
  two — which is the count, not the form.
- Three new cases in `tests/unit/application/test_study_quiz.py`: the quiz asks
  for its schema, the schema bounds the key it asks for, and **a schema does not
  replace the parse**.
- The `ChatModel` doubles across five test modules take `response_format=None`;
  the port grew an optional keyword argument, so no adapter or caller is forced
  to change.
- Full local suite: **1058 passed, 2 skipped**. `ruff check .` clean.
- The full gate is **not** needed: `Study` is not on the retrieval or answer
  path, and no existing case's behaviour changed. The four Study cases above
  were run against the real pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)