### PR TITLE
Record Phi-mini-MoE-instruct benchmark results (#179)

### DIFF
--- a/docs/model-history.md
+++ b/docs/model-history.md
@@ -47,6 +47,7 @@ version moved three (see "Stack drift" below).
 | `hf.co/noctrex/Granite-4.0-H-Tiny-MXFP4_MOE-GGUF:Granite-4.0-H-Tiny-MXFP4_MOE` | MoE, 4.2 GB | **53 / 63** (84.1%) | 8.4 | 117.2 | 75 *(of 51)* | 0.63 | `20260903T134407Z` |
 | `hf.co/noctrex/OLMoE-1B-7B-0125-Instruct-MXFP4_MOE-GGUF:OLMoE-1B-7B-0125-Instruct-MXFP4_MOE` | MoE, 3.9 GB | **40 / 63** (63.5%) | 7.7 | 212.9 | 66 *(of 51)* | 0.31 | `20260903T143414Z` |
 | `hf.co/noctrex/LFM2-8B-A1B-MXFP4_MOE-GGUF:LFM2-8B-A1B-MXFP4_MOE` | MoE, 4.9 GB | **49 / 63** (77.8%) | 8.2 | 157.7 | 54 *(of 51)* | 0.37 | `20260903T161257Z` |
+| `hf.co/noctrex/Phi-mini-MoE-instruct-MXFP4_MOE-GGUF:Phi-mini-MoE-instruct-MXFP4_MOE` | MoE, 4.9 GB | **5 / 63** (7.9%) | 51.0 | 87.8 | 229 *(of 13)* | 2.52 | `20260903T180057Z` |
 | `qwen3:30b-a3b` | 30B MoE, 3B active, 18 GB | pending | | | | | in progress |
 | `qwen3:8b` | 8B dense, 5.2 GB | pending | | | | | in progress |
 | `mistral-small3.2:24b` | 24B dense, 15 GB | pending | | | | | in progress |


### PR DESCRIPTION
## Summary
Benchmark evaluation of Microsoft's `hf.co/noctrex/Phi-mini-MoE-instruct-MXFP4_MOE-GGUF:Phi-mini-MoE-instruct-MXFP4_MOE` (~4.9 GB, MoE architecture) on the 83 gold evaluation cases.

## Findings
- **Pass Rate**: Failed the gate with **5/63 (7.9%)** on answered cases (22/83 global vs 77% baseline).
- **Speed & Latency**: High token generation rate (87.8 tok/s), but generated excessively long answers averaging 229 tokens, resulting in a high median latency of **51.0 s/case** (2.52 s/answer).
- **Study Features**: Failed all study cases (summary, outline, quiz) due to malformed JSON schemas.
- Model unloaded from VRAM and removed from disk.
- Run recorded: `20260903T180057Z_mineru-jina_clip-faiss` in `docs/model-history.md`.

Closes #179.