### PR TITLE
Replace a dead jina-clip worker instead of poisoning the process

### DIFF
--- a/rag/README.md
+++ b/rag/README.md
@@ -30,6 +30,16 @@ expects. MinerU, Jina CLIP and FAISS are built by the fixed composition root.
 The consequence worth knowing: the web app, desktop wrapper and evaluation
 gate execute the same indexing, retrieval and generation implementations.
 
+`wiring.py` also owns the jina-clip worker's lifetime, since it holds the one
+instance the whole process shares. A worker that dies between calls (the OOM
+killer picks it first, being the largest resident process after the model
+server) is replaced on the next request rather than making every later query
+fail until a restart. The adapter itself still never respawns its own worker,
+so a genuine crash loop stays visible as repeated failures; `wiring` is the
+caller its docstring points at. `release_embedder()` frees that worker after
+an indexing run that failed, where it would otherwise sit on ~1.7 GiB that
+the next attempt needs.
+
 [`engine/settings.py`](engine/settings.py) owns the other half of that
 agreement: the model roles, active store and pipeline flags the web control
 panel saves are read at startup so the session reopens under the user's

--- a/rag/chat_pdfs.py
+++ b/rag/chat_pdfs.py
@@ -507,6 +507,7 @@ from rag.engine.settings import (
 )
 from rag.engine.wiring import (
     app_config_from_runtime,
+    release_embedder,
     reset_vector_store_cache,
     vector_store,
 )

--- a/rag/engine/wiring.py
+++ b/rag/engine/wiring.py
@@ -12,6 +12,7 @@ not cheap is cached here instead: the Cross-Encoder weights and the tokenized
 BM25 corpus would otherwise be rebuilt on every question.
 """
 
+import logging
 import threading
 from typing import Any, Dict
 
@@ -126,25 +127,89 @@ def embedder(config: AppConfig):
     instance is unreachable yet pinned alive by its own stdout/stderr pump
     threads once its worker has started, so nothing ever closes it (#46).
 
-    Unlike ``vector_store``/``lexical_index``, this slot is never re-keyed
-    or republished -- there is no corpus- or config-dependent identity to
-    switch, and nothing today ever resets it, so once built it holds the
-    one instance that will ever exist for the process's life. The #57
-    read race (validate one value, return another) has nothing to attach
-    to here. That reasoning is conditional on there staying no
-    invalidation path: a future GPU-release routine that swaps this slot
-    back to ``None`` to free VRAM would reopen the window, and the
-    ``(key, value)`` tuple trick used above would not close it here --
-    returning a locally-captured reference cannot stop a concurrent
-    ``close()`` on the very object it points to. That would need an
-    ownership rule (e.g. refcounting callers, or not invalidating the
-    slot until nothing still holds it), not just an atomic-looking read.
+    This slot is never re-keyed by corpus or config -- there is no
+    config-dependent identity to switch -- but it *is* invalidated in two
+    cases, both added for issue #191:
+
+    1. The cached instance reports ``is_unusable``. ``JinaClipEmbedder``
+       deliberately refuses to respawn its own worker so a crash loop stays
+       visible; its docstring names this caller as the one that builds a
+       replacement. Without that, a worker killed by the OOM killer made
+       every later query fail with "no longer usable" until the whole
+       server was restarted.
+    2. ``release_embedder`` was called (see below).
+
+    Both paths run under ``_embedder_cache_lock``, so two threads that
+    observe the same dead instance produce exactly one replacement rather
+    than two workers competing for the same 8GB card.
+
+    The read race this module's own history warns about (#57: validate one
+    value, return another) applies to invalidation, not to case 1: a
+    locally-captured reference cannot stop a concurrent ``close()`` on the
+    object it points to. Case 1 is safe because the instance being replaced
+    is already dead -- every call on it fails regardless of who holds it, so
+    a concurrent holder loses nothing. Case 2 is not safe in general, which
+    is why ``release_embedder`` has exactly one caller and that caller runs
+    where indexing has already failed; see its docstring.
     """
-    if _embedder_cache["embedder"] is None:
-        with _embedder_cache_lock:
-            if _embedder_cache["embedder"] is None:
-                _embedder_cache["embedder"] = build_embedder(config)
+    cached = _embedder_cache["embedder"]
+    if cached is not None and not _is_unusable(cached):
+        return cached
+
+    with _embedder_cache_lock:
+        cached = _embedder_cache["embedder"]
+        if cached is not None and _is_unusable(cached):
+            _close_quietly(cached)
+            _embedder_cache["embedder"] = cached = None
+        if cached is None:
+            _embedder_cache["embedder"] = build_embedder(config)
     return _embedder_cache["embedder"]
+
+
+def _is_unusable(instance) -> bool:
+    """Whether an embedder has retired itself, for embedders that can say so.
+
+    ``getattr`` rather than an isinstance check: the port is a Protocol and
+    test doubles satisfy it structurally, so an embedder with no opinion on
+    liveness (every double that never dies) reads as usable.
+    """
+    return bool(getattr(instance, "is_unusable", False))
+
+
+def _close_quietly(instance) -> None:
+    """Best-effort ``close()``. Releasing VRAM must never be what raises:
+    refusing to drop a dead instance because its pipes were already gone
+    would strand the very object being replaced."""
+    try:
+        instance.close()
+    except Exception:
+        logging.warning("Failed to close the previous embedder", exc_info=True)
+
+
+def release_embedder() -> None:
+    """Close the cached embedder and empty the slot.
+
+    Exists for one caller: the web layer's background indexing thread, on
+    the path where a run failed (issue #191). A worker that has just failed
+    a whole re-index is holding ~1.7 GiB and nothing is going to use it
+    again, which is what made the *next* attempt fail on memory the previous
+    failure was holding -- naming a PID with no visible connection to
+    anything the user did.
+
+    Deliberately not called after a successful run: that worker is the one
+    the next query will use, and reloading jina-clip costs ~29s.
+
+    Ownership rule, since ``embedder`` above returns a bare reference: only
+    call this where no retrieval can be in flight. The failed-indexing path
+    qualifies because the store it would have queried is empty. This is not
+    a general-purpose "free the GPU" entry point, and adding a second caller
+    means answering the ownership question that docstring raises, not just
+    reusing this one.
+    """
+    with _embedder_cache_lock:
+        instance, _embedder_cache["embedder"] = _embedder_cache["embedder"], None
+    if instance is not None:
+        _close_quietly(instance)
 
 
 def rag_chat_model(config: AppConfig) -> OllamaChatModel:
@@ -490,6 +555,7 @@ __all__ = [
     "rag_chat_model",
     "recomp_chat_model",
     "reranker",
+    "release_embedder",
     "reset_vector_store_cache",
     "retrieval_metrics_to_legacy",
     "vector_store",

--- a/rag/web/app.py
+++ b/rag/web/app.py
@@ -175,6 +175,13 @@ def _run_indexing_bg():
     except Exception as e:
         _state["indexing_error"] = str(e)
         _state["indexing_failed"] = True
+        # The worker that just failed a whole re-index is holding ~1.7 GiB and
+        # nothing is going to use it again. Left alive it makes the *next*
+        # attempt fail on memory this failure is holding, blaming a PID with
+        # no visible connection to anything the user did (issue #191). Safe
+        # here specifically: the store this run would have filled is empty, so
+        # no retrieval can be mid-flight against it.
+        rag_engine.release_embedder()
     finally:
         _state["indexing"] = False
         _state["indexing_progress"] = None

--- a/src/monkeygrab/adapters/embedding/jina_clip_embedder.py
+++ b/src/monkeygrab/adapters/embedding/jina_clip_embedder.py
@@ -129,6 +129,26 @@ class JinaClipEmbedder:
 
     # lifecycle
 
+    @property
+    def is_unusable(self) -> bool:
+        """Whether this instance has retired its worker for good.
+
+        Exists so the caller named in the class docstring -- the one that
+        "wants a fresh worker constructs a new JinaClipEmbedder" -- can act on
+        that rule without catching an exception per call or reading a private
+        attribute (issue #191). This adapter still never respawns on its own;
+        deciding to build a replacement stays outside it, which is what keeps
+        a crash loop visible as repeated construction rather than hidden
+        behind an apparently healthy instance.
+
+        A worker that has not started yet reads ``False``: nothing has died.
+        """
+        if self._dead_reason is not None:
+            return True
+        # Death observed only now, between calls -- the same lazy check
+        # _ensure_worker makes, without the side effect of recording it.
+        return self._process is not None and self._process.poll() is not None
+
     def _ensure_worker(self) -> subprocess.Popen:
         if self._process is not None:
             if self._process.poll() is None:

--- a/tests/test_web_indexing_releases_worker.py
+++ b/tests/test_web_indexing_releases_worker.py
@@ -1,0 +1,71 @@
+"""Tests that a failed indexing run releases the jina-clip worker (issue #191).
+
+The observed shape: a re-index failed on every file, and seven minutes later
+the worker was still alive holding 1784 MiB. The next attempt then failed with
+a *different* error than the first -- CUDA OOM naming the orphan's PID -- so
+the second failure blamed memory the first failure was holding.
+
+Doubles the engine entirely: what is under test is which lifecycle call the
+web layer makes on each path, not indexing or CUDA.
+"""
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from rag.web import app as web_app  # noqa: E402
+
+
+class _FakeStore:
+    def count(self):
+        return 0
+
+
+def _reset_state(monkeypatch):
+    for key, value in (
+        ("indexing", True),
+        ("indexing_failed", False),
+        ("indexing_error", None),
+        ("indexing_done_empty", False),
+        ("indexing_progress", None),
+    ):
+        monkeypatch.setitem(web_app._state, key, value)
+
+
+def _track_release(monkeypatch):
+    calls = []
+    monkeypatch.setattr(web_app.rag_engine, "release_embedder", lambda: calls.append(1))
+    monkeypatch.setattr(web_app, "_get_collection", lambda: _FakeStore())
+    return calls
+
+
+def test_a_failed_indexing_run_releases_the_worker(monkeypatch):
+    _reset_state(monkeypatch)
+    released = _track_release(monkeypatch)
+
+    def _boom(*_a, **_kw):
+        raise RuntimeError("Indexing failed on all 6 file(s)")
+
+    monkeypatch.setattr(web_app.rag_engine, "indexar_documentos", _boom)
+
+    web_app._run_indexing_bg()
+
+    assert released == [1], "the worker holding VRAM must not outlive the run that failed"
+    assert web_app._state["indexing_failed"] is True
+
+
+def test_a_successful_indexing_run_keeps_the_worker(monkeypatch):
+    # Deliberate asymmetry: that worker is the one the next query will use,
+    # and reloading jina-clip costs ~29s. Releasing here would trade an
+    # orphaned-VRAM bug for a latency one.
+    _reset_state(monkeypatch)
+    released = _track_release(monkeypatch)
+    monkeypatch.setattr(web_app.rag_engine, "indexar_documentos", lambda *_a, **_kw: 885)
+
+    web_app._run_indexing_bg()
+
+    assert released == []
+    assert web_app._state["indexing_failed"] is False

--- a/tests/unit/adapters/test_jina_clip_embedder.py
+++ b/tests/unit/adapters/test_jina_clip_embedder.py
@@ -638,3 +638,22 @@ def test_a_stale_pump_thread_does_not_leak_its_stderr_into_a_fresh_workers_tail(
 
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-v"]))
+
+
+def test_a_fresh_embedder_is_not_unusable(monkeypatch):
+    # Nothing has died yet -- an embedder whose worker has never started must
+    # not read as retired, or wiring would replace it before its first use.
+    embedder, _calls = _embedder(monkeypatch)
+
+    assert embedder.is_unusable is False
+
+
+def test_an_embedder_whose_worker_died_reports_itself_unusable(monkeypatch):
+    # The signal wiring.embedder reads to build a replacement (issue #191).
+    # The adapter still refuses to respawn on its own; it only says so.
+    embedder, _calls = _embedder(monkeypatch, startup_message="eof")
+
+    with pytest.raises(RuntimeError):
+        embedder.embed("first")
+
+    assert embedder.is_unusable is True

--- a/tests/unit/test_wiring_embedder_replacement.py
+++ b/tests/unit/test_wiring_embedder_replacement.py
@@ -1,0 +1,174 @@
+"""Tests for replacing a dead jina-clip worker instead of poisoning the process (#191).
+
+``JinaClipEmbedder`` deliberately never respawns its own worker: a crash loop
+must stay a visible, repeated failure rather than hide behind what looks like
+uninterrupted operation. Its class docstring names the way out -- "a caller
+that wants a fresh worker constructs a new JinaClipEmbedder" -- and this is
+that caller. Before this, ``wiring.embedder`` cached one instance for the
+life of the process, so a worker killed by the OOM killer made every
+subsequent query fail until the whole server was restarted.
+
+The adapter's own policy is unchanged and still pinned by
+tests/unit/adapters/test_jina_clip_embedder.py.
+"""
+
+import sys
+import threading
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import rag.chat_pdfs  # noqa: E402,F401
+from monkeygrab.config.app_config import AppConfig  # noqa: E402
+from rag.engine import wiring  # noqa: E402
+
+
+class _FakeEmbedder:
+    """Stands in for JinaClipEmbedder: only the liveness contract matters."""
+
+    def __init__(self):
+        self.unusable = False
+        self.closed = False
+
+    @property
+    def is_unusable(self) -> bool:
+        return self.unusable
+
+    def close(self):
+        self.closed = True
+
+
+def _reset_cache():
+    with wiring._embedder_cache_lock:
+        wiring._embedder_cache["embedder"] = None
+
+
+def _patch_builder(monkeypatch):
+    built = []
+
+    def _build(_config):
+        instance = _FakeEmbedder()
+        built.append(instance)
+        return instance
+
+    monkeypatch.setattr(wiring, "build_embedder", _build)
+    return built
+
+
+def test_a_live_embedder_is_reused(monkeypatch):
+    _reset_cache()
+    built = _patch_builder(monkeypatch)
+    config = AppConfig()
+
+    first = wiring.embedder(config)
+    second = wiring.embedder(config)
+
+    assert first is second
+    assert len(built) == 1
+
+
+def test_a_dead_embedder_is_replaced_on_the_next_call(monkeypatch):
+    # The issue's shape: the worker is killed (OOM killer picks it first,
+    # being the largest resident process after the model server) and every
+    # later query fails with "no longer usable" until app.py is restarted.
+    _reset_cache()
+    built = _patch_builder(monkeypatch)
+    config = AppConfig()
+
+    first = wiring.embedder(config)
+    first.unusable = True
+
+    second = wiring.embedder(config)
+
+    assert second is not first
+    assert len(built) == 2
+    assert second.is_unusable is False
+
+
+def test_the_replaced_embedder_is_closed_not_leaked(monkeypatch):
+    # A dead worker's process object is gone, but close() also releases the
+    # pipes and pump threads that otherwise pin the instance alive (#46).
+    _reset_cache()
+    _patch_builder(monkeypatch)
+    config = AppConfig()
+
+    first = wiring.embedder(config)
+    first.unusable = True
+    wiring.embedder(config)
+
+    assert first.closed is True
+
+
+def test_release_embedder_closes_the_worker_and_empties_the_slot(monkeypatch):
+    # Issue #191's other half: an indexing run that raised left the worker
+    # alive holding 1.7 GiB, so the *next* attempt failed on memory the
+    # previous failure was holding -- blaming a PID with no visible
+    # connection to anything the user did.
+    _reset_cache()
+    built = _patch_builder(monkeypatch)
+    config = AppConfig()
+
+    first = wiring.embedder(config)
+    wiring.release_embedder()
+
+    assert first.closed is True
+    assert wiring._embedder_cache["embedder"] is None
+
+    second = wiring.embedder(config)
+    assert second is not first
+    assert len(built) == 2
+
+
+def test_release_embedder_with_nothing_built_is_a_no_op():
+    _reset_cache()
+    wiring.release_embedder()
+    assert wiring._embedder_cache["embedder"] is None
+
+
+def test_a_failing_close_still_empties_the_slot(monkeypatch):
+    # Releasing VRAM is best-effort; refusing to clear the slot because
+    # close() threw would strand the very instance we are replacing.
+    _reset_cache()
+    monkeypatch.setattr(wiring, "build_embedder", lambda _c: _RefusingEmbedder())
+
+    wiring.embedder(AppConfig())
+    wiring.release_embedder()
+
+    assert wiring._embedder_cache["embedder"] is None
+
+
+class _RefusingEmbedder(_FakeEmbedder):
+    def close(self):
+        raise OSError("pipe already gone")
+
+
+def test_replacement_under_concurrency_builds_exactly_one_new_embedder(monkeypatch):
+    # Same race the double-checked locking in this module exists to close
+    # (#46): two threads observing the same dead instance must not each
+    # construct a replacement, since each duplicate loads jina-clip onto the
+    # same 8GB card.
+    _reset_cache()
+    built = _patch_builder(monkeypatch)
+    config = AppConfig()
+
+    dead = wiring.embedder(config)
+    dead.unusable = True
+
+    start = threading.Barrier(4)
+    seen = []
+
+    def _worker():
+        start.wait()
+        seen.append(wiring.embedder(config))
+
+    threads = [threading.Thread(target=_worker) for _ in range(3)]
+    for t in threads:
+        t.start()
+    start.wait()
+    for t in threads:
+        t.join()
+
+    assert len(built) == 2, "one initial build plus exactly one replacement"
+    assert len({id(e) for e in seen}) == 1


### PR DESCRIPTION
Closes #191.

## The two failures

Both from the 2026-09-04 incident, both leaving the app unusable until a full restart.

**No replacement when it dies.** A worker that exits between calls marks the
adapter permanently dead, and `wiring.embedder` cached that one instance for the
life of the process — so every later query failed with `jina-clip worker is no
longer usable` until `rag/web/app.py` was restarted. A worker can die without a
person typing `kill`: the OOM killer picks it first, being the largest resident
process after the model server.

**Orphaned worker.** A re-index that failed on every file left the worker alive
holding ~1.7 GiB, so the *next* attempt failed with a different error than the
first — CUDA OOM naming the orphan's PID. The second failure blamed memory the
first failure was holding.

## Where the fix went, and why not in the adapter

`JinaClipEmbedder` refuses to respawn its own worker on purpose: a crash loop
must stay a visible, repeated failure rather than hide behind what looks like
uninterrupted operation. That policy is unchanged here, and its existing test
(`test_worker_marked_dead_refuses_further_calls_without_a_new_process`) still
passes untouched.

The adapter's docstring already named the way out — *"a caller that wants a
fresh worker constructs a new JinaClipEmbedder"* — and `wiring` is that caller.
It now replaces a dead instance on the next call, under the same lock that
stops two threads building two workers for one 8GB card. The adapter only
gained an `is_unusable` property so the caller can act on that rule without
catching an exception per call or reading a private attribute.

`release_embedder()` handles the orphan, on the failed-indexing path only. A
successful run deliberately keeps its worker: that is the one the next query
uses, and reloading jina-clip costs ~29s.

## On the ownership question

`wiring.embedder`'s docstring already flagged that adding an invalidation path
reopens a race, because a locally-captured reference cannot stop a concurrent
`close()` on the object it points to. That is answered rather than ignored:

- **Replacing a dead instance is safe** — every call on it already fails, so a
  concurrent holder loses nothing.
- **`release_embedder` is not safe in general**, so it has exactly one caller,
  running where indexing has already failed and the store it would have
  queried is empty. It is documented as not being a general-purpose "free the
  GPU" entry point. `/api/chat` does *not* refuse requests while indexing, so
  this restraint is load-bearing rather than theoretical.

## Verification

Doubles alone would not have shown this, so it was also driven on the real stack:

1. `/api/rag` query → worker up, 2800 MiB on the card.
2. `kill -9` the worker.
3. `/api/rag` again → **answered correctly and started a fresh worker.** Before
   this change that query failed until the server was restarted.
4. `nvidia-smi --query-compute-apps` → no orphan left behind.

Full suite: 1083 passed, 2 skipped (Ollama-dependent). `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)