### PR TITLE
Budget document fragments in Study to fit model context window (#170)

### DIFF
--- a/src/monkeygrab/application/study.py
+++ b/src/monkeygrab/application/study.py
@@ -246,6 +246,62 @@ def _single_document(fragments: Sequence[Fragment]) -> str:
     return next(iter(sources)) if len(sources) == 1 else ""
 
 
+def _calculate_context_char_budget(config: AppConfig) -> int:
+    """Derive a safe character budget for document context from config.models.ollama.rag_num_ctx.
+
+    Reserves tokens for instructions, system prompt, JSON schema, and output generation.
+    Assumes a conservative 3.0 characters per token to account for non-ASCII multi-lingual
+    text and dense mathematical notations.
+    """
+    num_ctx = config.models.ollama.rag_num_ctx
+    available_tokens = max(1000, num_ctx - 2048)
+    return int(available_tokens * 3.0)
+
+
+def _budget_fragments(fragments: Sequence[Fragment], max_chars: int) -> Sequence[Fragment]:
+    """Sample fragments evenly if the full document exceeds the character budget (issue #170).
+
+    Study artifacts operate over whole documents rather than a top-k retrieval. For
+    large documents (e.g. 60+ pages with > 200k tokens), sending every chunk
+    exceeds the generator's context window (num_ctx) and causes Ollama to reject
+    the call with HTTP 400 exceed_context_size_error.
+
+    When total characters fit within max_chars, all fragments are preserved verbatim.
+    When exceeding max_chars, fragments are sampled uniformly across the document
+    so all sections remain represented in the artifact.
+    """
+    if not fragments or max_chars <= 0:
+        return fragments
+
+    total_chars = sum(len(f.doc) for f in fragments)
+    if total_chars <= max_chars:
+        return fragments
+
+    avg_chunk_len = max(1, total_chars // len(fragments))
+    target_count = max(1, min(len(fragments), max_chars // avg_chunk_len))
+    if target_count >= len(fragments):
+        return fragments
+
+    step = len(fragments) / target_count
+    sampled_indices = [int(i * step) for i in range(target_count)]
+    seen = set()
+    unique_indices = []
+    for idx in sampled_indices:
+        if idx not in seen and idx < len(fragments):
+            seen.add(idx)
+            unique_indices.append(idx)
+
+    sampled = [fragments[i] for i in unique_indices]
+    current_chars = 0
+    kept = []
+    for f in sampled:
+        if current_chars + len(f.doc) > max_chars and kept:
+            break
+        kept.append(f)
+        current_chars += len(f.doc)
+    return kept or fragments[:1]
+
+
 def _parse_sections(raw: str) -> List[Dict[str, Any]]:
     """Decode the generator's reply into section dicts, or raise.
 
@@ -373,8 +429,9 @@ class Study:
         # the format the pipeline already produces rather than a second one
         # that could drift from it. The metrics half of the return is the
         # caller's concern there and nobody's here.
+        budgeted = _budget_fragments(fragments, _calculate_context_char_budget(config))
         context, _metrics = build_context_for_model(
-            list(fragments), config.flags.usar_optimizacion_contexto
+            list(budgeted), config.flags.usar_optimizacion_contexto
         )
         instruction = "Summarise the following material."
         if language:
@@ -429,8 +486,9 @@ class Study:
         if not fragments:
             return DocumentOutline(nodes=(), source_document="")
 
+        budgeted = _budget_fragments(fragments, _calculate_context_char_budget(config))
         context, _metrics = build_context_for_model(
-            list(fragments), config.flags.usar_optimizacion_contexto
+            list(budgeted), config.flags.usar_optimizacion_contexto
         )
         instruction = "Outline the structure of the following material."
         if language:
@@ -499,8 +557,9 @@ class Study:
         if not fragments:
             return Quiz(questions=(), source_document="")
 
+        budgeted = _budget_fragments(fragments, _calculate_context_char_budget(config))
         context, _metrics = build_context_for_model(
-            list(fragments), config.flags.usar_optimizacion_contexto
+            list(budgeted), config.flags.usar_optimizacion_contexto
         )
         instruction = (
             f"Write {question_count} multiple-choice questions about the following material."

--- a/tests/unit/application/test_study_summaries.py
+++ b/tests/unit/application/test_study_summaries.py
@@ -256,3 +256,41 @@ class TestOutline:
     def test_a_generator_failure_propagates(self):
         with pytest.raises(RuntimeError, match="down"):
             Study(_FakeChatModel(RuntimeError("down"))).outline([_fragment()], AppConfig())
+
+
+class TestStudyContextBudgeting:
+    def test_fragments_fitting_in_budget_are_kept_verbatim(self):
+        from monkeygrab.application.study import _budget_fragments
+
+        frags = [_fragment(page=i, text=f"Text {i}") for i in range(5)]
+        budgeted = _budget_fragments(frags, max_chars=1000)
+        assert list(budgeted) == frags
+
+    def test_fragments_exceeding_budget_are_subsampled_evenly(self):
+        from monkeygrab.application.study import _budget_fragments
+
+        # 100 fragments of 200 chars each = 20,000 chars total
+        frags = [_fragment(page=i + 1, text=f"Chunk {i:03d} " + "x" * 190) for i in range(100)]
+        budgeted = _budget_fragments(frags, max_chars=3000)
+
+        assert len(budgeted) < len(frags)
+        assert sum(len(f.doc) for f in budgeted) <= 3000
+        # Verify even distribution across early, middle, and late pages
+        pages = [f.metadata.page for f in budgeted]
+        assert pages[0] == 1
+        assert pages[-1] > 80
+
+    def test_study_summarize_bounds_prompt_for_large_documents(self):
+        reply = '[{"heading": "Test", "body": "Summary body."}]'
+        model = _FakeChatModel(reply)
+        # 100 chunks of 2,000 chars each = 200,000 chars (like planck-cosmology)
+        frags = [_fragment(page=i + 1, text="Word " * 400) for i in range(100)]
+
+        config = AppConfig()
+        Study(model).summarize(frags, config)
+
+        prompt = model.calls[0]["prompt"]
+        # With default rag_num_ctx = 16384, max_chars is ~43000.
+        # The prompt must be well bounded and not contain all 200,000 characters.
+        assert len(prompt) < 50000
+


### PR DESCRIPTION
## Problem / Context
When invoking Study tools (`Study.summarize`, `Study.outline`, `Study.quiz`) on large documents like `planck-cosmology.pdf` (211,379 tokens), `ricci-flow.pdf` (50,620 tokens), or `gravitational-waves.pdf` (40,538 tokens), Study passes all document chunks directly to the model. Ollama rejects this with HTTP 400 `exceed_context_size_error` because the prompt far exceeds `num_ctx` (16,384 tokens).

## Solution
1. Add `_calculate_context_char_budget(config)` to derive a safe character budget based on `config.models.ollama.rag_num_ctx`.
2. Add `_budget_fragments(fragments, max_chars)`:
   - When fragments fit within the budget, all are kept verbatim.
   - When fragments exceed the budget, chunks are sampled uniformly across early, middle, and late pages of the document, ensuring full document representation without overflowing the context.
   - Document-level page attribution (`_pages_of(fragments)`) remains intact over the entire document.
3. Added unit tests in `tests/unit/application/test_study_summaries.py` to verify both within-budget and over-budget behavior.

Closes #170.