### PR TITLE
Record OLMoE-1B-7B MoE benchmark measurements (#174)

### DIFF
--- a/docs/model-history.md
+++ b/docs/model-history.md
@@ -45,6 +45,7 @@ version moved three (see "Stack drift" below).
 | `hf.co/bartowski/Llama-3.2-3B-Instruct-GGUF:Q4_K_M` | 3B dense, 2.0 GB | **49 / 63** (77.8%) | 8.2 | 98.5 | 25 | 0.25 | `20260903T115934Z` |
 | `hf.co/noctrex/Ling-3.0-tiny-MXFP4_MOE-GGUF:MXFP4_MOE` | MoE, 4.9 GB | **56 / 63** (88.9%) | 8.1 | 109.3 | 18 *(of 50)* | 0.15 | `20260903T124819Z` |
 | `hf.co/noctrex/Granite-4.0-H-Tiny-MXFP4_MOE-GGUF:Granite-4.0-H-Tiny-MXFP4_MOE` | MoE, 4.2 GB | **53 / 63** (84.1%) | 8.4 | 117.2 | 75 *(of 51)* | 0.63 | `20260903T134407Z` |
+| `hf.co/noctrex/OLMoE-1B-7B-0125-Instruct-MXFP4_MOE-GGUF:OLMoE-1B-7B-0125-Instruct-MXFP4_MOE` | MoE, 3.9 GB | **40 / 63** (63.5%) | 7.7 | 212.9 | 66 *(of 51)* | 0.31 | `20260903T143414Z` |
 | `qwen3:30b-a3b` | 30B MoE, 3B active, 18 GB | pending | | | | | in progress |
 | `qwen3:8b` | 8B dense, 5.2 GB | pending | | | | | in progress |
 | `mistral-small3.2:24b` | 24B dense, 15 GB | pending | | | | | in progress |


### PR DESCRIPTION
## Summary
Benchmark evaluation of AllenAI's `hf.co/noctrex/OLMoE-1B-7B-0125-Instruct-MXFP4_MOE-GGUF:OLMoE-1B-7B-0125-Instruct-MXFP4_MOE` (~3.9 GB) across the 83 gold cases.

## Findings
- **Speed**: Recorded highest decode throughput yet: **212.9 tokens/s** with **0.31 s/answer** median latency.
- **Pass Rate**: **40/63 (63.5%)** on answered cases (57/83 overall, below 77% baseline).
- **Limitations**: Fails schema-constrained Study artifacts (`malformed artifact`) due to syntax errors in JSON output when constrained.
- Run recorded: `20260903T143414Z_mineru-jina_clip-faiss` in `docs/model-history.md`.

Closes #174.