### PR TITLE
Let the grader see a number wrapped in a LaTeX style command

### DIFF
--- a/harness/ledger/0001_20260908T083117Z.json
+++ b/harness/ledger/0001_20260908T083117Z.json
@@ -1,0 +1,269 @@
+{
+  "schema_version": 4,
+  "iteration": 1,
+  "parent_iteration": null,
+  "git_commit": "50877bab5c6c3a41a43284253771faa27f41dd72",
+  "config_overrides": {
+    "retrieval.top_k_final": 4
+  },
+  "effective_config": {
+    "models": {
+      "rag": "hf.co/noctrex/Ling-3.0-tiny-MXFP4_MOE-GGUF:MXFP4_MOE",
+      "chat": "hf.co/noctrex/Ling-3.0-tiny-MXFP4_MOE-GGUF:MXFP4_MOE",
+      "contextual": "hf.co/noctrex/Ling-3.0-tiny-MXFP4_MOE-GGUF:MXFP4_MOE",
+      "recomp": "hf.co/noctrex/Ling-3.0-tiny-MXFP4_MOE-GGUF:MXFP4_MOE",
+      "desc": "hf.co/noctrex/Ling-3.0-tiny-MXFP4_MOE-GGUF",
+      "ollama": {
+        "rag_num_ctx": 16384,
+        "query_num_ctx": 2048,
+        "recomp_num_ctx": 8192,
+        "contextual_num_ctx": 32768,
+        "request_timeout": 900,
+        "keep_alive": 0,
+        "generate_retries": 2,
+        "generate_retry_delay": 3,
+        "base_url": "http://localhost:11434"
+      }
+    },
+    "chunking": {
+      "chunk_size": 2000,
+      "chunk_overlap": 400,
+      "min_chunk_length": 150,
+      "contextual_doc_chars": 24000
+    },
+    "retrieval": {
+      "n_semantic_results": 80,
+      "n_keyword_results": 40,
+      "top_k_rerank_candidates": 200,
+      "top_k_final": 4,
+      "n_top_for_expansion": 3,
+      "rrf_k": 60,
+      "bm25_k1": 1.5,
+      "bm25_b": 0.75,
+      "weight_semantic_rrf": 0.55,
+      "weight_bm25_rrf": 0.45,
+      "min_question_length": 10
+    },
+    "reranking": {
+      "score_threshold": 0.65
+    },
+    "context": {
+      "max_context_chars": 24000
+    },
+    "flags": {
+      "usar_contextual_retrieval": false,
+      "usar_llm_query_decomposition": true,
+      "usar_busqueda_hibrida": true,
+      "usar_reranker": true,
+      "expandir_contexto": true,
+      "usar_optimizacion_contexto": true,
+      "usar_recomp_synthesis": true,
+      "usar_embeddings_imagen": true,
+      "usar_descripcion_imagen": true,
+      "logging_metricas": true,
+      "guardar_debug_rag": true
+    },
+    "paths": {
+      "base_dir": "/home/idiaval/dev/personal/localOllamaRAG/rag",
+      "data_dir": "/home/idiaval/dev/personal/localOllamaRAG/rag",
+      "docs_folder": "/home/idiaval/dev/personal/localOllamaRAG/rag/docs/en",
+      "path_db": "/home/idiaval/dev/personal/localOllamaRAG/rag/vector_db/dev_docs_jina_clip",
+      "collection_name": "docs_dev_docs",
+      "historial_path": "/home/idiaval/dev/personal/localOllamaRAG/rag/historial_chat.json",
+      "max_historial_mensajes": 40,
+      "carpeta_debug_rag": "/home/idiaval/dev/personal/localOllamaRAG/rag/debug_rag"
+    }
+  },
+  "proposer": "grid",
+  "proposer_rationale": null,
+  "proposer_model": null,
+  "proposer_fallback": false,
+  "proposer_fallback_reason": null,
+  "evaluated_case_set": "fast_tier",
+  "case_records": [
+    {
+      "id": "att-bleu-table",
+      "case_type": "table_retrieval",
+      "passed": true,
+      "elapsed_seconds": 19.63,
+      "infrastructure_error": false
+    },
+    {
+      "id": "dpo-pipeline-figure-es",
+      "case_type": "figure_retrieval",
+      "passed": false,
+      "elapsed_seconds": 7.4,
+      "infrastructure_error": false
+    },
+    {
+      "id": "gw-strain-figure",
+      "case_type": "figure_retrieval",
+      "passed": true,
+      "elapsed_seconds": 8.37,
+      "infrastructure_error": false
+    },
+    {
+      "id": "higgs-diphoton-figure",
+      "case_type": "figure_retrieval",
+      "passed": false,
+      "elapsed_seconds": 8.8,
+      "infrastructure_error": false
+    },
+    {
+      "id": "planck-contours-figure",
+      "case_type": "figure_retrieval",
+      "passed": false,
+      "elapsed_seconds": 9.98,
+      "infrastructure_error": false
+    },
+    {
+      "id": "att-n-layers",
+      "case_type": "factual_number",
+      "passed": true,
+      "elapsed_seconds": 14.62,
+      "infrastructure_error": false
+    },
+    {
+      "id": "dpo-acronym",
+      "case_type": "factual_concept",
+      "passed": true,
+      "elapsed_seconds": 16.9,
+      "infrastructure_error": false
+    },
+    {
+      "id": "gw-snr",
+      "case_type": "factual_number",
+      "passed": true,
+      "elapsed_seconds": 17.83,
+      "infrastructure_error": false
+    },
+    {
+      "id": "gw-site",
+      "case_type": "factual_concept",
+      "passed": false,
+      "elapsed_seconds": 18.44,
+      "infrastructure_error": false
+    },
+    {
+      "id": "higgs-significance",
+      "case_type": "factual_number",
+      "passed": true,
+      "elapsed_seconds": 16.26,
+      "infrastructure_error": false
+    },
+    {
+      "id": "planck-sigma8-es",
+      "case_type": "factual_number",
+      "passed": true,
+      "elapsed_seconds": 18.67,
+      "infrastructure_error": false
+    },
+    {
+      "id": "planck-h0-tension",
+      "case_type": "factual_concept",
+      "passed": false,
+      "elapsed_seconds": 17.31,
+      "infrastructure_error": false
+    },
+    {
+      "id": "ricci-hamilton-intro",
+      "case_type": "factual_concept",
+      "passed": true,
+      "elapsed_seconds": 15.34,
+      "infrastructure_error": false
+    },
+    {
+      "id": "att-study-outline",
+      "case_type": "study_outline",
+      "passed": true,
+      "elapsed_seconds": 5.81,
+      "infrastructure_error": false
+    },
+    {
+      "id": "att-study-summary",
+      "case_type": "study_summary",
+      "passed": true,
+      "elapsed_seconds": 5.85,
+      "infrastructure_error": false
+    },
+    {
+      "id": "att-study-quiz",
+      "case_type": "study_quiz",
+      "passed": true,
+      "elapsed_seconds": 6.01,
+      "infrastructure_error": false
+    }
+  ],
+  "summary": {
+    "total": 16,
+    "passed": 11,
+    "pass_rate": 0.6875,
+    "by_case_type": {
+      "table_retrieval": {
+        "total": 1,
+        "passed": 1,
+        "pass_rate": 1.0
+      },
+      "figure_retrieval": {
+        "total": 4,
+        "passed": 1,
+        "pass_rate": 0.25
+      },
+      "factual_number": {
+        "total": 4,
+        "passed": 4,
+        "pass_rate": 1.0
+      },
+      "factual_concept": {
+        "total": 4,
+        "passed": 2,
+        "pass_rate": 0.5
+      },
+      "study_outline": {
+        "total": 1,
+        "passed": 1,
+        "pass_rate": 1.0
+      },
+      "study_summary": {
+        "total": 1,
+        "passed": 1,
+        "pass_rate": 1.0
+      },
+      "study_quiz": {
+        "total": 1,
+        "passed": 1,
+        "pass_rate": 1.0
+      }
+    }
+  },
+  "objective_raw": 11,
+  "objective_adjusted": 11,
+  "median_latency_answered_s": 16.26,
+  "median_latency_retrieval_only_s": 8.8,
+  "reference_median_latency_answered_s": 16.16,
+  "reference_median_latency_retrieval_only_s": 7.27,
+  "latency_ceiling_multiplier": 1.2,
+  "verdict": "rejected_regression",
+  "reason": "fast-tier regression on ['dpo-pipeline-figure-es']",
+  "regression_baseline_iteration": null,
+  "environment_fingerprint": {
+    "schema": 1,
+    "packages": {
+      "isolated:mineru": "3.4.5",
+      "isolated:transformers": "4.57.6",
+      "isolated:sentence-transformers": "5.6.1",
+      "isolated:torch": "2.6.0+cu124",
+      "isolated:faiss-cpu": null,
+      "isolated:rank-bm25": null,
+      "isolated:ollama": null,
+      "product:mineru": null,
+      "product:transformers": "5.16.1",
+      "product:sentence-transformers": "6.0.1",
+      "product:torch": "2.13.0",
+      "product:faiss-cpu": "1.15.0",
+      "product:rank-bm25": "0.2.2",
+      "product:ollama": "0.6.2"
+    }
+  },
+  "evaluator": "real"
+}

--- a/harness/ledger/0002_20260908T083454Z.json
+++ b/harness/ledger/0002_20260908T083454Z.json
@@ -1,0 +1,269 @@
+{
+  "schema_version": 4,
+  "iteration": 2,
+  "parent_iteration": 1,
+  "git_commit": "50877bab5c6c3a41a43284253771faa27f41dd72",
+  "config_overrides": {
+    "retrieval.top_k_final": 6
+  },
+  "effective_config": {
+    "models": {
+      "rag": "hf.co/noctrex/Ling-3.0-tiny-MXFP4_MOE-GGUF:MXFP4_MOE",
+      "chat": "hf.co/noctrex/Ling-3.0-tiny-MXFP4_MOE-GGUF:MXFP4_MOE",
+      "contextual": "hf.co/noctrex/Ling-3.0-tiny-MXFP4_MOE-GGUF:MXFP4_MOE",
+      "recomp": "hf.co/noctrex/Ling-3.0-tiny-MXFP4_MOE-GGUF:MXFP4_MOE",
+      "desc": "hf.co/noctrex/Ling-3.0-tiny-MXFP4_MOE-GGUF",
+      "ollama": {
+        "rag_num_ctx": 16384,
+        "query_num_ctx": 2048,
+        "recomp_num_ctx": 8192,
+        "contextual_num_ctx": 32768,
+        "request_timeout": 900,
+        "keep_alive": 0,
+        "generate_retries": 2,
+        "generate_retry_delay": 3,
+        "base_url": "http://localhost:11434"
+      }
+    },
+    "chunking": {
+      "chunk_size": 2000,
+      "chunk_overlap": 400,
+      "min_chunk_length": 150,
+      "contextual_doc_chars": 24000
+    },
+    "retrieval": {
+      "n_semantic_results": 80,
+      "n_keyword_results": 40,
+      "top_k_rerank_candidates": 200,
+      "top_k_final": 6,
+      "n_top_for_expansion": 3,
+      "rrf_k": 60,
+      "bm25_k1": 1.5,
+      "bm25_b": 0.75,
+      "weight_semantic_rrf": 0.55,
+      "weight_bm25_rrf": 0.45,
+      "min_question_length": 10
+    },
+    "reranking": {
+      "score_threshold": 0.65
+    },
+    "context": {
+      "max_context_chars": 24000
+    },
+    "flags": {
+      "usar_contextual_retrieval": false,
+      "usar_llm_query_decomposition": true,
+      "usar_busqueda_hibrida": true,
+      "usar_reranker": true,
+      "expandir_contexto": true,
+      "usar_optimizacion_contexto": true,
+      "usar_recomp_synthesis": true,
+      "usar_embeddings_imagen": true,
+      "usar_descripcion_imagen": true,
+      "logging_metricas": true,
+      "guardar_debug_rag": true
+    },
+    "paths": {
+      "base_dir": "/home/idiaval/dev/personal/localOllamaRAG/rag",
+      "data_dir": "/home/idiaval/dev/personal/localOllamaRAG/rag",
+      "docs_folder": "/home/idiaval/dev/personal/localOllamaRAG/rag/docs/en",
+      "path_db": "/home/idiaval/dev/personal/localOllamaRAG/rag/vector_db/dev_docs_jina_clip",
+      "collection_name": "docs_dev_docs",
+      "historial_path": "/home/idiaval/dev/personal/localOllamaRAG/rag/historial_chat.json",
+      "max_historial_mensajes": 40,
+      "carpeta_debug_rag": "/home/idiaval/dev/personal/localOllamaRAG/rag/debug_rag"
+    }
+  },
+  "proposer": "grid",
+  "proposer_rationale": null,
+  "proposer_model": null,
+  "proposer_fallback": false,
+  "proposer_fallback_reason": null,
+  "evaluated_case_set": "fast_tier",
+  "case_records": [
+    {
+      "id": "att-bleu-table",
+      "case_type": "table_retrieval",
+      "passed": true,
+      "elapsed_seconds": 19.72,
+      "infrastructure_error": false
+    },
+    {
+      "id": "dpo-pipeline-figure-es",
+      "case_type": "figure_retrieval",
+      "passed": false,
+      "elapsed_seconds": 7.26,
+      "infrastructure_error": false
+    },
+    {
+      "id": "gw-strain-figure",
+      "case_type": "figure_retrieval",
+      "passed": true,
+      "elapsed_seconds": 8.69,
+      "infrastructure_error": false
+    },
+    {
+      "id": "higgs-diphoton-figure",
+      "case_type": "figure_retrieval",
+      "passed": false,
+      "elapsed_seconds": 8.37,
+      "infrastructure_error": false
+    },
+    {
+      "id": "planck-contours-figure",
+      "case_type": "figure_retrieval",
+      "passed": false,
+      "elapsed_seconds": 10.27,
+      "infrastructure_error": false
+    },
+    {
+      "id": "att-n-layers",
+      "case_type": "factual_number",
+      "passed": true,
+      "elapsed_seconds": 14.86,
+      "infrastructure_error": false
+    },
+    {
+      "id": "dpo-acronym",
+      "case_type": "factual_concept",
+      "passed": true,
+      "elapsed_seconds": 16.65,
+      "infrastructure_error": false
+    },
+    {
+      "id": "gw-snr",
+      "case_type": "factual_number",
+      "passed": true,
+      "elapsed_seconds": 17.92,
+      "infrastructure_error": false
+    },
+    {
+      "id": "gw-site",
+      "case_type": "factual_concept",
+      "passed": false,
+      "elapsed_seconds": 18.53,
+      "infrastructure_error": false
+    },
+    {
+      "id": "higgs-significance",
+      "case_type": "factual_number",
+      "passed": true,
+      "elapsed_seconds": 16.41,
+      "infrastructure_error": false
+    },
+    {
+      "id": "planck-sigma8-es",
+      "case_type": "factual_number",
+      "passed": true,
+      "elapsed_seconds": 18.57,
+      "infrastructure_error": false
+    },
+    {
+      "id": "planck-h0-tension",
+      "case_type": "factual_concept",
+      "passed": false,
+      "elapsed_seconds": 23.17,
+      "infrastructure_error": true
+    },
+    {
+      "id": "ricci-hamilton-intro",
+      "case_type": "factual_concept",
+      "passed": true,
+      "elapsed_seconds": 15.69,
+      "infrastructure_error": false
+    },
+    {
+      "id": "att-study-outline",
+      "case_type": "study_outline",
+      "passed": true,
+      "elapsed_seconds": 6.58,
+      "infrastructure_error": false
+    },
+    {
+      "id": "att-study-summary",
+      "case_type": "study_summary",
+      "passed": true,
+      "elapsed_seconds": 5.9,
+      "infrastructure_error": false
+    },
+    {
+      "id": "att-study-quiz",
+      "case_type": "study_quiz",
+      "passed": true,
+      "elapsed_seconds": 6.46,
+      "infrastructure_error": false
+    }
+  ],
+  "summary": {
+    "total": 16,
+    "passed": 11,
+    "pass_rate": 0.6875,
+    "by_case_type": {
+      "table_retrieval": {
+        "total": 1,
+        "passed": 1,
+        "pass_rate": 1.0
+      },
+      "figure_retrieval": {
+        "total": 4,
+        "passed": 1,
+        "pass_rate": 0.25
+      },
+      "factual_number": {
+        "total": 4,
+        "passed": 4,
+        "pass_rate": 1.0
+      },
+      "factual_concept": {
+        "total": 4,
+        "passed": 2,
+        "pass_rate": 0.5
+      },
+      "study_outline": {
+        "total": 1,
+        "passed": 1,
+        "pass_rate": 1.0
+      },
+      "study_summary": {
+        "total": 1,
+        "passed": 1,
+        "pass_rate": 1.0
+      },
+      "study_quiz": {
+        "total": 1,
+        "passed": 1,
+        "pass_rate": 1.0
+      }
+    }
+  },
+  "objective_raw": 11,
+  "objective_adjusted": 11,
+  "median_latency_answered_s": 16.41,
+  "median_latency_retrieval_only_s": 8.69,
+  "reference_median_latency_answered_s": 16.16,
+  "reference_median_latency_retrieval_only_s": 7.27,
+  "latency_ceiling_multiplier": 1.2,
+  "verdict": "inconclusive",
+  "reason": "fast-tier evaluation carries infrastructure_error record(s) -- not scored",
+  "regression_baseline_iteration": null,
+  "environment_fingerprint": {
+    "schema": 1,
+    "packages": {
+      "isolated:mineru": "3.4.5",
+      "isolated:transformers": "4.57.6",
+      "isolated:sentence-transformers": "5.6.1",
+      "isolated:torch": "2.6.0+cu124",
+      "isolated:faiss-cpu": null,
+      "isolated:rank-bm25": null,
+      "isolated:ollama": null,
+      "product:mineru": null,
+      "product:transformers": "5.16.1",
+      "product:sentence-transformers": "6.0.1",
+      "product:torch": "2.13.0",
+      "product:faiss-cpu": "1.15.0",
+      "product:rank-bm25": "0.2.2",
+      "product:ollama": "0.6.2"
+    }
+  },
+  "evaluator": "real"
+}

--- a/harness/ledger/0003_20260908T091402Z.json
+++ b/harness/ledger/0003_20260908T091402Z.json
@@ -1,0 +1,507 @@
+{
+  "schema_version": 4,
+  "iteration": 3,
+  "parent_iteration": 2,
+  "git_commit": "50877bab5c6c3a41a43284253771faa27f41dd72",
+  "config_overrides": {
+    "retrieval.top_k_final": 12
+  },
+  "effective_config": {
+    "models": {
+      "rag": "hf.co/noctrex/Ling-3.0-tiny-MXFP4_MOE-GGUF:MXFP4_MOE",
+      "chat": "hf.co/noctrex/Ling-3.0-tiny-MXFP4_MOE-GGUF:MXFP4_MOE",
+      "contextual": "hf.co/noctrex/Ling-3.0-tiny-MXFP4_MOE-GGUF:MXFP4_MOE",
+      "recomp": "hf.co/noctrex/Ling-3.0-tiny-MXFP4_MOE-GGUF:MXFP4_MOE",
+      "desc": "hf.co/noctrex/Ling-3.0-tiny-MXFP4_MOE-GGUF",
+      "ollama": {
+        "rag_num_ctx": 16384,
+        "query_num_ctx": 2048,
+        "recomp_num_ctx": 8192,
+        "contextual_num_ctx": 32768,
+        "request_timeout": 900,
+        "keep_alive": 0,
+        "generate_retries": 2,
+        "generate_retry_delay": 3,
+        "base_url": "http://localhost:11434"
+      }
+    },
+    "chunking": {
+      "chunk_size": 2000,
+      "chunk_overlap": 400,
+      "min_chunk_length": 150,
+      "contextual_doc_chars": 24000
+    },
+    "retrieval": {
+      "n_semantic_results": 80,
+      "n_keyword_results": 40,
+      "top_k_rerank_candidates": 200,
+      "top_k_final": 12,
+      "n_top_for_expansion": 3,
+      "rrf_k": 60,
+      "bm25_k1": 1.5,
+      "bm25_b": 0.75,
+      "weight_semantic_rrf": 0.55,
+      "weight_bm25_rrf": 0.45,
+      "min_question_length": 10
+    },
+    "reranking": {
+      "score_threshold": 0.65
+    },
+    "context": {
+      "max_context_chars": 24000
+    },
+    "flags": {
+      "usar_contextual_retrieval": false,
+      "usar_llm_query_decomposition": true,
+      "usar_busqueda_hibrida": true,
+      "usar_reranker": true,
+      "expandir_contexto": true,
+      "usar_optimizacion_contexto": true,
+      "usar_recomp_synthesis": true,
+      "usar_embeddings_imagen": true,
+      "usar_descripcion_imagen": true,
+      "logging_metricas": true,
+      "guardar_debug_rag": true
+    },
+    "paths": {
+      "base_dir": "/home/idiaval/dev/personal/localOllamaRAG/rag",
+      "data_dir": "/home/idiaval/dev/personal/localOllamaRAG/rag",
+      "docs_folder": "/home/idiaval/dev/personal/localOllamaRAG/rag/docs/en",
+      "path_db": "/home/idiaval/dev/personal/localOllamaRAG/rag/vector_db/dev_docs_jina_clip",
+      "collection_name": "docs_dev_docs",
+      "historial_path": "/home/idiaval/dev/personal/localOllamaRAG/rag/historial_chat.json",
+      "max_historial_mensajes": 40,
+      "carpeta_debug_rag": "/home/idiaval/dev/personal/localOllamaRAG/rag/debug_rag"
+    }
+  },
+  "proposer": "grid",
+  "proposer_rationale": null,
+  "proposer_model": null,
+  "proposer_fallback": false,
+  "proposer_fallback_reason": null,
+  "evaluated_case_set": "search_set",
+  "case_records": [
+    {
+      "id": "att-bleu-table",
+      "case_type": "table_retrieval",
+      "passed": true,
+      "elapsed_seconds": 8.21,
+      "infrastructure_error": false
+    },
+    {
+      "id": "att-arch-figure",
+      "case_type": "figure_retrieval",
+      "passed": true,
+      "elapsed_seconds": 6.69,
+      "infrastructure_error": false
+    },
+    {
+      "id": "att-arch-figure-es",
+      "case_type": "figure_retrieval",
+      "passed": true,
+      "elapsed_seconds": 7.23,
+      "infrastructure_error": false
+    },
+    {
+      "id": "dpo-pipeline-figure",
+      "case_type": "figure_retrieval",
+      "passed": true,
+      "elapsed_seconds": 7.05,
+      "infrastructure_error": false
+    },
+    {
+      "id": "dpo-pipeline-figure-es",
+      "case_type": "figure_retrieval",
+      "passed": true,
+      "elapsed_seconds": 7.28,
+      "infrastructure_error": false
+    },
+    {
+      "id": "gw-strain-figure",
+      "case_type": "figure_retrieval",
+      "passed": true,
+      "elapsed_seconds": 8.85,
+      "infrastructure_error": false
+    },
+    {
+      "id": "higgs-diphoton-figure",
+      "case_type": "figure_retrieval",
+      "passed": false,
+      "elapsed_seconds": 8.0,
+      "infrastructure_error": false
+    },
+    {
+      "id": "planck-contours-figure",
+      "case_type": "figure_retrieval",
+      "passed": true,
+      "elapsed_seconds": 8.88,
+      "infrastructure_error": false
+    },
+    {
+      "id": "planck-params-table",
+      "case_type": "table_retrieval",
+      "passed": true,
+      "elapsed_seconds": 8.81,
+      "infrastructure_error": false
+    },
+    {
+      "id": "att-arch-figure-ca",
+      "case_type": "figure_retrieval",
+      "passed": true,
+      "elapsed_seconds": 6.64,
+      "infrastructure_error": false
+    },
+    {
+      "id": "dpo-pipeline-figure-ca",
+      "case_type": "figure_retrieval",
+      "passed": true,
+      "elapsed_seconds": 6.71,
+      "infrastructure_error": false
+    },
+    {
+      "id": "att-bleu-ende",
+      "case_type": "factual_number",
+      "passed": true,
+      "elapsed_seconds": 27.38,
+      "infrastructure_error": false
+    },
+    {
+      "id": "att-bleu-enfr",
+      "case_type": "factual_number",
+      "passed": true,
+      "elapsed_seconds": 16.46,
+      "infrastructure_error": false
+    },
+    {
+      "id": "att-n-layers",
+      "case_type": "factual_number",
+      "passed": true,
+      "elapsed_seconds": 15.01,
+      "infrastructure_error": false
+    },
+    {
+      "id": "att-dmodel",
+      "case_type": "factual_number",
+      "passed": true,
+      "elapsed_seconds": 16.4,
+      "infrastructure_error": false
+    },
+    {
+      "id": "dpo-acronym",
+      "case_type": "factual_concept",
+      "passed": true,
+      "elapsed_seconds": 15.08,
+      "infrastructure_error": false
+    },
+    {
+      "id": "dpo-no-sampling",
+      "case_type": "factual_concept",
+      "passed": false,
+      "elapsed_seconds": 16.15,
+      "infrastructure_error": false
+    },
+    {
+      "id": "dpo-rlfree",
+      "case_type": "factual_concept",
+      "passed": true,
+      "elapsed_seconds": 13.62,
+      "infrastructure_error": false
+    },
+    {
+      "id": "dpo-model-scale",
+      "case_type": "factual_number",
+      "passed": true,
+      "elapsed_seconds": 14.85,
+      "infrastructure_error": false
+    },
+    {
+      "id": "gw-snr",
+      "case_type": "factual_number",
+      "passed": true,
+      "elapsed_seconds": 17.24,
+      "infrastructure_error": false
+    },
+    {
+      "id": "gw-final-mass",
+      "case_type": "factual_number",
+      "passed": true,
+      "elapsed_seconds": 16.4,
+      "infrastructure_error": false
+    },
+    {
+      "id": "gw-site",
+      "case_type": "factual_concept",
+      "passed": true,
+      "elapsed_seconds": 17.4,
+      "infrastructure_error": false
+    },
+    {
+      "id": "gw-year-es",
+      "case_type": "factual_number",
+      "passed": true,
+      "elapsed_seconds": 17.19,
+      "infrastructure_error": false
+    },
+    {
+      "id": "higgs-mass",
+      "case_type": "factual_number",
+      "passed": true,
+      "elapsed_seconds": 16.11,
+      "infrastructure_error": false
+    },
+    {
+      "id": "higgs-significance",
+      "case_type": "factual_number",
+      "passed": true,
+      "elapsed_seconds": 15.18,
+      "infrastructure_error": false
+    },
+    {
+      "id": "higgs-collider",
+      "case_type": "factual_concept",
+      "passed": true,
+      "elapsed_seconds": 15.32,
+      "infrastructure_error": false
+    },
+    {
+      "id": "higgs-luminosity-es",
+      "case_type": "factual_number",
+      "passed": true,
+      "elapsed_seconds": 16.35,
+      "infrastructure_error": false
+    },
+    {
+      "id": "planck-h0",
+      "case_type": "factual_number",
+      "passed": false,
+      "elapsed_seconds": 22.07,
+      "infrastructure_error": true
+    },
+    {
+      "id": "planck-omega-m",
+      "case_type": "factual_number",
+      "passed": true,
+      "elapsed_seconds": 15.27,
+      "infrastructure_error": false
+    },
+    {
+      "id": "planck-sigma8-es",
+      "case_type": "factual_number",
+      "passed": true,
+      "elapsed_seconds": 17.3,
+      "infrastructure_error": false
+    },
+    {
+      "id": "planck-h0-tension",
+      "case_type": "factual_concept",
+      "passed": false,
+      "elapsed_seconds": 18.09,
+      "infrastructure_error": false
+    },
+    {
+      "id": "ricci-hamilton-intro",
+      "case_type": "factual_concept",
+      "passed": true,
+      "elapsed_seconds": 14.54,
+      "infrastructure_error": false
+    },
+    {
+      "id": "ricci-dimension",
+      "case_type": "factual_number",
+      "passed": true,
+      "elapsed_seconds": 14.03,
+      "infrastructure_error": false
+    },
+    {
+      "id": "ricci-hamilton-es",
+      "case_type": "factual_concept",
+      "passed": true,
+      "elapsed_seconds": 15.78,
+      "infrastructure_error": false
+    },
+    {
+      "id": "att-study-outline",
+      "case_type": "study_outline",
+      "passed": true,
+      "elapsed_seconds": 5.39,
+      "infrastructure_error": false
+    },
+    {
+      "id": "att-study-summary",
+      "case_type": "study_summary",
+      "passed": true,
+      "elapsed_seconds": 5.63,
+      "infrastructure_error": false
+    },
+    {
+      "id": "att-study-quiz",
+      "case_type": "study_quiz",
+      "passed": true,
+      "elapsed_seconds": 6.57,
+      "infrastructure_error": false
+    },
+    {
+      "id": "planck-study-quiz",
+      "case_type": "study_quiz",
+      "passed": true,
+      "elapsed_seconds": 7.0,
+      "infrastructure_error": false
+    },
+    {
+      "id": "gw-year-ca",
+      "case_type": "factual_number",
+      "passed": true,
+      "elapsed_seconds": 17.97,
+      "infrastructure_error": false
+    },
+    {
+      "id": "ricci-hamilton-ca",
+      "case_type": "factual_concept",
+      "passed": true,
+      "elapsed_seconds": 19.48,
+      "infrastructure_error": false
+    },
+    {
+      "id": "higgs-luminosity-ca",
+      "case_type": "factual_number",
+      "passed": true,
+      "elapsed_seconds": 15.64,
+      "infrastructure_error": false
+    },
+    {
+      "id": "planck-sigma8-ca",
+      "case_type": "factual_number",
+      "passed": true,
+      "elapsed_seconds": 16.97,
+      "infrastructure_error": false
+    },
+    {
+      "id": "att-study-summary-es",
+      "case_type": "study_summary",
+      "passed": true,
+      "elapsed_seconds": 5.56,
+      "infrastructure_error": false
+    },
+    {
+      "id": "att-study-outline-es",
+      "case_type": "study_outline",
+      "passed": true,
+      "elapsed_seconds": 5.67,
+      "infrastructure_error": false
+    },
+    {
+      "id": "att-study-quiz-es",
+      "case_type": "study_quiz",
+      "passed": true,
+      "elapsed_seconds": 10.27,
+      "infrastructure_error": false
+    },
+    {
+      "id": "ricci-study-summary-es",
+      "case_type": "study_summary",
+      "passed": true,
+      "elapsed_seconds": 9.39,
+      "infrastructure_error": false
+    },
+    {
+      "id": "att-study-summary-ca",
+      "case_type": "study_summary",
+      "passed": true,
+      "elapsed_seconds": 6.75,
+      "infrastructure_error": false
+    },
+    {
+      "id": "att-study-outline-ca",
+      "case_type": "study_outline",
+      "passed": true,
+      "elapsed_seconds": 5.01,
+      "infrastructure_error": false
+    },
+    {
+      "id": "att-study-quiz-ca",
+      "case_type": "study_quiz",
+      "passed": true,
+      "elapsed_seconds": 5.72,
+      "infrastructure_error": false
+    },
+    {
+      "id": "gw-study-quiz-ca",
+      "case_type": "study_quiz",
+      "passed": false,
+      "elapsed_seconds": 1521.0,
+      "infrastructure_error": false
+    }
+  ],
+  "summary": {
+    "total": 50,
+    "passed": 45,
+    "pass_rate": 0.9,
+    "by_case_type": {
+      "table_retrieval": {
+        "total": 2,
+        "passed": 2,
+        "pass_rate": 1.0
+      },
+      "figure_retrieval": {
+        "total": 9,
+        "passed": 8,
+        "pass_rate": 0.8889
+      },
+      "factual_number": {
+        "total": 18,
+        "passed": 17,
+        "pass_rate": 0.9444
+      },
+      "factual_concept": {
+        "total": 9,
+        "passed": 7,
+        "pass_rate": 0.7778
+      },
+      "study_outline": {
+        "total": 3,
+        "passed": 3,
+        "pass_rate": 1.0
+      },
+      "study_summary": {
+        "total": 4,
+        "passed": 4,
+        "pass_rate": 1.0
+      },
+      "study_quiz": {
+        "total": 5,
+        "passed": 4,
+        "pass_rate": 0.8
+      }
+    }
+  },
+  "objective_raw": 45,
+  "objective_adjusted": 45,
+  "median_latency_answered_s": 15.32,
+  "median_latency_retrieval_only_s": 7.28,
+  "reference_median_latency_answered_s": 16.16,
+  "reference_median_latency_retrieval_only_s": 7.27,
+  "latency_ceiling_multiplier": 1.2,
+  "verdict": "inconclusive",
+  "reason": "search-set evaluation carries infrastructure_error record(s) -- not scored",
+  "regression_baseline_iteration": null,
+  "environment_fingerprint": {
+    "schema": 1,
+    "packages": {
+      "isolated:mineru": "3.4.5",
+      "isolated:transformers": "4.57.6",
+      "isolated:sentence-transformers": "5.6.1",
+      "isolated:torch": "2.6.0+cu124",
+      "isolated:faiss-cpu": null,
+      "isolated:rank-bm25": null,
+      "isolated:ollama": null,
+      "product:mineru": null,
+      "product:transformers": "5.16.1",
+      "product:sentence-transformers": "6.0.1",
+      "product:torch": "2.13.0",
+      "product:faiss-cpu": "1.15.0",
+      "product:rank-bm25": "0.2.2",
+      "product:ollama": "0.6.2"
+    }
+  },
+  "evaluator": "real"
+}

--- a/harness/ledger/index.jsonl
+++ b/harness/ledger/index.jsonl
@@ -1,0 +1,3 @@
+{"iteration": 1, "parent_iteration": null, "proposer": "grid", "verdict": "rejected_regression", "objective_adjusted": 11, "entry_file": "0001_20260908T083117Z.json"}
+{"iteration": 2, "parent_iteration": 1, "proposer": "grid", "verdict": "inconclusive", "objective_adjusted": 11, "entry_file": "0002_20260908T083454Z.json"}
+{"iteration": 3, "parent_iteration": 2, "proposer": "grid", "verdict": "inconclusive", "objective_adjusted": 45, "entry_file": "0003_20260908T091402Z.json"}

--- a/harness/ledger/report.json
+++ b/harness/ledger/report.json
@@ -1,0 +1,1096 @@
+{
+  "generated_at": "2026-09-08T09:14:02.985047+00:00",
+  "reference": {
+    "objective_raw": 46,
+    "objective_adjusted": 46,
+    "median_latency_answered_s": 16.16,
+    "median_latency_retrieval_only_s": 7.27,
+    "overrides_applied": {}
+  },
+  "ratchet": 46,
+  "best_iteration": null,
+  "iterations_run": 3,
+  "termination_reason": "patience",
+  "recovery_mode": {
+    "active": false,
+    "baseline_iteration": null,
+    "baseline_objective_adjusted": null,
+    "eligible_history_entries": 0
+  },
+  "environment": {
+    "fingerprint": {
+      "schema": 1,
+      "packages": {
+        "isolated:mineru": "3.4.5",
+        "isolated:transformers": "4.57.6",
+        "isolated:sentence-transformers": "5.6.1",
+        "isolated:torch": "2.6.0+cu124",
+        "isolated:faiss-cpu": null,
+        "isolated:rank-bm25": null,
+        "isolated:ollama": null,
+        "product:mineru": null,
+        "product:transformers": "5.16.1",
+        "product:sentence-transformers": "6.0.1",
+        "product:torch": "2.13.0",
+        "product:faiss-cpu": "1.15.0",
+        "product:rank-bm25": "0.2.2",
+        "product:ollama": "0.6.2"
+      }
+    },
+    "readable": true
+  },
+  "resolution_warning": {
+    "available_search_set_failures": 5,
+    "demonstrability_flip_threshold": 6,
+    "net_flips_under_known_sabotage": 3,
+    "sabotage_description": "RAG_TOP_K_FINAL=1 (single fragment retrieved; criterion 2, 2026-07-29)",
+    "message": "The search set can win at most 5 cases and moved only 3 net flips under a known-catastrophic single-field sabotage, below the ~6-flip threshold design doc section 3 sets for a demonstrable paired difference. An accepted improvement on today's corpus is a candidate for confirmation, not a demonstrated result -- see docs/design/2026-07-28-loop-automejorable.md section 3 and issue #30 (block B, the corpus expansion this harness is sized against)."
+  },
+  "iterations": [
+    {
+      "schema_version": 4,
+      "iteration": 1,
+      "parent_iteration": null,
+      "git_commit": "50877bab5c6c3a41a43284253771faa27f41dd72",
+      "config_overrides": {
+        "retrieval.top_k_final": 4
+      },
+      "effective_config": {
+        "models": {
+          "rag": "hf.co/noctrex/Ling-3.0-tiny-MXFP4_MOE-GGUF:MXFP4_MOE",
+          "chat": "hf.co/noctrex/Ling-3.0-tiny-MXFP4_MOE-GGUF:MXFP4_MOE",
+          "contextual": "hf.co/noctrex/Ling-3.0-tiny-MXFP4_MOE-GGUF:MXFP4_MOE",
+          "recomp": "hf.co/noctrex/Ling-3.0-tiny-MXFP4_MOE-GGUF:MXFP4_MOE",
+          "desc": "hf.co/noctrex/Ling-3.0-tiny-MXFP4_MOE-GGUF",
+          "ollama": {
+            "rag_num_ctx": 16384,
+            "query_num_ctx": 2048,
+            "recomp_num_ctx": 8192,
+            "contextual_num_ctx": 32768,
+            "request_timeout": 900,
+            "keep_alive": 0,
+            "generate_retries": 2,
+            "generate_retry_delay": 3,
+            "base_url": "http://localhost:11434"
+          }
+        },
+        "chunking": {
+          "chunk_size": 2000,
+          "chunk_overlap": 400,
+          "min_chunk_length": 150,
+          "contextual_doc_chars": 24000
+        },
+        "retrieval": {
+          "n_semantic_results": 80,
+          "n_keyword_results": 40,
+          "top_k_rerank_candidates": 200,
+          "top_k_final": 4,
+          "n_top_for_expansion": 3,
+          "rrf_k": 60,
+          "bm25_k1": 1.5,
+          "bm25_b": 0.75,
+          "weight_semantic_rrf": 0.55,
+          "weight_bm25_rrf": 0.45,
+          "min_question_length": 10
+        },
+        "reranking": {
+          "score_threshold": 0.65
+        },
+        "context": {
+          "max_context_chars": 24000
+        },
+        "flags": {
+          "usar_contextual_retrieval": false,
+          "usar_llm_query_decomposition": true,
+          "usar_busqueda_hibrida": true,
+          "usar_reranker": true,
+          "expandir_contexto": true,
+          "usar_optimizacion_contexto": true,
+          "usar_recomp_synthesis": true,
+          "usar_embeddings_imagen": true,
+          "usar_descripcion_imagen": true,
+          "logging_metricas": true,
+          "guardar_debug_rag": true
+        },
+        "paths": {
+          "base_dir": "/home/idiaval/dev/personal/localOllamaRAG/rag",
+          "data_dir": "/home/idiaval/dev/personal/localOllamaRAG/rag",
+          "docs_folder": "/home/idiaval/dev/personal/localOllamaRAG/rag/docs/en",
+          "path_db": "/home/idiaval/dev/personal/localOllamaRAG/rag/vector_db/dev_docs_jina_clip",
+          "collection_name": "docs_dev_docs",
+          "historial_path": "/home/idiaval/dev/personal/localOllamaRAG/rag/historial_chat.json",
+          "max_historial_mensajes": 40,
+          "carpeta_debug_rag": "/home/idiaval/dev/personal/localOllamaRAG/rag/debug_rag"
+        }
+      },
+      "proposer": "grid",
+      "proposer_rationale": null,
+      "proposer_model": null,
+      "proposer_fallback": false,
+      "proposer_fallback_reason": null,
+      "evaluated_case_set": "fast_tier",
+      "case_records": [
+        {
+          "id": "att-bleu-table",
+          "case_type": "table_retrieval",
+          "passed": true,
+          "elapsed_seconds": 19.63,
+          "infrastructure_error": false
+        },
+        {
+          "id": "dpo-pipeline-figure-es",
+          "case_type": "figure_retrieval",
+          "passed": false,
+          "elapsed_seconds": 7.4,
+          "infrastructure_error": false
+        },
+        {
+          "id": "gw-strain-figure",
+          "case_type": "figure_retrieval",
+          "passed": true,
+          "elapsed_seconds": 8.37,
+          "infrastructure_error": false
+        },
+        {
+          "id": "higgs-diphoton-figure",
+          "case_type": "figure_retrieval",
+          "passed": false,
+          "elapsed_seconds": 8.8,
+          "infrastructure_error": false
+        },
+        {
+          "id": "planck-contours-figure",
+          "case_type": "figure_retrieval",
+          "passed": false,
+          "elapsed_seconds": 9.98,
+          "infrastructure_error": false
+        },
+        {
+          "id": "att-n-layers",
+          "case_type": "factual_number",
+          "passed": true,
+          "elapsed_seconds": 14.62,
+          "infrastructure_error": false
+        },
+        {
+          "id": "dpo-acronym",
+          "case_type": "factual_concept",
+          "passed": true,
+          "elapsed_seconds": 16.9,
+          "infrastructure_error": false
+        },
+        {
+          "id": "gw-snr",
+          "case_type": "factual_number",
+          "passed": true,
+          "elapsed_seconds": 17.83,
+          "infrastructure_error": false
+        },
+        {
+          "id": "gw-site",
+          "case_type": "factual_concept",
+          "passed": false,
+          "elapsed_seconds": 18.44,
+          "infrastructure_error": false
+        },
+        {
+          "id": "higgs-significance",
+          "case_type": "factual_number",
+          "passed": true,
+          "elapsed_seconds": 16.26,
+          "infrastructure_error": false
+        },
+        {
+          "id": "planck-sigma8-es",
+          "case_type": "factual_number",
+          "passed": true,
+          "elapsed_seconds": 18.67,
+          "infrastructure_error": false
+        },
+        {
+          "id": "planck-h0-tension",
+          "case_type": "factual_concept",
+          "passed": false,
+          "elapsed_seconds": 17.31,
+          "infrastructure_error": false
+        },
+        {
+          "id": "ricci-hamilton-intro",
+          "case_type": "factual_concept",
+          "passed": true,
+          "elapsed_seconds": 15.34,
+          "infrastructure_error": false
+        },
+        {
+          "id": "att-study-outline",
+          "case_type": "study_outline",
+          "passed": true,
+          "elapsed_seconds": 5.81,
+          "infrastructure_error": false
+        },
+        {
+          "id": "att-study-summary",
+          "case_type": "study_summary",
+          "passed": true,
+          "elapsed_seconds": 5.85,
+          "infrastructure_error": false
+        },
+        {
+          "id": "att-study-quiz",
+          "case_type": "study_quiz",
+          "passed": true,
+          "elapsed_seconds": 6.01,
+          "infrastructure_error": false
+        }
+      ],
+      "summary": {
+        "total": 16,
+        "passed": 11,
+        "pass_rate": 0.6875,
+        "by_case_type": {
+          "table_retrieval": {
+            "total": 1,
+            "passed": 1,
+            "pass_rate": 1.0
+          },
+          "figure_retrieval": {
+            "total": 4,
+            "passed": 1,
+            "pass_rate": 0.25
+          },
+          "factual_number": {
+            "total": 4,
+            "passed": 4,
+            "pass_rate": 1.0
+          },
+          "factual_concept": {
+            "total": 4,
+            "passed": 2,
+            "pass_rate": 0.5
+          },
+          "study_outline": {
+            "total": 1,
+            "passed": 1,
+            "pass_rate": 1.0
+          },
+          "study_summary": {
+            "total": 1,
+            "passed": 1,
+            "pass_rate": 1.0
+          },
+          "study_quiz": {
+            "total": 1,
+            "passed": 1,
+            "pass_rate": 1.0
+          }
+        }
+      },
+      "objective_raw": 11,
+      "objective_adjusted": 11,
+      "median_latency_answered_s": 16.26,
+      "median_latency_retrieval_only_s": 8.8,
+      "reference_median_latency_answered_s": 16.16,
+      "reference_median_latency_retrieval_only_s": 7.27,
+      "latency_ceiling_multiplier": 1.2,
+      "verdict": "rejected_regression",
+      "reason": "fast-tier regression on ['dpo-pipeline-figure-es']",
+      "regression_baseline_iteration": null,
+      "environment_fingerprint": {
+        "schema": 1,
+        "packages": {
+          "isolated:mineru": "3.4.5",
+          "isolated:transformers": "4.57.6",
+          "isolated:sentence-transformers": "5.6.1",
+          "isolated:torch": "2.6.0+cu124",
+          "isolated:faiss-cpu": null,
+          "isolated:rank-bm25": null,
+          "isolated:ollama": null,
+          "product:mineru": null,
+          "product:transformers": "5.16.1",
+          "product:sentence-transformers": "6.0.1",
+          "product:torch": "2.13.0",
+          "product:faiss-cpu": "1.15.0",
+          "product:rank-bm25": "0.2.2",
+          "product:ollama": "0.6.2"
+        }
+      },
+      "evaluator": "real"
+    },
+    {
+      "schema_version": 4,
+      "iteration": 2,
+      "parent_iteration": 1,
+      "git_commit": "50877bab5c6c3a41a43284253771faa27f41dd72",
+      "config_overrides": {
+        "retrieval.top_k_final": 6
+      },
+      "effective_config": {
+        "models": {
+          "rag": "hf.co/noctrex/Ling-3.0-tiny-MXFP4_MOE-GGUF:MXFP4_MOE",
+          "chat": "hf.co/noctrex/Ling-3.0-tiny-MXFP4_MOE-GGUF:MXFP4_MOE",
+          "contextual": "hf.co/noctrex/Ling-3.0-tiny-MXFP4_MOE-GGUF:MXFP4_MOE",
+          "recomp": "hf.co/noctrex/Ling-3.0-tiny-MXFP4_MOE-GGUF:MXFP4_MOE",
+          "desc": "hf.co/noctrex/Ling-3.0-tiny-MXFP4_MOE-GGUF",
+          "ollama": {
+            "rag_num_ctx": 16384,
+            "query_num_ctx": 2048,
+            "recomp_num_ctx": 8192,
+            "contextual_num_ctx": 32768,
+            "request_timeout": 900,
+            "keep_alive": 0,
+            "generate_retries": 2,
+            "generate_retry_delay": 3,
+            "base_url": "http://localhost:11434"
+          }
+        },
+        "chunking": {
+          "chunk_size": 2000,
+          "chunk_overlap": 400,
+          "min_chunk_length": 150,
+          "contextual_doc_chars": 24000
+        },
+        "retrieval": {
+          "n_semantic_results": 80,
+          "n_keyword_results": 40,
+          "top_k_rerank_candidates": 200,
+          "top_k_final": 6,
+          "n_top_for_expansion": 3,
+          "rrf_k": 60,
+          "bm25_k1": 1.5,
+          "bm25_b": 0.75,
+          "weight_semantic_rrf": 0.55,
+          "weight_bm25_rrf": 0.45,
+          "min_question_length": 10
+        },
+        "reranking": {
+          "score_threshold": 0.65
+        },
+        "context": {
+          "max_context_chars": 24000
+        },
+        "flags": {
+          "usar_contextual_retrieval": false,
+          "usar_llm_query_decomposition": true,
+          "usar_busqueda_hibrida": true,
+          "usar_reranker": true,
+          "expandir_contexto": true,
+          "usar_optimizacion_contexto": true,
+          "usar_recomp_synthesis": true,
+          "usar_embeddings_imagen": true,
+          "usar_descripcion_imagen": true,
+          "logging_metricas": true,
+          "guardar_debug_rag": true
+        },
+        "paths": {
+          "base_dir": "/home/idiaval/dev/personal/localOllamaRAG/rag",
+          "data_dir": "/home/idiaval/dev/personal/localOllamaRAG/rag",
+          "docs_folder": "/home/idiaval/dev/personal/localOllamaRAG/rag/docs/en",
+          "path_db": "/home/idiaval/dev/personal/localOllamaRAG/rag/vector_db/dev_docs_jina_clip",
+          "collection_name": "docs_dev_docs",
+          "historial_path": "/home/idiaval/dev/personal/localOllamaRAG/rag/historial_chat.json",
+          "max_historial_mensajes": 40,
+          "carpeta_debug_rag": "/home/idiaval/dev/personal/localOllamaRAG/rag/debug_rag"
+        }
+      },
+      "proposer": "grid",
+      "proposer_rationale": null,
+      "proposer_model": null,
+      "proposer_fallback": false,
+      "proposer_fallback_reason": null,
+      "evaluated_case_set": "fast_tier",
+      "case_records": [
+        {
+          "id": "att-bleu-table",
+          "case_type": "table_retrieval",
+          "passed": true,
+          "elapsed_seconds": 19.72,
+          "infrastructure_error": false
+        },
+        {
+          "id": "dpo-pipeline-figure-es",
+          "case_type": "figure_retrieval",
+          "passed": false,
+          "elapsed_seconds": 7.26,
+          "infrastructure_error": false
+        },
+        {
+          "id": "gw-strain-figure",
+          "case_type": "figure_retrieval",
+          "passed": true,
+          "elapsed_seconds": 8.69,
+          "infrastructure_error": false
+        },
+        {
+          "id": "higgs-diphoton-figure",
+          "case_type": "figure_retrieval",
+          "passed": false,
+          "elapsed_seconds": 8.37,
+          "infrastructure_error": false
+        },
+        {
+          "id": "planck-contours-figure",
+          "case_type": "figure_retrieval",
+          "passed": false,
+          "elapsed_seconds": 10.27,
+          "infrastructure_error": false
+        },
+        {
+          "id": "att-n-layers",
+          "case_type": "factual_number",
+          "passed": true,
+          "elapsed_seconds": 14.86,
+          "infrastructure_error": false
+        },
+        {
+          "id": "dpo-acronym",
+          "case_type": "factual_concept",
+          "passed": true,
+          "elapsed_seconds": 16.65,
+          "infrastructure_error": false
+        },
+        {
+          "id": "gw-snr",
+          "case_type": "factual_number",
+          "passed": true,
+          "elapsed_seconds": 17.92,
+          "infrastructure_error": false
+        },
+        {
+          "id": "gw-site",
+          "case_type": "factual_concept",
+          "passed": false,
+          "elapsed_seconds": 18.53,
+          "infrastructure_error": false
+        },
+        {
+          "id": "higgs-significance",
+          "case_type": "factual_number",
+          "passed": true,
+          "elapsed_seconds": 16.41,
+          "infrastructure_error": false
+        },
+        {
+          "id": "planck-sigma8-es",
+          "case_type": "factual_number",
+          "passed": true,
+          "elapsed_seconds": 18.57,
+          "infrastructure_error": false
+        },
+        {
+          "id": "planck-h0-tension",
+          "case_type": "factual_concept",
+          "passed": false,
+          "elapsed_seconds": 23.17,
+          "infrastructure_error": true
+        },
+        {
+          "id": "ricci-hamilton-intro",
+          "case_type": "factual_concept",
+          "passed": true,
+          "elapsed_seconds": 15.69,
+          "infrastructure_error": false
+        },
+        {
+          "id": "att-study-outline",
+          "case_type": "study_outline",
+          "passed": true,
+          "elapsed_seconds": 6.58,
+          "infrastructure_error": false
+        },
+        {
+          "id": "att-study-summary",
+          "case_type": "study_summary",
+          "passed": true,
+          "elapsed_seconds": 5.9,
+          "infrastructure_error": false
+        },
+        {
+          "id": "att-study-quiz",
+          "case_type": "study_quiz",
+          "passed": true,
+          "elapsed_seconds": 6.46,
+          "infrastructure_error": false
+        }
+      ],
+      "summary": {
+        "total": 16,
+        "passed": 11,
+        "pass_rate": 0.6875,
+        "by_case_type": {
+          "table_retrieval": {
+            "total": 1,
+            "passed": 1,
+            "pass_rate": 1.0
+          },
+          "figure_retrieval": {
+            "total": 4,
+            "passed": 1,
+            "pass_rate": 0.25
+          },
+          "factual_number": {
+            "total": 4,
+            "passed": 4,
+            "pass_rate": 1.0
+          },
+          "factual_concept": {
+            "total": 4,
+            "passed": 2,
+            "pass_rate": 0.5
+          },
+          "study_outline": {
+            "total": 1,
+            "passed": 1,
+            "pass_rate": 1.0
+          },
+          "study_summary": {
+            "total": 1,
+            "passed": 1,
+            "pass_rate": 1.0
+          },
+          "study_quiz": {
+            "total": 1,
+            "passed": 1,
+            "pass_rate": 1.0
+          }
+        }
+      },
+      "objective_raw": 11,
+      "objective_adjusted": 11,
+      "median_latency_answered_s": 16.41,
+      "median_latency_retrieval_only_s": 8.69,
+      "reference_median_latency_answered_s": 16.16,
+      "reference_median_latency_retrieval_only_s": 7.27,
+      "latency_ceiling_multiplier": 1.2,
+      "verdict": "inconclusive",
+      "reason": "fast-tier evaluation carries infrastructure_error record(s) -- not scored",
+      "regression_baseline_iteration": null,
+      "environment_fingerprint": {
+        "schema": 1,
+        "packages": {
+          "isolated:mineru": "3.4.5",
+          "isolated:transformers": "4.57.6",
+          "isolated:sentence-transformers": "5.6.1",
+          "isolated:torch": "2.6.0+cu124",
+          "isolated:faiss-cpu": null,
+          "isolated:rank-bm25": null,
+          "isolated:ollama": null,
+          "product:mineru": null,
+          "product:transformers": "5.16.1",
+          "product:sentence-transformers": "6.0.1",
+          "product:torch": "2.13.0",
+          "product:faiss-cpu": "1.15.0",
+          "product:rank-bm25": "0.2.2",
+          "product:ollama": "0.6.2"
+        }
+      },
+      "evaluator": "real"
+    },
+    {
+      "schema_version": 4,
+      "iteration": 3,
+      "parent_iteration": 2,
+      "git_commit": "50877bab5c6c3a41a43284253771faa27f41dd72",
+      "config_overrides": {
+        "retrieval.top_k_final": 12
+      },
+      "effective_config": {
+        "models": {
+          "rag": "hf.co/noctrex/Ling-3.0-tiny-MXFP4_MOE-GGUF:MXFP4_MOE",
+          "chat": "hf.co/noctrex/Ling-3.0-tiny-MXFP4_MOE-GGUF:MXFP4_MOE",
+          "contextual": "hf.co/noctrex/Ling-3.0-tiny-MXFP4_MOE-GGUF:MXFP4_MOE",
+          "recomp": "hf.co/noctrex/Ling-3.0-tiny-MXFP4_MOE-GGUF:MXFP4_MOE",
+          "desc": "hf.co/noctrex/Ling-3.0-tiny-MXFP4_MOE-GGUF",
+          "ollama": {
+            "rag_num_ctx": 16384,
+            "query_num_ctx": 2048,
+            "recomp_num_ctx": 8192,
+            "contextual_num_ctx": 32768,
+            "request_timeout": 900,
+            "keep_alive": 0,
+            "generate_retries": 2,
+            "generate_retry_delay": 3,
+            "base_url": "http://localhost:11434"
+          }
+        },
+        "chunking": {
+          "chunk_size": 2000,
+          "chunk_overlap": 400,
+          "min_chunk_length": 150,
+          "contextual_doc_chars": 24000
+        },
+        "retrieval": {
+          "n_semantic_results": 80,
+          "n_keyword_results": 40,
+          "top_k_rerank_candidates": 200,
+          "top_k_final": 12,
+          "n_top_for_expansion": 3,
+          "rrf_k": 60,
+          "bm25_k1": 1.5,
+          "bm25_b": 0.75,
+          "weight_semantic_rrf": 0.55,
+          "weight_bm25_rrf": 0.45,
+          "min_question_length": 10
+        },
+        "reranking": {
+          "score_threshold": 0.65
+        },
+        "context": {
+          "max_context_chars": 24000
+        },
+        "flags": {
+          "usar_contextual_retrieval": false,
+          "usar_llm_query_decomposition": true,
+          "usar_busqueda_hibrida": true,
+          "usar_reranker": true,
+          "expandir_contexto": true,
+          "usar_optimizacion_contexto": true,
+          "usar_recomp_synthesis": true,
+          "usar_embeddings_imagen": true,
+          "usar_descripcion_imagen": true,
+          "logging_metricas": true,
+          "guardar_debug_rag": true
+        },
+        "paths": {
+          "base_dir": "/home/idiaval/dev/personal/localOllamaRAG/rag",
+          "data_dir": "/home/idiaval/dev/personal/localOllamaRAG/rag",
+          "docs_folder": "/home/idiaval/dev/personal/localOllamaRAG/rag/docs/en",
+          "path_db": "/home/idiaval/dev/personal/localOllamaRAG/rag/vector_db/dev_docs_jina_clip",
+          "collection_name": "docs_dev_docs",
+          "historial_path": "/home/idiaval/dev/personal/localOllamaRAG/rag/historial_chat.json",
+          "max_historial_mensajes": 40,
+          "carpeta_debug_rag": "/home/idiaval/dev/personal/localOllamaRAG/rag/debug_rag"
+        }
+      },
+      "proposer": "grid",
+      "proposer_rationale": null,
+      "proposer_model": null,
+      "proposer_fallback": false,
+      "proposer_fallback_reason": null,
+      "evaluated_case_set": "search_set",
+      "case_records": [
+        {
+          "id": "att-bleu-table",
+          "case_type": "table_retrieval",
+          "passed": true,
+          "elapsed_seconds": 8.21,
+          "infrastructure_error": false
+        },
+        {
+          "id": "att-arch-figure",
+          "case_type": "figure_retrieval",
+          "passed": true,
+          "elapsed_seconds": 6.69,
+          "infrastructure_error": false
+        },
+        {
+          "id": "att-arch-figure-es",
+          "case_type": "figure_retrieval",
+          "passed": true,
+          "elapsed_seconds": 7.23,
+          "infrastructure_error": false
+        },
+        {
+          "id": "dpo-pipeline-figure",
+          "case_type": "figure_retrieval",
+          "passed": true,
+          "elapsed_seconds": 7.05,
+          "infrastructure_error": false
+        },
+        {
+          "id": "dpo-pipeline-figure-es",
+          "case_type": "figure_retrieval",
+          "passed": true,
+          "elapsed_seconds": 7.28,
+          "infrastructure_error": false
+        },
+        {
+          "id": "gw-strain-figure",
+          "case_type": "figure_retrieval",
+          "passed": true,
+          "elapsed_seconds": 8.85,
+          "infrastructure_error": false
+        },
+        {
+          "id": "higgs-diphoton-figure",
+          "case_type": "figure_retrieval",
+          "passed": false,
+          "elapsed_seconds": 8.0,
+          "infrastructure_error": false
+        },
+        {
+          "id": "planck-contours-figure",
+          "case_type": "figure_retrieval",
+          "passed": true,
+          "elapsed_seconds": 8.88,
+          "infrastructure_error": false
+        },
+        {
+          "id": "planck-params-table",
+          "case_type": "table_retrieval",
+          "passed": true,
+          "elapsed_seconds": 8.81,
+          "infrastructure_error": false
+        },
+        {
+          "id": "att-arch-figure-ca",
+          "case_type": "figure_retrieval",
+          "passed": true,
+          "elapsed_seconds": 6.64,
+          "infrastructure_error": false
+        },
+        {
+          "id": "dpo-pipeline-figure-ca",
+          "case_type": "figure_retrieval",
+          "passed": true,
+          "elapsed_seconds": 6.71,
+          "infrastructure_error": false
+        },
+        {
+          "id": "att-bleu-ende",
+          "case_type": "factual_number",
+          "passed": true,
+          "elapsed_seconds": 27.38,
+          "infrastructure_error": false
+        },
+        {
+          "id": "att-bleu-enfr",
+          "case_type": "factual_number",
+          "passed": true,
+          "elapsed_seconds": 16.46,
+          "infrastructure_error": false
+        },
+        {
+          "id": "att-n-layers",
+          "case_type": "factual_number",
+          "passed": true,
+          "elapsed_seconds": 15.01,
+          "infrastructure_error": false
+        },
+        {
+          "id": "att-dmodel",
+          "case_type": "factual_number",
+          "passed": true,
+          "elapsed_seconds": 16.4,
+          "infrastructure_error": false
+        },
+        {
+          "id": "dpo-acronym",
+          "case_type": "factual_concept",
+          "passed": true,
+          "elapsed_seconds": 15.08,
+          "infrastructure_error": false
+        },
+        {
+          "id": "dpo-no-sampling",
+          "case_type": "factual_concept",
+          "passed": false,
+          "elapsed_seconds": 16.15,
+          "infrastructure_error": false
+        },
+        {
+          "id": "dpo-rlfree",
+          "case_type": "factual_concept",
+          "passed": true,
+          "elapsed_seconds": 13.62,
+          "infrastructure_error": false
+        },
+        {
+          "id": "dpo-model-scale",
+          "case_type": "factual_number",
+          "passed": true,
+          "elapsed_seconds": 14.85,
+          "infrastructure_error": false
+        },
+        {
+          "id": "gw-snr",
+          "case_type": "factual_number",
+          "passed": true,
+          "elapsed_seconds": 17.24,
+          "infrastructure_error": false
+        },
+        {
+          "id": "gw-final-mass",
+          "case_type": "factual_number",
+          "passed": true,
+          "elapsed_seconds": 16.4,
+          "infrastructure_error": false
+        },
+        {
+          "id": "gw-site",
+          "case_type": "factual_concept",
+          "passed": true,
+          "elapsed_seconds": 17.4,
+          "infrastructure_error": false
+        },
+        {
+          "id": "gw-year-es",
+          "case_type": "factual_number",
+          "passed": true,
+          "elapsed_seconds": 17.19,
+          "infrastructure_error": false
+        },
+        {
+          "id": "higgs-mass",
+          "case_type": "factual_number",
+          "passed": true,
+          "elapsed_seconds": 16.11,
+          "infrastructure_error": false
+        },
+        {
+          "id": "higgs-significance",
+          "case_type": "factual_number",
+          "passed": true,
+          "elapsed_seconds": 15.18,
+          "infrastructure_error": false
+        },
+        {
+          "id": "higgs-collider",
+          "case_type": "factual_concept",
+          "passed": true,
+          "elapsed_seconds": 15.32,
+          "infrastructure_error": false
+        },
+        {
+          "id": "higgs-luminosity-es",
+          "case_type": "factual_number",
+          "passed": true,
+          "elapsed_seconds": 16.35,
+          "infrastructure_error": false
+        },
+        {
+          "id": "planck-h0",
+          "case_type": "factual_number",
+          "passed": false,
+          "elapsed_seconds": 22.07,
+          "infrastructure_error": true
+        },
+        {
+          "id": "planck-omega-m",
+          "case_type": "factual_number",
+          "passed": true,
+          "elapsed_seconds": 15.27,
+          "infrastructure_error": false
+        },
+        {
+          "id": "planck-sigma8-es",
+          "case_type": "factual_number",
+          "passed": true,
+          "elapsed_seconds": 17.3,
+          "infrastructure_error": false
+        },
+        {
+          "id": "planck-h0-tension",
+          "case_type": "factual_concept",
+          "passed": false,
+          "elapsed_seconds": 18.09,
+          "infrastructure_error": false
+        },
+        {
+          "id": "ricci-hamilton-intro",
+          "case_type": "factual_concept",
+          "passed": true,
+          "elapsed_seconds": 14.54,
+          "infrastructure_error": false
+        },
+        {
+          "id": "ricci-dimension",
+          "case_type": "factual_number",
+          "passed": true,
+          "elapsed_seconds": 14.03,
+          "infrastructure_error": false
+        },
+        {
+          "id": "ricci-hamilton-es",
+          "case_type": "factual_concept",
+          "passed": true,
+          "elapsed_seconds": 15.78,
+          "infrastructure_error": false
+        },
+        {
+          "id": "att-study-outline",
+          "case_type": "study_outline",
+          "passed": true,
+          "elapsed_seconds": 5.39,
+          "infrastructure_error": false
+        },
+        {
+          "id": "att-study-summary",
+          "case_type": "study_summary",
+          "passed": true,
+          "elapsed_seconds": 5.63,
+          "infrastructure_error": false
+        },
+        {
+          "id": "att-study-quiz",
+          "case_type": "study_quiz",
+          "passed": true,
+          "elapsed_seconds": 6.57,
+          "infrastructure_error": false
+        },
+        {
+          "id": "planck-study-quiz",
+          "case_type": "study_quiz",
+          "passed": true,
+          "elapsed_seconds": 7.0,
+          "infrastructure_error": false
+        },
+        {
+          "id": "gw-year-ca",
+          "case_type": "factual_number",
+          "passed": true,
+          "elapsed_seconds": 17.97,
+          "infrastructure_error": false
+        },
+        {
+          "id": "ricci-hamilton-ca",
+          "case_type": "factual_concept",
+          "passed": true,
+          "elapsed_seconds": 19.48,
+          "infrastructure_error": false
+        },
+        {
+          "id": "higgs-luminosity-ca",
+          "case_type": "factual_number",
+          "passed": true,
+          "elapsed_seconds": 15.64,
+          "infrastructure_error": false
+        },
+        {
+          "id": "planck-sigma8-ca",
+          "case_type": "factual_number",
+          "passed": true,
+          "elapsed_seconds": 16.97,
+          "infrastructure_error": false
+        },
+        {
+          "id": "att-study-summary-es",
+          "case_type": "study_summary",
+          "passed": true,
+          "elapsed_seconds": 5.56,
+          "infrastructure_error": false
+        },
+        {
+          "id": "att-study-outline-es",
+          "case_type": "study_outline",
+          "passed": true,
+          "elapsed_seconds": 5.67,
+          "infrastructure_error": false
+        },
+        {
+          "id": "att-study-quiz-es",
+          "case_type": "study_quiz",
+          "passed": true,
+          "elapsed_seconds": 10.27,
+          "infrastructure_error": false
+        },
+        {
+          "id": "ricci-study-summary-es",
+          "case_type": "study_summary",
+          "passed": true,
+          "elapsed_seconds": 9.39,
+          "infrastructure_error": false
+        },
+        {
+          "id": "att-study-summary-ca",
+          "case_type": "study_summary",
+          "passed": true,
+          "elapsed_seconds": 6.75,
+          "infrastructure_error": false
+        },
+        {
+          "id": "att-study-outline-ca",
+          "case_type": "study_outline",
+          "passed": true,
+          "elapsed_seconds": 5.01,
+          "infrastructure_error": false
+        },
+        {
+          "id": "att-study-quiz-ca",
+          "case_type": "study_quiz",
+          "passed": true,
+          "elapsed_seconds": 5.72,
+          "infrastructure_error": false
+        },
+        {
+          "id": "gw-study-quiz-ca",
+          "case_type": "study_quiz",
+          "passed": false,
+          "elapsed_seconds": 1521.0,
+          "infrastructure_error": false
+        }
+      ],
+      "summary": {
+        "total": 50,
+        "passed": 45,
+        "pass_rate": 0.9,
+        "by_case_type": {
+          "table_retrieval": {
+            "total": 2,
+            "passed": 2,
+            "pass_rate": 1.0
+          },
+          "figure_retrieval": {
+            "total": 9,
+            "passed": 8,
+            "pass_rate": 0.8889
+          },
+          "factual_number": {
+            "total": 18,
+            "passed": 17,
+            "pass_rate": 0.9444
+          },
+          "factual_concept": {
+            "total": 9,
+            "passed": 7,
+            "pass_rate": 0.7778
+          },
+          "study_outline": {
+            "total": 3,
+            "passed": 3,
+            "pass_rate": 1.0
+          },
+          "study_summary": {
+            "total": 4,
+            "passed": 4,
+            "pass_rate": 1.0
+          },
+          "study_quiz": {
+            "total": 5,
+            "passed": 4,
+            "pass_rate": 0.8
+          }
+        }
+      },
+      "objective_raw": 45,
+      "objective_adjusted": 45,
+      "median_latency_answered_s": 15.32,
+      "median_latency_retrieval_only_s": 7.28,
+      "reference_median_latency_answered_s": 16.16,
+      "reference_median_latency_retrieval_only_s": 7.27,
+      "latency_ceiling_multiplier": 1.2,
+      "verdict": "inconclusive",
+      "reason": "search-set evaluation carries infrastructure_error record(s) -- not scored",
+      "regression_baseline_iteration": null,
+      "environment_fingerprint": {
+        "schema": 1,
+        "packages": {
+          "isolated:mineru": "3.4.5",
+          "isolated:transformers": "4.57.6",
+          "isolated:sentence-transformers": "5.6.1",
+          "isolated:torch": "2.6.0+cu124",
+          "isolated:faiss-cpu": null,
+          "isolated:rank-bm25": null,
+          "isolated:ollama": null,
+          "product:mineru": null,
+          "product:transformers": "5.16.1",
+          "product:sentence-transformers": "6.0.1",
+          "product:torch": "2.13.0",
+          "product:faiss-cpu": "1.15.0",
+          "product:rank-bm25": "0.2.2",
+          "product:ollama": "0.6.2"
+        }
+      },
+      "evaluator": "real"
+    }
+  ]
+}

--- a/tests/eval/grade.py
+++ b/tests/eval/grade.py
@@ -58,6 +58,21 @@ _MARKDOWN_EMPHASIS_RE = re.compile(r"[*_`]+")
 # LaTeX sizing commands (\left(, \right]) carry no literal content.
 _LATEX_SIZING_RE = re.compile(r"\\(left|right)")
 
+# LaTeX typographic wrappers: the command name goes, its braced content stays.
+# Only commands actually followed by a brace match, so semantic commands that
+# carry meaning of their own (\pm, \cdot, \times) are never touched -- this
+# strips how the answer was *set*, never what it says.
+#
+# Without it, "$N = \textbf{6}$" lost its braces but kept the command,
+# leaving "n = \textbf6": the digit welded to letters, matching neither
+# "n = 6" nor "6 identical layers". A correct answer graded as a miss.
+_LATEX_TEXT_STYLE_RE = re.compile(
+    r"\\(?:emph"
+    r"|text(?:bf|it|rm|sf|tt|up|sl|md|normal)?"
+    r"|math(?:bf|it|rm|sf|tt|bb|cal|frak|normal)?"
+    r")(?=\s*\{)"
+)
+
 # Digit, optional spaces, "x", optional spaces, digit -- the spacing around a
 # multiplication sign is typography, not content: "16 x 16" is "16x16".
 _MULTIPLICATION_SPACING_RE = re.compile(r"(\d)\s*[xX]\s*(\d)")
@@ -87,7 +102,7 @@ def _strip_markup(text: str) -> str:
 
     Returns:
         Lowercased text with Markdown emphasis and LaTeX math delimiters,
-        grouping braces and sizing commands removed. Digit-grouping
+        grouping braces, sizing commands and typographic wrappers removed. Digit-grouping
         (thousands separator vs. decimal comma) is left to the caller --
         see ``_normalize`` and ``_normalize_decimal_comma``.
     """
@@ -95,6 +110,8 @@ def _strip_markup(text: str) -> str:
     s = _MARKDOWN_EMPHASIS_RE.sub("", s)
     s = s.replace("$", "")  # LaTeX math delimiters
     s = _LATEX_SIZING_RE.sub("", s)
+    # Before the braces go, or the command name is left glued to its content.
+    s = _LATEX_TEXT_STYLE_RE.sub("", s)
     s = s.replace("{", "").replace("}", "")  # LaTeX grouping braces, e.g. 10^{-4}
     # Multiplication reaches us three ways for the same value: the Unicode sign
     # from a PDF, the LaTeX command from a model writing math, and a plain "x"

--- a/tests/eval/test_grade.py
+++ b/tests/eval/test_grade.py
@@ -15,7 +15,7 @@ ROOT = Path(__file__).resolve().parent
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from grade import grade_answer, grade_retrieval  # noqa: E402
+from grade import _contains_token, _normalize, grade_answer, grade_retrieval  # noqa: E402
 
 GOLD_FILE = ROOT / "gold_cases.jsonl"
 
@@ -382,3 +382,43 @@ def test_gw_snr_rejects_a_coincidental_number():
     correct = "The signal was observed with a matched-filter signal-to-noise ratio of 24."
     assert not grade_answer(wrong, case)["pass"]
     assert grade_answer(correct, case)["pass"]
+
+
+# LaTeX text-style commands (issue #208)
+
+
+def test_a_bolded_number_still_matches_the_expected_literal():
+    # Observed in a real run: the model answered "$N = \textbf{6}$ identical
+    # layers" -- correct, and graded as a miss. _strip_markup removed the
+    # braces but not the command name, leaving "n = \textbf6": the digit ends
+    # up glued to letters, so neither "n = 6" nor "6 identical layers" can
+    # match. The answer was right; the grader could not see it.
+    answer = "the encoder stack consists of $N = \\textbf{6}$ identical layers"
+
+    assert _contains_token(_normalize(answer), _normalize("n = 6"))
+    assert _contains_token(
+        _normalize(answer), _normalize("6 identical layers")
+    )
+
+
+def test_a_math_wrapped_unit_still_matches():
+    # The other shape the same defect takes, from the Higgs paper's own
+    # notation: \mathrm{} around a unit or a qualifier.
+    answer = "a mass of $126.0 \\pm 0.4 (\\mathrm{stat})$ GeV"
+
+    assert _contains_token(_normalize(answer), _normalize("126.0"))
+    assert _contains_token(_normalize(answer), _normalize("stat"))
+
+
+def test_stripping_a_style_command_does_not_fuse_words():
+    # \textbf must leave the content, not weld it to what precedes it: an
+    # answer saying "figure \textbf{3}" must not read as "figure3", which
+    # would match neither "figure 3" nor "3".
+    assert _normalize("figure \\textbf{3}") == "figure 3"
+
+
+def test_an_unrelated_backslash_command_is_left_alone():
+    # Only typographic wrappers are removed. \pm carries meaning and has no
+    # braced content to unwrap; stripping command names wholesale would
+    # silently rewrite what the answer says.
+    assert "\\pm" in _normalize("0.5 \\pm 0.1") or "±" in _normalize("0.5 \\pm 0.1")


### PR DESCRIPTION
Closes #208.

## The defect

`_strip_markup` removes LaTeX grouping braces and *sizing* commands, but not
typographic ones. `$N = \textbf{6}$` therefore loses its braces and keeps its
command, leaving `n = \textbf6`. The digit ends up welded to letters, where the
word boundary `_contains_token` relies on cannot anchor, so neither `n = 6` nor
`6 identical layers` matches — an answer that says exactly the right thing,
scored as a miss.

Three real cases were affected:

| Case | Expected | Model answered |
|---|---|---|
| `att-n-layers` | `n = 6` / `6 identical layers` | `$N = \textbf{6}$ identical layers` |
| `vit-imagenet-top1` | `88.55` | `$\mathbf{88.55\pm0.04}$ percent` |
| `dpo-model-scale` | `6b` / `6 billion` | `$6\text{B}$ parameters` |

## Why this is not a loosened rule

AGENTS.md §1.9 forbids weakening a grading rule to raise the pass rate, so this
is checked rather than claimed.

The change strips **how an answer was set, never what it says**. Only command
names actually followed by a brace are removed, so semantic commands — `\pm`,
`\cdot`, `\times` — are untouched. `_strip_markup`'s own docstring already
described its job as removing markup; typographic wrappers are a category it
was never taught, not one anyone decided to keep.

Re-grading every answer stored in `tests/eval/runs/` with the old grader and
the new one, side by side:

```
answers re-graded: 94
miss -> hit: 4
hit -> miss: 0
```

Every recovered answer was read by hand and states the expected value. Nothing
that passed before stops passing.

## Tests

Four added to `tests/eval/test_grade.py`: a bolded number matches, a
`\mathrm`-wrapped qualifier matches, stripping a wrapper does not fuse it to
the preceding word (`figure \textbf{3}` → `figure 3`, not `figure3`), and an
unrelated backslash command survives.

Full suite 1100 passed, 2 skipped. `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)