### PR TITLE
Render the body that follows a heading instead of dropping it (#193)

### DIFF
--- a/rag/web/frontend/src/components/Markdown.tsx
+++ b/rag/web/frontend/src/components/Markdown.tsx
@@ -121,7 +121,26 @@ export function MarkdownContent({ text, compact = false }: { text: string; compa
         const heading = lines[0].match(/^(#{1,3})\s+(.+)$/);
         if (heading) {
           const Tag = heading[1].length === 1 ? 'h2' : heading[1].length === 2 ? 'h3' : 'h4';
-          return <Tag key={i}>{renderInlineMarkdown(heading[2], `h-${i}`)}</Tag>;
+          // The body that follows a heading inside the same block used to be
+          // dropped on the floor: a model that writes "### Title" and the
+          // paragraph on the next line, with no blank line between them, had
+          // everything but its headings deleted from the answer.
+          const body = lines.slice(1);
+          return (
+            <React.Fragment key={i}>
+              <Tag>{renderInlineMarkdown(heading[2], `h-${i}`)}</Tag>
+              {body.length > 0 && (
+                <p>
+                  {body.map((line, j) => (
+                    <React.Fragment key={j}>
+                      {j > 0 && <br />}
+                      {renderInlineMarkdown(line, `hb-${i}-${j}`)}
+                    </React.Fragment>
+                  ))}
+                </p>
+              )}
+            </React.Fragment>
+          );
         }
 
         if (lines.every(line => /^[-*]\s+/.test(line))) {


### PR DESCRIPTION
## Summary

`MarkdownContent` returned early on any block whose first line was a heading,
rendering the heading and discarding `lines.slice(1)`. A model that writes

```
## Mecanismo central
La auto-atencion relaciona posiciones de una secuencia.
```

with no blank line between the two lost the paragraph. Reported from the UI as
answers that show only their section titles.

The answer streamed in full and was stored in full, so nothing reported a
problem anywhere — it just read as if the model had replied in bare headings.
Whether it triggered depended only on the model's blank-line habits, which is
how it went unnoticed.

## Issue

Fixes #193.

## Test plan

Verified by rendering the component to static HTML with `react-dom/server`,
against the same input, before and after:

```
before:  <div class="markdown-content"><h3>Mecanismo central</h3><h3>Estructura</h3></div>
after:   <div class="markdown-content"><h3>Mecanismo central</h3>
         <p>La auto-atencion relaciona posiciones de una secuencia.<br/>Segunda linea del mismo parrafo.</p>
         <h3>Estructura</h3><p>El encoder y el decoder se apilan en capas.</p></div>
```

Three body lines missing before, zero after.

`pnpm run lint` and `pnpm run build` green.

**This PR ships without a test, and that is a gap, not a decision.** The repo has
no frontend test runner — `package.json` has `lint` and `build` only — so the
check above ran as a one-off script outside the tree. Adding a runner touches
`package.json` and CI, so it wants its own issue and agreement rather than
riding along here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)