### PR TITLE
Resolve the model roles in --check through settings.json too (#215)

### DIFF
--- a/.claude/skills/run-local/SKILL.md
+++ b/.claude/skills/run-local/SKILL.md
@@ -37,17 +37,20 @@ ls rag/web/frontend/dist/index.html          # built frontend; app serves a bare
 No `dist/`: `cd rag/web/frontend && pnpm install && pnpm run build` (pnpm only,
 `packageManager` is pinned).
 
-`--check` reports each component separately and never pulls anything. Two of
-its warnings are expected rather than blocking:
+`--check` reports each component separately and never pulls anything. One of
+its warnings is expected rather than blocking:
 
 - **jina-clip "BUSY, not missing"** means the card has no free memory because
   another instance or a resident Ollama model holds it. The install is fine.
   Free the VRAM and re-check.
-- **"missing model(s) for the configured roles"** can be false. It resolves
-  roles from the environment and its own module default, not from
-  `settings.json` (issue #215), so it names a model the app will not use.
-  `curl -s http://127.0.0.1:5000/api/models` is what the app actually resolves;
-  trust that against `ollama list`.
+
+**"missing model(s) for the configured roles"** names a role that genuinely is
+not pulled. It resolves the four roles through the same precedence the app
+does -- environment > `settings.json` > module default -- so a model chosen in
+the web UI is the one it checks for (issue #215; until then it read the
+environment and its own default only, and recommended pulling a model this
+machine would never load). `curl -s http://127.0.0.1:5000/api/models` shows
+the same resolution from the running app.
 
 Ollama does not need starting by hand. `start_ollama_if_needed()` in
 `rag/web/app.py` launches `ollama serve` on a daemon thread at boot when the

--- a/tests/unit/test_setup_environments.py
+++ b/tests/unit/test_setup_environments.py
@@ -19,6 +19,7 @@ Standard library only, like the script itself, so this runs in the fast gate's
 dependency-free `architecture` job.
 """
 
+import json
 import sys
 from pathlib import Path
 
@@ -40,17 +41,137 @@ class TestInterpreterLayout:
         assert setup._venv_python(tmp_path) == tmp_path / "bin" / "python"
 
 
+def _installed_models(monkeypatch, names):
+    """Double Ollama's ``/api/tags`` with the models it would report."""
+    payload = json.dumps({"models": [{"name": name} for name in names]}).encode("utf-8")
+
+    class _Response:
+        def read(self):
+            return payload
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+    monkeypatch.setattr(setup.urllib.request, "urlopen", lambda *a, **k: _Response())
+
+
+def _no_saved_settings(monkeypatch, tmp_path):
+    """Point the data dir at an empty directory, so no settings.json is found.
+
+    Without this the tests below read the repo's own ``rag/settings.json`` and
+    assert against whatever this machine happens to have saved.
+    """
+    monkeypatch.setenv("MONKEYGRAB_DATA_DIR", str(tmp_path))
+
+
+def _saved_settings(monkeypatch, tmp_path, roles):
+    """Write a settings.json holding ``roles`` and point the data dir at it."""
+    monkeypatch.setenv("MONKEYGRAB_DATA_DIR", str(tmp_path))
+    (tmp_path / "settings.json").write_text(
+        json.dumps({"roles": roles, "active_store": "ca"}), encoding="utf-8"
+    )
+
+
 class TestConfiguredModels:
-    def test_defaults_to_one_model_for_all_four_roles(self, monkeypatch):
+    def test_defaults_to_one_model_for_all_four_roles(self, monkeypatch, tmp_path):
+        _no_saved_settings(monkeypatch, tmp_path)
         for var in setup.OLLAMA_ROLE_VARS.values():
             monkeypatch.delenv(var, raising=False)
         assert setup._configured_models() == [setup.DEFAULT_OLLAMA_MODEL]
 
-    def test_the_environment_decides_and_duplicates_collapse(self, monkeypatch):
+    def test_the_environment_decides_and_duplicates_collapse(self, monkeypatch, tmp_path):
+        _no_saved_settings(monkeypatch, tmp_path)
         for var in setup.OLLAMA_ROLE_VARS.values():
             monkeypatch.setenv(var, "small:model")
         monkeypatch.setenv("OLLAMA_RAG_MODEL", "big:model")
         assert setup._configured_models() == ["big:model", "small:model"]
+
+
+class TestSavedRolesArePartOfThePrecedence:
+    """Issue #215. The check must resolve roles the way the product does.
+
+    Reading environment-then-module-default skipped the middle term and was
+    wrong in both directions: it named a model this machine would never load,
+    and it stayed silent about a saved role that was not pulled.
+    """
+
+    def test_the_saved_roles_are_what_gets_checked(self, monkeypatch, tmp_path):
+        _saved_settings(monkeypatch, tmp_path, {role: "saved:model" for role in setup.OLLAMA_ROLE_VARS})
+        for var in setup.OLLAMA_ROLE_VARS.values():
+            monkeypatch.delenv(var, raising=False)
+        assert setup._configured_models() == ["saved:model"]
+
+    def test_the_environment_still_outranks_a_saved_role(self, monkeypatch, tmp_path):
+        _saved_settings(monkeypatch, tmp_path, {role: "saved:model" for role in setup.OLLAMA_ROLE_VARS})
+        monkeypatch.delenv("OLLAMA_CHAT_MODEL", raising=False)
+        monkeypatch.delenv("OLLAMA_CONTEXTUAL_MODEL", raising=False)
+        monkeypatch.delenv("OLLAMA_RECOMP_MODEL", raising=False)
+        monkeypatch.setenv("OLLAMA_RAG_MODEL", "pinned:model")
+        assert setup._configured_models() == ["pinned:model", "saved:model"]
+
+    def test_a_role_saved_without_a_value_falls_through_to_the_default(
+        self, monkeypatch, tmp_path
+    ):
+        _saved_settings(monkeypatch, tmp_path, {"rag": "  ", "chat": "saved:model"})
+        for var in setup.OLLAMA_ROLE_VARS.values():
+            monkeypatch.delenv(var, raising=False)
+        assert setup._configured_models() == [setup.DEFAULT_OLLAMA_MODEL, "saved:model"]
+
+    def test_a_corrupt_settings_file_leaves_the_defaults_standing(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("MONKEYGRAB_DATA_DIR", str(tmp_path))
+        (tmp_path / "settings.json").write_text("{not json", encoding="utf-8")
+        for var in setup.OLLAMA_ROLE_VARS.values():
+            monkeypatch.delenv(var, raising=False)
+        assert setup._configured_models() == [setup.DEFAULT_OLLAMA_MODEL]
+
+    def test_a_saved_role_that_is_not_pulled_is_reported_missing(self, monkeypatch, tmp_path):
+        """The false negative: green while the run is going to fail at first use."""
+        _saved_settings(monkeypatch, tmp_path, {role: "saved:model" for role in setup.OLLAMA_ROLE_VARS})
+        for var in setup.OLLAMA_ROLE_VARS.values():
+            monkeypatch.delenv(var, raising=False)
+        _installed_models(monkeypatch, ["something:else"])
+
+        passed, message = setup._check_ollama()
+        assert not passed
+        assert "ollama pull saved:model" in message
+
+    def test_a_saved_role_that_is_pulled_is_reported_present(self, monkeypatch, tmp_path):
+        """The false positive: told to pull gigabytes it already has."""
+        _saved_settings(monkeypatch, tmp_path, {role: "saved:model" for role in setup.OLLAMA_ROLE_VARS})
+        for var in setup.OLLAMA_ROLE_VARS.values():
+            monkeypatch.delenv(var, raising=False)
+        _installed_models(monkeypatch, ["saved:model"])
+
+        passed, message = setup._check_ollama()
+        assert passed
+        assert setup.DEFAULT_OLLAMA_MODEL not in message
+
+
+class TestSettingsLocationDrift:
+    """The settings path is duplicated here; this is what stops it drifting.
+
+    ``_settings_path`` cannot import the product to ask where the file lives --
+    the fast gate's architecture job runs on the standard library alone. So the
+    rule is copied, and copied rules go stale silently. Reading the product's
+    own line back is the cheapest thing that fails loudly when it moves.
+    """
+
+    def test_the_product_still_derives_its_data_dir_the_way_this_script_assumes(self):
+        source = (REPO_ROOT / "rag" / "chat_pdfs.py").read_text(encoding="utf-8")
+        assert 'DATA_DIR = os.path.abspath(os.getenv("MONKEYGRAB_DATA_DIR", BASE_DIR))' in source
+        assert "BASE_DIR = os.path.dirname(os.path.abspath(__file__))" in source
+
+    def test_the_product_still_defaults_every_role_to_the_model_this_script_names(self):
+        source = (REPO_ROOT / "rag" / "chat_pdfs.py").read_text(encoding="utf-8")
+        for var in setup.OLLAMA_ROLE_VARS.values():
+            assert f'os.getenv("{var}", "{setup.DEFAULT_OLLAMA_MODEL}")' in source
+
+    def test_the_path_lands_on_the_repo_settings_file_by_default(self, monkeypatch):
+        monkeypatch.delenv("MONKEYGRAB_DATA_DIR", raising=False)
+        assert setup._settings_path() == REPO_ROOT / "rag" / "settings.json"
 
 
 class TestReporting:

--- a/tools/setup_environments.py
+++ b/tools/setup_environments.py
@@ -230,9 +230,59 @@ def _check_jina_worker() -> Tuple[bool, str]:
     return False, f"jina-clip: worker produced no ready event (exit {result.returncode})"
 
 
+def _settings_path() -> Path:
+    """Where the app keeps its persisted choices.
+
+    Mirrors ``DATA_DIR`` in ``rag/chat_pdfs.py``: ``MONKEYGRAB_DATA_DIR`` when
+    set, the ``rag/`` package dir otherwise. Duplicated rather than imported
+    because this script and its test must run on the standard library alone --
+    ``rag.engine.settings`` reaches ``rag/chat_pdfs.py`` and pulls torch in.
+    ``TestSettingsLocationDrift`` fails if the product's rule moves.
+    """
+    data_dir = os.getenv("MONKEYGRAB_DATA_DIR") or REPO_ROOT / "rag"
+    return Path(data_dir).resolve() / "settings.json"
+
+
+def _saved_roles() -> dict:
+    """The model roles saved by the web UI, or ``{}`` if unreadable.
+
+    Best-effort like ``rag/engine/settings.py``: a missing or corrupt file
+    leaves the defaults standing rather than failing a check whose job is to
+    report state.
+    """
+    try:
+        # utf-8-sig for the same reason the product reads it that way: the file
+        # may have been hand-edited with a tool that writes a BOM.
+        with open(_settings_path(), "r", encoding="utf-8-sig") as handle:
+            data = json.load(handle)
+    except (OSError, ValueError):
+        return {}
+    roles = data.get("roles") if isinstance(data, dict) else None
+    if not isinstance(roles, dict):
+        return {}
+    return {
+        role: model
+        for role, model in roles.items()
+        if isinstance(model, str) and model.strip()
+    }
+
+
 def _configured_models() -> List[str]:
-    """The Ollama models the four roles resolve to, environment first."""
-    return sorted({os.getenv(var, DEFAULT_OLLAMA_MODEL) for var in OLLAMA_ROLE_VARS.values()})
+    """The Ollama models the four roles resolve to.
+
+    Same precedence the product runs under -- environment > ``settings.json`` >
+    module default (``AGENTS.md`` §3). Reading only the first and last was
+    issue #215: it recommended pulling gigabytes of a model this machine would
+    never load, and stayed green when a role saved in the UI named a tag that
+    was not pulled.
+    """
+    saved = _saved_roles()
+    return sorted(
+        {
+            os.getenv(var) or saved.get(role) or DEFAULT_OLLAMA_MODEL
+            for role, var in OLLAMA_ROLE_VARS.items()
+        }
+    )
 
 
 def _check_ollama() -> Tuple[bool, str]:


### PR DESCRIPTION
## Summary

`tools/setup_environments.py --check` resolved the four Ollama roles with
`os.getenv(var, DEFAULT_OLLAMA_MODEL)`: environment, then its own module
constant. The product's precedence has a middle term the check ignored --
environment > `settings.json` > module default (`AGENTS.md` §3) -- so it
reported on a configuration the app does not run under.

Wrong in both directions, and the cheap-looking one is the expensive one:

- **False positive.** On a machine whose four saved roles are all pulled, it
  ended a check whose whole point is not spending your bandwidth by
  recommending `ollama pull gemma4:e4b`, several gigabytes nothing here loads.
- **False negative.** A role picked in the web UI naming a tag that is not
  pulled stayed green, and the run failed later at first use.

The settings path is duplicated rather than imported, deliberately. This
script and its test run on the standard library alone in the fast gate's
`architecture` job, and `rag.engine.settings` reaches `rag/chat_pdfs.py`,
which pulls torch in. A copied rule is exactly the kind of pointer that goes
stale without saying so, so `TestSettingsLocationDrift` reads the product's own
`DATA_DIR` line back and fails if it moves.

## Issue

Fixes #215.

## Test plan

The check run on this machine, whose four saved roles are all
`hf.co/noctrex/Ling-3.0-tiny-MXFP4_MOE-GGUF:MXFP4_MOE` and pulled. Before,
as recorded in the issue:

```
[ warn  ] Ollama: reachable, missing model(s) for the configured roles -- ollama pull gemma4:e4b
```

After:

```
[  ok   ] Ollama: reachable at http://localhost:11434, all 1 configured model(s) present
```

The jina-clip line still reads `BUSY, not missing` in that same run, correctly:
the web app was up and holding the card.

- Six new tests over the precedence and both directions of the defect: the
  saved roles are what gets checked, the environment still outranks them, a
  saved role that is not pulled is reported with its `pull` command, one that
  is pulled is reported present, a blank saved value falls through to the
  default, and a corrupt file leaves the defaults standing.
- Verified they fail without the fix, not just pass with it: stashing the
  change alone drops 6 of them.
- `ruff check .` clean; `pytest tests/unit tests/eval harness/tests
  --ignore=tests/unit/adapters` 894 passed, 1 skipped.

Tooling and docs, no product code: the full gate is not required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)