### PR TITLE
Record Granite-4.0-H-Tiny MoE benchmark measurements (#172)

### DIFF
--- a/docs/model-history.md
+++ b/docs/model-history.md
@@ -44,6 +44,7 @@ version moved three (see "Stack drift" below).
 | `gemma4:e4b` *(default)* | 9.6 GB | 19 / 23 | 39.8 | not recorded | not recorded | not recorded | `20260901T023915Z` |
 | `hf.co/bartowski/Llama-3.2-3B-Instruct-GGUF:Q4_K_M` | 3B dense, 2.0 GB | **49 / 63** (77.8%) | 8.2 | 98.5 | 25 | 0.25 | `20260903T115934Z` |
 | `hf.co/noctrex/Ling-3.0-tiny-MXFP4_MOE-GGUF:MXFP4_MOE` | MoE, 4.9 GB | **56 / 63** (88.9%) | 8.1 | 109.3 | 18 *(of 50)* | 0.15 | `20260903T124819Z` |
+| `hf.co/noctrex/Granite-4.0-H-Tiny-MXFP4_MOE-GGUF:Granite-4.0-H-Tiny-MXFP4_MOE` | MoE, 4.2 GB | **53 / 63** (84.1%) | 8.4 | 117.2 | 75 *(of 51)* | 0.63 | `20260903T134407Z` |
 | `qwen3:30b-a3b` | 30B MoE, 3B active, 18 GB | pending | | | | | in progress |
 | `qwen3:8b` | 8B dense, 5.2 GB | pending | | | | | in progress |
 | `mistral-small3.2:24b` | 24B dense, 15 GB | pending | | | | | in progress |


### PR DESCRIPTION
## Summary
Benchmark evaluation of community MoE model `hf.co/noctrex/Granite-4.0-H-Tiny-MXFP4_MOE-GGUF:Granite-4.0-H-Tiny-MXFP4_MOE` (~4.2 GB) across the 83 gold cases (dev + blind sets across English, Spanish, and Valencian, including Study artifacts).

## Findings
- **Pass Rate**: Achieved **53/63 (84.1%)** answered cases pass rate (70/83 global pass rate).
- **Speed**: **117.2 tokens/s** decode rate with **0.63 s/answer** median latency and **75 tokens/answer**.
- **Memory**: Fits 100% in 8 GB VRAM (~4.5 GB in VRAM).
- **Observations**: Successfully generated quizzes with context budgeting, but encountered backend GGML buffer assertion crashes on specific outline/summary structured schemas.
- Run recorded: `20260903T134407Z_mineru-jina_clip-faiss` in `docs/model-history.md`.

Closes #172.