### PR TITLE
Keep the conversation pinned to the bottom when the mode changes

### DIFF
--- a/rag/web/frontend/src/App.tsx
+++ b/rag/web/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect, useCallback } from 'react';
+import React, { useState, useRef, useEffect, useLayoutEffect, useCallback } from 'react';
 import {
   Send, FileText, Database, Ollama,
   Search, Layers, Menu, X,
@@ -288,7 +288,7 @@ export default function App() {
     recompSynthesis: true,
   });
 
-  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const messagesContainerRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const reindexFileInputRef = useRef<HTMLInputElement>(null);
   const [retryTrigger, setRetryTrigger] = useState(0);
@@ -327,13 +327,36 @@ export default function App() {
   }, [pdfViewer]);
 
   // ---- Scroll to bottom ----
-  const scrollToBottom = useCallback(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  // Scrolls the container itself rather than calling scrollIntoView on a
+  // zero-height anchor: that anchor sat inside the list's pb-32, so aligning
+  // it left the last message short of the bottom, and scrollIntoView also
+  // walks every scrollable ancestor, which is not what "keep this pane at the
+  // bottom" means.
+  const scrollToBottom = useCallback((behavior: ScrollBehavior = 'smooth') => {
+    const el = messagesContainerRef.current;
+    if (!el) return;
+    el.scrollTo({ top: el.scrollHeight, behavior });
   }, []);
 
   useEffect(() => {
     scrollToBottom();
   }, [messages, scrollToBottom]);
+
+  // Switching mode swaps the whole conversation at once. Animating that
+  // scroll means racing the incoming messages' own entry animation, and the
+  // smooth scroll settles against heights that are still changing -- which
+  // is what left the conversation part-way up the pane, cut off at the
+  // bottom. A jump is also what the user expects here: they did not scroll,
+  // they changed view, and arriving mid-conversation reads as lost state.
+  //
+  // useLayoutEffect, not useEffect: this runs after the DOM is updated but
+  // before the browser paints, so the new conversation is never shown at the
+  // wrong offset first. requestAnimationFrame would do the same job one frame
+  // later -- visibly, and not at all while the tab is in the background,
+  // where rAF is throttled to a stop.
+  useLayoutEffect(() => {
+    scrollToBottom('auto');
+  }, [mode, scrollToBottom]);
 
   // ---- Initialize on mount ----
   useEffect(() => {
@@ -1158,7 +1181,7 @@ export default function App() {
         </header>
 
         {/* Chat Area */}
-        <div className="flex-1 overflow-y-auto p-6 md:p-8 custom-scrollbar scroll-smooth relative">
+        <div ref={messagesContainerRef} className="flex-1 overflow-y-auto p-6 md:p-8 custom-scrollbar scroll-smooth relative">
           <div className={`max-w-3xl mx-auto space-y-10 relative z-10 ${mode === 'study' ? 'pb-44' : 'pb-32'}`}>
             <AnimatePresence>
               {messages.length === 0 && !isLoading && (
@@ -1272,7 +1295,6 @@ export default function App() {
                 )}
               </motion.div>
             ))}
-            <div ref={messagesEndRef} />
           </div>
         </div>
 


### PR DESCRIPTION
Closes #199.

## The bug, measured

Switching to Estudiar swaps the message list's bottom padding from `pb-32` to
`pb-44`, because that mode's composer is taller. The content grows 48px, the
scroll offset does not move, and the end of the conversation ends up behind the
composer.

Driving the real app with a reply on screen, cycling Chat → RAG → Chat →
Estudiar → Chat:

| Step | Before | After |
|------|--------|-------|
| after a reply | 0 | 0 |
| in RAG | 0 | 0 |
| back in Chat | 0 | 0 |
| **in Estudiar** | **48px short** | **0** |
| back in Chat | 0 | 0 |

48px is exactly `pb-44` minus `pb-32`.

## The change

**Scroll the pane, not an anchor.** `scrollIntoView` was called on a
zero-height `<div>` that sat *inside* the list's own `pb-32`, so aligning it
was never the same as reaching the bottom — and `scrollIntoView` also scrolls
every scrollable ancestor, which is not what "keep this pane at the bottom"
means. The container is scrolled directly now. Dropping that anchor also
removes the 40px of dead space `space-y-10` was giving it, which is why the
scrollable range shrinks in the numbers above.

**Re-pin on mode change.** The only scroll effect keyed on `messages`, and
switching mode does not change them. A layout effect on `mode` handles it.
`useLayoutEffect` rather than `useEffect` or `requestAnimationFrame`: it runs
after the DOM updates and before paint, so the new geometry is never shown at
the old offset first, and it still runs in a background tab, where rAF is
throttled to a stop.

## A note on how this was verified

The first attempt measured the pane through an embedded browser view whose page
was `document.hidden`. In that state Chromium defers *every* programmatic
scroll — `scrollTo`, `scrollIntoView` and direct `scrollTop` assignment all did
nothing, while synthetic wheel events worked — which made a working autoscroll
look broken and produced a bug that did not exist. The numbers above come from
a real visible page driven with Playwright, with `document.visibilityState`
asserted as `visible`. Worth knowing before anyone measures scroll here again.

Frontend `tsc --noEmit` and `vite build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)