### PR TITLE
Make the message and document actions visible without hovering

### DIFF
--- a/rag/web/frontend/src/App.tsx
+++ b/rag/web/frontend/src/App.tsx
@@ -1027,14 +1027,14 @@ export default function App() {
                           </div>
                           <span className="text-sm text-ink group-hover:text-ink truncate font-medium flex-1 min-w-0">{doc}</span>
                           <button
-                            className="opacity-0 group-hover:opacity-100 p-1.5 rounded-full text-ink-faint hover:text-ink hover:bg-surface-raised transition-all flex-shrink-0"
+                            className="p-1.5 rounded-full text-ink-faint hover:text-ink hover:bg-surface-raised focus-visible:text-ink transition-all flex-shrink-0"
                             onClick={() => openPdf(doc)}
                             title={T.viewPdf}
                           >
                             <Eye className="w-4 h-4" />
                           </button>
                           <button
-                            className="opacity-0 group-hover:opacity-100 p-1.5 rounded-full text-ink-faint hover:text-danger hover:bg-danger/10 transition-all flex-shrink-0 disabled:opacity-50"
+                            className="p-1.5 rounded-full text-ink-faint hover:text-danger hover:bg-danger/10 focus-visible:text-danger transition-all flex-shrink-0 disabled:opacity-50"
                             onClick={() => handleDeleteDoc(doc)}
                             disabled={deletingDoc !== null}
                             title={T.deleteDoc}
@@ -1203,7 +1203,7 @@ export default function App() {
                         )}
                         <button
                           onClick={() => handleCopyMessage(msg)}
-                          className="p-1.5 rounded-full text-ink-faint hover:text-ink hover:bg-surface-raised transition-all opacity-0 group-hover/meta:opacity-100"
+                          className="p-2 rounded-full text-ink-faint hover:text-ink hover:bg-surface-raised focus-visible:text-ink transition-all"
                           title={T.copyMsg}
                         >
                           {copiedId === msg.id ? (


### PR DESCRIPTION
Closes #201.

## The problem

Three actions were rendered with `opacity-0 group-hover:opacity-100`:
**Copiar mensaje** on every chat message, and **Ver PDF** / **Eliminar
documento** on every sidebar document. They did not exist visually until the
pointer happened to be over the right strip.

## Why this is a defect, not a preference

`docs/design/2026-09-04-lenguaje-visual.md` §"El chat" already says what these
should do:

> Las acciones de cada mensaje (copiar, reintentar, ver fuentes) son iconos
> pequeños en `ink-faint` que se activan al pasar por encima. **Presentes, no
> prominentes.**

`opacity-0` makes them absent, not present. This PR does not change the design;
it makes the code match the design that was already decided.

Two consequences that go past discoverability:

- **Touch has no hover**, so on a touch screen these could not be revealed at
  all.
- **One of them is destructive.** "Eliminar documento" materialising under the
  cursor, with nothing beforehand to say it exists, is the worst case of the
  three.

## The change

All three sit in `ink-faint` and brighten to `ink` (or `danger` for delete) on
hover *and* on keyboard focus — the "se activan al pasar por encima" the doc
describes, now including keyboard users. The copy button's hit area goes 28px →
30px, since it is the one people reach for repeatedly (Fitts); the sidebar
pair keeps its size to avoid crowding a six-item list.

## Verification

Driven in a real browser with the pointer parked at (5,5) so nothing is
hovered:

| Action | Computed opacity | Colour |
|--------|------------------|--------|
| Copiar mensaje | `1` | `rgb(111,108,100)` = `ink-faint` |
| Ver PDF | `1` | `ink-faint` |
| Eliminar documento | `1` | `ink-faint` |

Present, and still not prominent. Frontend `tsc --noEmit` and `vite build`
clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)