### PR TITLE
Keep a numbered list's numbering instead of restarting at 1

### DIFF
--- a/rag/web/frontend/src/components/Markdown.tsx
+++ b/rag/web/frontend/src/components/Markdown.tsx
@@ -154,8 +154,13 @@ export function MarkdownContent({ text, compact = false }: { text: string; compa
         }
 
         if (lines.every(line => /^\d+\.\s+/.test(line))) {
+          // Start from the number the model actually wrote. Models routinely
+          // separate list items with a blank line, and blocks are split on
+          // exactly that -- so a ten-item list arrives here as ten one-item
+          // blocks, and every one of them restarted at 1.
+          const firstNumber = Number(lines[0].match(/^(\d+)\./)![1]);
           return (
-            <ol key={i}>
+            <ol key={i} start={firstNumber}>
               {lines.map((line, j) => (
                 <li key={j}>{renderInlineMarkdown(line.replace(/^\d+\.\s+/, ''), `ol-${i}-${j}`)}</li>
               ))}


### PR DESCRIPTION
Closes #203.

## The bug

Every item of a numbered list rendered as `1.` — "list the eight planets" came
back as eight items all numbered 1.

`MarkdownContent` splits text into blocks on blank lines and renders a block as
`<ol>` when every line starts with `\d+\.`. Models routinely separate list
items with a blank line, so one eight-item list arrives as eight one-item
blocks: eight separate `<ol>` elements, each restarting at 1.

## The change

Render the number the model actually wrote, with `<ol start>`. That keeps the
sequence however the list ends up split, without trying to guess which adjacent
blocks were "really" one list.

## Verification

Driven against the running app, reading the rendered DOM:

| | Before | After |
|---|--------|-------|
| `<ol>` elements | 8 | 8 |
| `start` attributes | none | `1,2,3,4,5,6,7,8` |
| Displayed markers | `1.` ×8 | `1.` … `8.` |

Frontend `tsc --noEmit` and `vite build` clean.

## Scope note

While testing I also suspected LaTeX was not being rendered, since replies
contain raw `$...$`. That turned out to be unfounded: the raw text I was
looking at came from the JSON API and from the copy button, and neither goes
through the renderer — `katex` is wired up in `Markdown.tsx` and the inline
pattern does match `$...$`. Nothing changed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)