### PR TITLE
Remove the lava-lamp markup its stylesheet no longer backs (#188)

### DIFF
--- a/rag/web/frontend/index.html
+++ b/rag/web/frontend/index.html
@@ -6,12 +6,6 @@
     <title>MonkeyGrab</title>
   </head>
   <body>
-    <div class="lava-lamp" aria-hidden="true">
-      <span class="blob blob-1"></span>
-      <span class="blob blob-2"></span>
-      <span class="blob blob-3"></span>
-      <span class="blob blob-4"></span>
-    </div>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>


### PR DESCRIPTION
## Summary

#189 deleted `.lava-lamp` and its four `.blob-*` rules from `index.css`, but the
markup that used them is in `index.html`, one level above `src/`. The grep that
was supposed to prove the class was gone only looked inside `src/`, so four
`aria-hidden` divs stayed in the DOM with nothing styling them.

Invisible before and after — this removes dead markup, it does not change what
renders.

## Issue

Follow-up to #188.

## Test plan

- `grep -rn 'lava-lamp\|blob-[0-9]'` across `*.html`, `*.css`, `*.tsx`, `*.ts`
  (excluding `node_modules` and `dist`) returns nothing.
- `pnpm run lint` and `pnpm run build` green.
- The app was loaded locally after the change; the interface is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)