### PR TITLE
Measure the configuration the product actually runs

### DIFF
--- a/harness/cli.py
+++ b/harness/cli.py
@@ -41,16 +41,58 @@ from harness import proposers as proposers_mod
 
 
 def _build_reference():
-    """The ``AppConfig`` the loop's ratchet, feasibility and latency ceiling measure against."""
+    """The ``AppConfig`` the loop's ratchet, feasibility and latency ceiling measure against.
+
+    Built the way the product builds its own: apply the saved choices in
+    ``settings.json``, then convert the resulting runtime globals. Precedence
+    stays environment > ``settings.json`` > module defaults, because
+    ``cargar_ajustes_persistidos`` already skips every role the environment
+    pins (AGENTS.md section 1, rule 7).
+
+    This used to be ``AppConfig.from_env()`` alone, which never read
+    ``settings.json`` -- so on any machine where the model or the pipeline
+    flags had been chosen in the web UI, the loop searched for improvements
+    around a configuration nobody was running. The RUNBOOK's own §1 warns
+    that a campaign already lost hours to exactly this ("a settings.json
+    value nobody had checked"); reading the file is the fix that warning
+    was asking for.
+
+    The engine stack is imported lazily and its absence is tolerated on
+    purpose: the harness is also exercised where the product's dependencies
+    are not installed at all (its own tests run against fake evaluators, in
+    the CI job that installs nothing). That fallback is announced on stderr
+    rather than taken silently -- degrading to a different reference than the
+    one the operator believes they are measuring is the failure this whole
+    docstring is about.
+    """
     import sys as _sys
     from pathlib import Path as _Path
 
-    src = _Path(__file__).resolve().parents[1] / "src"
-    if str(src) not in _sys.path:
-        _sys.path.insert(0, str(src))
-    from monkeygrab.config.app_config import AppConfig
+    root = _Path(__file__).resolve().parents[1]
+    for entry in (root / "src", root):
+        if str(entry) not in _sys.path:
+            _sys.path.insert(0, str(entry))
 
-    return AppConfig.from_env()
+    try:
+        # rag.chat_pdfs first, deliberately: it owns the runtime globals the
+        # two modules below read and write, and importing either of them as
+        # the entry point instead leaves it half-initialised (the same
+        # ordering tests/unit/test_indexing_fingerprint.py documents).
+        import rag.chat_pdfs  # noqa: F401
+        from rag.engine.settings import cargar_ajustes_persistidos
+        from rag.engine.wiring import app_config_from_runtime
+    except ImportError as exc:
+        from monkeygrab.config.app_config import AppConfig
+
+        print(
+            f"NOTE: engine stack unavailable ({exc.name}); the reference comes from the "
+            "environment and module defaults, ignoring any saved settings.json.",
+            file=sys.stderr,
+        )
+        return AppConfig.from_env()
+
+    cargar_ajustes_persistidos()
+    return app_config_from_runtime()
 
 
 def parse_set_overrides(pairs: Sequence[str]) -> Dict[str, Any]:

--- a/harness/tests/conftest.py
+++ b/harness/tests/conftest.py
@@ -1,0 +1,33 @@
+"""Shared fixtures for the harness tests.
+
+These tests measure the harness's own logic -- comparability, the ratchet, the
+ledger -- against fake evaluators. None of them is about which model this
+machine has configured, so none may depend on it.
+
+Two things would otherwise make them depend on it, and both are invisible
+when they bite:
+
+- ``settings.json`` is gitignored, so CI has no such file and a developer's
+  machine does. A test reading it passes in one place and fails in the other,
+  with nothing on either side saying why.
+- ``rag/web/app.py`` applies that file onto ``rag.chat_pdfs``'s globals at
+  import time, so merely importing the web app anywhere earlier in the run
+  changes what a later test sees. Test order becomes load-bearing.
+
+Pinning the reference to ``AppConfig.from_env()`` closes both. The path that
+does read ``settings.json`` is the product's real one and is covered by
+``tests/test_harness_reference_honours_settings.py``, which controls the file
+instead of inheriting it.
+"""
+
+import pytest
+
+from harness import cli
+
+
+@pytest.fixture(autouse=True)
+def reference_from_env_only(monkeypatch):
+    """Build the campaign reference from the environment alone."""
+    from monkeygrab.config.app_config import AppConfig
+
+    monkeypatch.setattr(cli, "_build_reference", AppConfig.from_env)

--- a/tests/test_harness_reference_honours_settings.py
+++ b/tests/test_harness_reference_honours_settings.py
@@ -1,0 +1,115 @@
+"""The harness's reference config must describe the product as configured
+(issue: the loop measured a configuration nobody runs).
+
+``harness.cli._build_reference`` built its reference with
+``AppConfig.from_env()``, which reads the environment and otherwise falls back
+to ``rag/chat_pdfs.py``'s module defaults. It never read ``settings.json`` --
+the file the web UI writes and the app applies at startup. So on a machine
+whose saved choice is one model, the loop would search for improvements around
+a different one, and around whatever pipeline flags the defaults happen to
+carry.
+
+Lives here rather than in ``harness/tests/`` because it imports the engine
+stack (``rag.engine.wiring``), which the dependency-free CI job cannot load.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import pytest  # noqa: E402
+
+from harness import cli  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def restore_runtime_globals():
+    """Undo what cargar_ajustes_persistidos writes.
+
+    It applies onto ``rag.chat_pdfs``'s module-level globals, which outlive a
+    test. Without this, a test that saves a role leaks it into the next one --
+    and the leak is invisible, because the next test then reads a plausible
+    value that simply came from the wrong place.
+    """
+    import rag.chat_pdfs as cfg
+
+    names = [n for n in dir(cfg) if n.startswith(("MODELO_", "USAR_", "CARPETA_DOCS"))]
+    saved = {n: getattr(cfg, n) for n in names}
+    yield
+    for name, value in saved.items():
+        setattr(cfg, name, value)
+
+
+@pytest.fixture
+def saved_settings(tmp_path, monkeypatch):
+    """Point the settings module at a throwaway file and return a writer."""
+    import rag.chat_pdfs  # noqa: F401
+    from rag.engine import settings as settings_mod
+
+    path = tmp_path / "settings.json"
+    monkeypatch.setattr(settings_mod, "ruta_ajustes", lambda: str(path))
+
+    def write(payload):
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        return path
+
+    return write
+
+
+def test_reference_uses_the_saved_model_roles(saved_settings, monkeypatch):
+    monkeypatch.delenv("OLLAMA_RAG_MODEL", raising=False)
+    saved_settings({"roles": {"rag": "saved-model:latest"}})
+
+    reference = cli._build_reference()
+
+    assert reference.models.rag == "saved-model:latest"
+
+
+def test_the_environment_still_outranks_the_saved_role(saved_settings, monkeypatch):
+    # Precedence is environment > settings.json > module defaults (AGENTS.md
+    # section 1, rule 7). A campaign launched with an exported model must
+    # measure that model, not the one the UI last saved.
+    #
+    # The global is set here as well as the variable, because that is the real
+    # sequence: a launch exports OLLAMA_RAG_MODEL *before* the process starts,
+    # so rag.chat_pdfs binds it at import. Setting only the variable would test
+    # a state that cannot occur -- the environment changing after import -- and
+    # would fail for that reason rather than for a defect.
+    import rag.chat_pdfs as cfg
+
+    monkeypatch.setenv("OLLAMA_RAG_MODEL", "pinned-by-env:latest")
+    monkeypatch.setattr(cfg, "MODELO_RAG", "pinned-by-env:latest")
+    saved_settings({"roles": {"rag": "saved-model:latest"}})
+
+    reference = cli._build_reference()
+
+    assert reference.models.rag == "pinned-by-env:latest"
+
+
+def test_reference_uses_the_saved_pipeline_flags(saved_settings, monkeypatch):
+    # Not only models: the saved flags change what is indexed and what runs
+    # per query, so a reference that ignores them measures a different
+    # pipeline from the one the user has.
+    saved_settings({"flags": {"USAR_CONTEXTUAL_RETRIEVAL": False}})
+
+    reference = cli._build_reference()
+
+    assert reference.flags.usar_contextual_retrieval is False
+
+
+def test_reference_still_builds_with_no_settings_file(tmp_path, monkeypatch):
+    # A clean clone has no settings.json; the reference must fall back to the
+    # module defaults rather than raising.
+    import rag.chat_pdfs  # noqa: F401
+    from rag.engine import settings as settings_mod
+
+    monkeypatch.setattr(settings_mod, "ruta_ajustes", lambda: str(tmp_path / "absent.json"))
+    monkeypatch.delenv("OLLAMA_RAG_MODEL", raising=False)
+
+    reference = cli._build_reference()
+
+    assert reference.models.rag


### PR DESCRIPTION
Closes #205.

## The problem

`--status` reported the campaign reference as `gemma4:e4b` in all four roles —
a model not installed on this machine — while the product runs `Ling-3.0-tiny`.
`_build_reference()` used `AppConfig.from_env()`, which implements environment
and module defaults but skips `settings.json` in the middle. Two pipeline flags
differed too (`USAR_CONTEXTUAL_RETRIEVAL`, `USAR_DESCRIPCION_IMAGEN`), so the
loop would have searched around a pipeline nobody has.

`harness/RUNBOOK.md` §1 already warns that a campaign "lost hours to a
`settings.json` value nobody had checked", and tells the operator to correct it
by hand with `--set` on every launch. This makes that unnecessary.

## The change

The reference is now built the way the product builds its own: apply the saved
choices, then convert the runtime globals via `wiring.app_config_from_runtime`.
Precedence stays environment > `settings.json` > module defaults, since
`cargar_ajustes_persistidos` already skips every role the environment pins.

The engine import is lazy and its absence tolerated — the harness is also
exercised where the product's dependencies are not installed, in the CI job
that installs nothing. That fallback prints to stderr rather than being taken
silently: degrading to a different reference than the operator believes they
are measuring is the exact failure this PR is about.

## The quieter half, which cost more than the first

`settings.json` is gitignored **and** `rag/web/app.py` applies it to
`rag.chat_pdfs`'s globals at import time. Left alone, this change would have
made `harness/tests` pass in CI (no file) and fail locally (file present), and
made test order load-bearing — importing the web app anywhere earlier in a run
changes what a later test sees. Both are invisible failure modes.

`harness/tests/conftest.py` pins the reference to `from_env()` for those tests,
which measure comparability and the ratchet, not this machine. The path that
does read `settings.json` is covered by
`tests/test_harness_reference_honours_settings.py`, which controls the file
instead of inheriting it.

## Verification

```
reference models: rag=hf.co/noctrex/Ling-3.0-tiny-MXFP4_MOE-GGUF:MXFP4_MOE, chat=…, contextual=…, recomp=…
```

- 4 new tests: saved roles are used, saved flags are used, the environment
  still wins, and a machine with no settings file still builds a reference.
- Full suite 1096 passed, 2 skipped. Fast gate (`tests/unit tests/eval
  harness/tests`) 1018 passed. `ruff` clean.
- The six RUNBOOK preflight checks pass, including `--dry-run`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)