### PR TITLE
Keep the fingerprint when a re-index fails on every file

### DIFF
--- a/rag/engine/indexing.py
+++ b/rag/engine/indexing.py
@@ -47,6 +47,13 @@ def indexar_documentos(
 
     Returns:
         Total number of chunks successfully indexed.
+
+    Raises:
+        RuntimeError: Every PDF in scope failed to index. The store and its
+            fingerprint are left exactly as they were, so the stale-index
+            warning keeps working and the caller can report the failure
+            (issue #192). A run where only *some* files failed returns
+            normally: those failures are logged per file.
     """
     os.makedirs(carpeta, exist_ok=True)
     archivos_pdf = [f for f in os.listdir(carpeta) if f.endswith(".pdf")]
@@ -105,6 +112,8 @@ def indexar_documentos(
     )
 
     total_chunks = 0
+    fallos = 0
+    ultimo_error = None
     for idx, archivo in enumerate(archivos_pdf):
         if progress_callback:
             try:
@@ -125,6 +134,8 @@ def indexar_documentos(
             # this line went to the log and a second one to the user's console;
             # both now land in logging, and `silent` no longer distinguishes
             # them -- it silences progress chatter, not failures.
+            fallos += 1
+            ultimo_error = e
             logging.error(f"Error processing {archivo}: {e}")
 
     # Only a full-folder run (solo_archivos=None) can vouch for the *entire*
@@ -137,16 +148,31 @@ def indexar_documentos(
     # silently launder away a real mismatch from an earlier config change,
     # exactly what index_fingerprint_mismatch exists to catch.
     #
-    # Written even when some individual files failed above (per-file
+    # Written even when *some* individual files failed above (per-file
     # exceptions are caught and logged, not re-raised): the fingerprint
     # asserts the *recipe* whatever ended up stored was built under, not that
     # every requested file is present -- unlike run_eval.ensure_indexed, whose
     # write-after-verify exists to guarantee a specific set of gold-case
     # papers landed, a different property. Every chunk actually added this
     # pass did go through `config`, so the recipe claim holds regardless of
-    # which files errored; a fully failed run leaves an empty store, which the
-    # `collection.count() == 0` branch in the web app re-attempts on next
-    # launch without ever consulting this fingerprint.
+    # which files errored.
+    #
+    # A run where *every* file failed is the exception, and it raises before
+    # reaching that write (issue #192). Such a run stored nothing, so there is
+    # no recipe to assert -- and writing one would actively hide the failure:
+    # the stored value would match the config in force, turning off the
+    # index_fingerprint_mismatch warning that is the only thing standing
+    # between the user and a silently empty store. The per-file logging.error
+    # above goes to the server's stdout, which is not where anyone running the
+    # packaged desktop app is looking; raising is what puts the failure on the
+    # channel the web layer already surfaces (_state["indexing_error"]).
+    if fallos and fallos == len(archivos_pdf):
+        raise RuntimeError(
+            f"Indexing failed on all {fallos} file(s) in {carpeta}; "
+            f"the store and its fingerprint were left untouched. "
+            f"Last error: {ultimo_error}"
+        )
+
     if solo_archivos is None:
         collection.write_fingerprint(compute_index_fingerprint(config))
 

--- a/tests/test_web_indexing_total_failure.py
+++ b/tests/test_web_indexing_total_failure.py
@@ -1,0 +1,70 @@
+"""Tests that a re-index failing on every file reaches the interface (issue #192).
+
+The bug this pins: those per-file failures were caught and logged, the run
+returned 0 chunks, and the web layer read that 0 as ``indexing_done_empty``.
+The user got "no documents indexed" -- the same screen as a genuinely empty
+corpus folder -- for a corpus that had six PDFs and lost all of them.
+
+Doubles ``indexar_documentos`` rather than driving the real stack: what is
+under test is which state the web layer lands in, not extraction itself, which
+tests/unit/test_indexing_fingerprint.py covers.
+"""
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from rag.web import app as web_app  # noqa: E402
+
+
+class _FakeStore:
+    def count(self):
+        return 0
+
+
+def _reset_state(monkeypatch):
+    for key, value in (
+        ("indexing", True),
+        ("indexing_failed", False),
+        ("indexing_error", None),
+        ("indexing_done_empty", False),
+        ("indexing_progress", None),
+    ):
+        monkeypatch.setitem(web_app._state, key, value)
+
+
+def test_a_run_that_fails_on_every_file_reports_an_error_not_an_empty_corpus(monkeypatch):
+    _reset_state(monkeypatch)
+    monkeypatch.setattr(web_app, "_get_collection", lambda: _FakeStore())
+
+    def _all_files_fail(*_a, **_kw):
+        raise RuntimeError("Indexing failed on all 6 file(s) in rag/docs/en")
+
+    monkeypatch.setattr(web_app.rag_engine, "indexar_documentos", _all_files_fail)
+
+    web_app._run_indexing_bg()
+
+    assert web_app._state["indexing_failed"] is True
+    assert "all 6 file(s)" in web_app._state["indexing_error"]
+    # The distinction the bug erased: an empty corpus and a corpus that failed
+    # to index are different screens, and only one of them tells the user to
+    # do something about it.
+    assert web_app._state["indexing_done_empty"] is False
+    assert web_app._state["indexing"] is False
+
+
+def test_a_run_with_no_pdfs_still_reports_an_empty_corpus(monkeypatch):
+    # The other side of the same branch: nothing to index is not a failure,
+    # and must keep reaching the "no documents" screen rather than an error.
+    _reset_state(monkeypatch)
+    monkeypatch.setattr(web_app, "_get_collection", lambda: _FakeStore())
+    monkeypatch.setattr(web_app.rag_engine, "indexar_documentos", lambda *_a, **_kw: 0)
+
+    web_app._run_indexing_bg()
+
+    assert web_app._state["indexing_failed"] is False
+    assert web_app._state["indexing_error"] is None
+    assert web_app._state["indexing_done_empty"] is True

--- a/tests/unit/test_indexing_fingerprint.py
+++ b/tests/unit/test_indexing_fingerprint.py
@@ -10,6 +10,8 @@ tests/conftest.py.
 
 from types import SimpleNamespace
 
+import pytest
+
 from monkeygrab.application.index_fingerprint import compute_index_fingerprint
 from monkeygrab.config.app_config import AppConfig
 
@@ -141,3 +143,74 @@ def test_mismatch_check_never_blocks_startup_on_a_read_failure(monkeypatch):
             raise OSError("sidecar file is locked")
 
     assert indexing.index_fingerprint_mismatch(_BrokenStore()) is False
+
+
+class _FailingIndexCorpus:
+    """An IndexCorpus whose every run raises -- the shape issue #192 reports,
+    where extraction failed on every file of a full re-index."""
+
+    def __init__(self, *_a, **_kw):
+        pass
+
+    def run(self, *_a, **_kw):
+        raise RuntimeError("CUDA out of memory")
+
+
+def test_run_where_every_file_fails_keeps_the_previous_fingerprint(tmp_path, monkeypatch):
+    # Issue #192: the fingerprint asserts the recipe the stored corpus was
+    # built under. A run that indexed nothing built no corpus, so writing it
+    # here would silence index_fingerprint_mismatch -- the one warning that
+    # would have told the user their store is empty because a re-index failed,
+    # not because they never indexed.
+    (tmp_path / "paper.pdf").write_bytes(b"%PDF-1.4")
+    config = _config()
+    _wire_fakes(monkeypatch, config)
+    monkeypatch.setattr(indexing, "IndexCorpus", _FailingIndexCorpus)
+    store = _FakeStore(fingerprint="pre-existing-value")
+
+    with pytest.raises(RuntimeError):
+        indexing.indexar_documentos(str(tmp_path), store, silent=True)
+
+    assert store.read_fingerprint() == "pre-existing-value"
+
+
+def test_run_where_every_file_fails_raises_so_the_ui_can_report_it(tmp_path, monkeypatch):
+    # The failures themselves only reach logging.error, i.e. the terminal that
+    # started the server -- not where anyone running the desktop app is
+    # looking. Raising is what puts the run on the channel the web layer
+    # already surfaces (_state["indexing_error"], read by /api/status).
+    (tmp_path / "a.pdf").write_bytes(b"%PDF-1.4")
+    (tmp_path / "b.pdf").write_bytes(b"%PDF-1.4")
+    config = _config()
+    _wire_fakes(monkeypatch, config)
+    monkeypatch.setattr(indexing, "IndexCorpus", _FailingIndexCorpus)
+
+    with pytest.raises(RuntimeError, match="2"):
+        indexing.indexar_documentos(str(tmp_path), _FakeStore(), silent=True)
+
+
+def test_a_run_where_only_some_files_fail_still_writes_the_fingerprint(tmp_path, monkeypatch):
+    # Deliberately unchanged by issue #192: every chunk that did land went
+    # through this config, so the recipe claim holds. Only a run that stored
+    # nothing at all fails to earn the fingerprint.
+    (tmp_path / "ok.pdf").write_bytes(b"%PDF-1.4")
+    (tmp_path / "bad.pdf").write_bytes(b"%PDF-1.4")
+    config = _config()
+    _wire_fakes(monkeypatch, config)
+
+    class _HalfFailingIndexCorpus:
+        def __init__(self, *_a, **_kw):
+            pass
+
+        def run(self, _path, nombre, *_a, **_kw):
+            if nombre == "bad.pdf":
+                raise RuntimeError("extraction failed")
+            return SimpleNamespace(chunks_indexed=3)
+
+    monkeypatch.setattr(indexing, "IndexCorpus", _HalfFailingIndexCorpus)
+    store = _FakeStore()
+
+    total = indexing.indexar_documentos(str(tmp_path), store, silent=True)
+
+    assert total == 3
+    assert store.read_fingerprint() == compute_index_fingerprint(config)


### PR DESCRIPTION
Closes #192.

## The problem

A full re-index that failed on all six PDFs (CUDA OOM per file, caught by the
per-file `except`) still wrote the new fingerprint and returned 0 chunks. That
combination is what made it invisible: the store was empty *and* the stored
fingerprint now matched the config in force, so `index_fingerprint_mismatch`
had nothing to report. The user saw `0 fragmentos`, `COLECCIÓN (0 DOCS)` and
"no documents indexed" — the same screen as a genuinely empty corpus folder —
with no error anywhere. The failures went to `logging.error`, i.e. the terminal
that started the server, not where anyone running the desktop app is looking.

## The change

`indexar_documentos` now raises when *every* file in scope failed. That single
change covers both halves of the issue's closure criterion:

- the previous fingerprint is left in place, because the raise happens before
  the write, so the stale-index warning keeps working;
- the failure reaches the interface, because `_run_indexing_bg` already turns
  an exception into `_state["indexing_error"]` / `indexing_failed`, which the
  frontend already renders as an error screen with a retry action.

Runs where only *some* files failed are deliberately unchanged: every chunk
that did land went through this config, so the fingerprint's recipe claim
still holds. The comment block explaining that reasoning was updated rather
than left contradicting the code.

## Tests

- `tests/unit/test_indexing_fingerprint.py`: a run whose `IndexCorpus` always
  raises keeps the previous fingerprint and raises with the file count; a run
  where only one of two files fails still writes it.
- `tests/test_web_indexing_total_failure.py`: pins the observable difference at
  the web layer — a total failure lands in `indexing_failed`, and an empty
  corpus folder still lands in `indexing_done_empty`. Those are two different
  screens, and the bug collapsed them into one.

Full suite: 1076 passed, 2 skipped (Ollama-dependent). `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)