### PR TITLE
Drop the send button's accent and the store label's icon (#195)

### DIFF
--- a/rag/web/frontend/src/App.tsx
+++ b/rag/web/frontend/src/App.tsx
@@ -962,8 +962,7 @@ export default function App() {
                 className="space-y-6"
               >
                 <div className="space-y-2">
-                  <div className="flex items-center gap-2 pl-2 text-[10px] font-bold text-ink-faint uppercase tracking-widest">
-                    <Database className="h-3 w-3" />
+                  <div className="pl-2 text-[10px] font-bold text-ink-faint uppercase tracking-widest">
                     {T.storesLabel}
                   </div>
                   <div className={`rounded-2xl border border-edge bg-field p-1.5 space-y-1 ${storeBusy || isReindexing || isLoading ? 'opacity-50' : ''}`}>
@@ -1369,7 +1368,7 @@ export default function App() {
                   <button
                     onClick={handleSend}
                     disabled={!input.trim() || isLoading}
-                    className="p-3 bg-brand text-brand-contrast hover:opacity-90 active:scale-95 disabled:opacity-40 disabled:bg-surface-raised disabled:text-ink-faint transition-all flex-shrink-0 rounded-xl"
+                    className="p-3 bg-ink text-surface hover:opacity-90 active:scale-95 disabled:opacity-40 disabled:bg-surface-raised disabled:text-ink-faint transition-all flex-shrink-0 rounded-xl"
                   >
                     {isLoading ? <Loader2 className="w-5 h-5 animate-spin" /> : <Send className="w-5 h-5 ml-0.5" />}
                   </button>
@@ -1378,7 +1377,7 @@ export default function App() {
                 <button
                   onClick={handleSend}
                   disabled={!input.trim() || isLoading}
-                  className="p-3.5 bg-brand text-brand-contrast hover:opacity-90 active:scale-95 disabled:opacity-40 disabled:bg-surface-raised disabled:text-ink-faint transition-all flex-shrink-0 rounded-2xl"
+                  className="p-3.5 bg-ink text-surface hover:opacity-90 active:scale-95 disabled:opacity-40 disabled:bg-surface-raised disabled:text-ink-faint transition-all flex-shrink-0 rounded-2xl"
                 >
                   {isLoading ? (
                     <Loader2 className="w-5 h-5 animate-spin" />


### PR DESCRIPTION
## Summary

Two owner-requested adjustments after using the redesigned interface.

Both send buttons move from `bg-brand` to `bg-ink` with the glyph in
`text-surface`. The accent was `#f6b8d0` in dark and `#b23a76` in light —
measured in a settled state, since a first reading landed inside the 200ms
transition and reported the wrong theme's value. Both read as pink, and the
send button is not where a system this restrained needs to spend its colour.

The `ALMACÉN VECTORIAL` heading loses its database icon.

`brand` keeps one consumer, `selection:bg-brand/25`, so the token still carries
meaning rather than sitting unused.

## Issue

Fixes #195.

## Test plan

- `pnpm run lint` and `pnpm run build` green.
- `grep -c 'bg-brand' src/App.tsx` returns 1, the text-selection rule.
- Both themes reviewed in a browser with the composer non-empty, so the button
  renders enabled rather than in its disabled state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)