### PR TITLE
Set keep_alive=0 for query_decomposer to avoid CUDA OOM during reranking (#164)

### DIFF
--- a/rag/engine/wiring.py
+++ b/rag/engine/wiring.py
@@ -205,11 +205,15 @@ def query_decomposer(config: AppConfig) -> OllamaChatModel:
     should explore different angles on the question, and identical phrasings
     would add nothing to retrieve.
     """
+    # keep_alive is 0 because query decomposition is an auxiliary pre-retrieval
+    # step immediately followed by Cross-Encoder reranking; keeping the chat
+    # model resident alongside Jina CLIP and the reranker exhausts VRAM on
+    # 8 GB cards (issue #164).
     ollama = config.models.ollama
     return OllamaChatModel(
         config.models.chat,
         num_ctx=ollama.query_num_ctx,
-        keep_alive=ollama.keep_alive,
+        keep_alive=0,
         request_timeout=ollama.request_timeout,
         generate_retries=ollama.generate_retries,
         generate_retry_delay=ollama.generate_retry_delay,

--- a/tests/test_ollama_endpoint_wiring.py
+++ b/tests/test_ollama_endpoint_wiring.py
@@ -129,5 +129,13 @@ def test_unset_variables_keep_every_role_on_the_local_server(monkeypatch):
     assert endpoints == {"http://localhost:11434"}
 
 
+def test_query_decomposer_uses_zero_keep_alive(monkeypatch):
+    """Query decomposition runs immediately before Cross-Encoder reranking;
+    holding VRAM on 8 GB cards causes CUDA OOM (issue #164)."""
+    wiring = _wiring_with_env(monkeypatch)
+    config = wiring.app_config_from_runtime()
+    assert wiring.query_decomposer(config)._keep_alive == 0
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

When `USAR_LLM_QUERY_DECOMPOSITION` is enabled, `query_decomposer` was inheriting `ollama.keep_alive` (120s). Generating sub-queries for questions > 60 chars caused Ollama to hold the chat model (~2.8 GiB) resident in VRAM. The very next step of `Retrieve.run()` runs `BAAI/bge-reranker-v2-m3` (~1.3 GiB) alongside the active Jina CLIP worker (~2.7 GiB). On 8 GB cards (7.6 GiB usable), this VRAM contention caused Cross-Encoder reranking to fail with CUDA out of memory.

- In `rag/engine/wiring.py`, build `query_decomposer` with `keep_alive=0` so Ollama immediately unloads the chat model after generating search sub-queries.
- Add regression test in `tests/test_ollama_endpoint_wiring.py` asserting `query_decomposer._keep_alive == 0`.

## Issue

Fixes #164

## Test plan

- Fast gate: `.venv/bin/pytest tests/unit tests/eval harness/tests --ignore=tests/unit/adapters` (884 passed, 1 skipped).
- Endpoint wiring test: `.venv/bin/pytest tests/test_ollama_endpoint_wiring.py` (4 passed).
- Lint: `.venv/bin/ruff check .` (All checks passed).