### PR TITLE
Release resident Ollama models before Phase 1 retrieval in run_eval.py (#162)

### DIFF
--- a/tests/eval/run_eval.py
+++ b/tests/eval/run_eval.py
@@ -57,6 +57,7 @@ if str(REPO_ROOT / "src") not in sys.path:
     sys.path.insert(0, str(REPO_ROOT / "src"))
 if str(EVAL_DIR) not in sys.path:
     sys.path.insert(0, str(EVAL_DIR))
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
 
 import grade  # noqa: E402  (tests/eval sibling module)
 
@@ -1637,6 +1638,7 @@ def evaluate(
             # states "a later rerank simply loads again". Releasing here costs
             # one model load and buys the phase the whole card.
             _release_gpu_models(retrieve_dev, retrieve_blind)
+            _release_ollama_models(required_models)
 
             print(
                 f"\n[run] stack={stack_slug} {len(cases)} cases x up to {len(models)} model(s)\n",

--- a/tests/eval/test_phase1_one_corpus_at_a_time.py
+++ b/tests/eval/test_phase1_one_corpus_at_a_time.py
@@ -249,3 +249,18 @@ def test_the_release_is_safe_because_both_halves_reload():
         "CrossEncoderReranker.release no longer documents lazy reload; "
         "releasing after indexing would leave phase 1 with no reranker"
     )
+
+
+def test_evaluate_releases_ollama_models_before_the_run_starts():
+    """Any model preflight or earlier requests loaded in Ollama must be released
+    before phase 1 begins, so phase 1 starts with 0 B Ollama VRAM on the card (issue #162)."""
+    import inspect
+
+    source = inspect.getsource(run_eval.evaluate)
+    release_call = source.index("_release_ollama_models(required_models)")
+    run_call = source.index("records = run_all_cases(")
+    assert release_call < run_call, (
+        "evaluate() must release Ollama models BEFORE run_all_cases, or "
+        "phase 1 starts with resident Ollama models contending for 8 GB VRAM"
+    )
+

--- a/tests/unit/test_env_example_drift.py
+++ b/tests/unit/test_env_example_drift.py
@@ -127,6 +127,7 @@ _CODE_READS_NOT_DOCUMENTED = {
     "DISABLE_HMR",
     "LOCALAPPDATA",
     "XDG_DATA_HOME",
+    "PYTORCH_CUDA_ALLOC_CONF",
 }
 
 # monkeygrab.config.env's typed readers, plus rag/chat_pdfs.py's own


### PR DESCRIPTION
## Summary

When `run_eval.py` executes on systems with 8 GB cards (such as the RTX 4060 Laptop), resident models previously loaded in Ollama consume ~2.8 GiB of VRAM. Coexistence of `jina_clip_worker` (~2.8 GiB) and CrossEncoder reranker (`bge-reranker-v2-m3`, ~1.3 GiB) caused Phase 1 retrieval to fail with CUDA out of memory.

- Call `_release_ollama_models(required_models)` alongside `_release_gpu_models(retrieve_dev, retrieve_blind)` right before `run_all_cases`.
- Set `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` in `run_eval.py` before PyTorch imports to prevent memory fragmentation.
- Add regression test in `tests/eval/test_phase1_one_corpus_at_a_time.py` pinning the release ordering.
- Update `tests/unit/test_env_example_drift.py` to exempt `PYTORCH_CUDA_ALLOC_CONF`.

## Issue

Fixes #162

## Test plan

- `pytest tests/unit tests/eval harness/tests --ignore=tests/unit/adapters` (799 passed, 2 skipped).
- `.venv/bin/ruff check .` (All checks passed).