### PR TITLE
Re-measure every generator on one gold set and fix what made the old table incomparable (#218)

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,28 +169,20 @@ The rest of the stack is not an Ollama model:
 > which needs a CUDA GPU, because its dependencies conflict with the
 > product's — see [`src/monkeygrab/README.md`](src/monkeygrab/README.md).
 
-### Evaluated Generator Models (Hardware Benchmark: RTX 4060 Laptop 8 GB VRAM)
+### Choosing a generator
 
-Empirical evaluations across the 83 gold acceptance cases demonstrate that **compact Mixture-of-Experts (MoE)** models systematically outperform dense architectures on consumer hardware (8 GB VRAM):
+Any Ollama-compatible chat model can fill the four roles above. `rag/chat_pdfs.py`
+sets the shipped default for each -- the tip above points at where that default
+is documented, rather than copying it into prose here. Override a role with
+its environment variable, or pick another model from the web UI, which saves
+the choice to `settings.json` in the data directory for that machine
+(environment, then saved choice, then this default -- see "Running it" below).
 
-1. **Memory Bandwidth & Decoding Throughput**: On a 128-bit memory bus (~272 GB/s VRAM bandwidth), a dense 8B model reads ~5–8 GB of weights per token, capping decoding at ~30–45 tok/s. A compact MoE (e.g. `Ling-3.0-tiny`: 7.9B total, 1.3B active) retains 8B-tier capacity while reading only ~1.3 GB per token, reaching **109–158 tokens/s**.
-2. **Zero System RAM Offload**: Dense models >=8B combined with 16k context and KV caches collide with the 8 GB ceiling, forcing partial CPU offload and ballooning latency. Compact MoEs quantized to MXFP4/Q4 (4.2–4.9 GB) reside 100% in VRAM with zero host-to-device bus penalty.
-3. **Specialized Multilingual Routing**: Distinct expert subsets decouple scientific extraction, Spanish, and Catalan/Valencian syntax without catastrophic gradient interference.
-
-| Model | Architecture & Size | Gold Cases Passed | Median Time / Case | Decode Speed | Latency | Status / Verdict |
-|---|---|---|---|---|---|---|
-| [**`Ling-3.0-tiny-MXFP4_MOE`**](https://huggingface.co/noctrex/Ling-3.0-tiny-MXFP4_MOE-GGUF) | MoE (7.9B total, 1.3B active), 4.9 GB | **56 / 63 (88.9%)** | **8.1 s** | **109.3 tok/s** | **0.15 s/answer** | 🥇 **Current Champion** (fastest wait, highest pass rate) |
-| [**`Granite-4.0-H-Tiny-MXFP4_MOE`**](https://huggingface.co/noctrex/Granite-4.0-H-Tiny-MXFP4_MOE-GGUF) | MoE, 4.2 GB | **53 / 63 (84.1%)** | **8.4 s** | **117.2 tok/s** | 0.63 s/answer | 🥈 Strong runner-up (IBM Research) |
-| [**`LFM2-8B-A1B-MXFP4_MOE`**](https://huggingface.co/noctrex/LFM2-8B-A1B-MXFP4_MOE-GGUF) | MoE (8B total, 1B active), 4.9 GB | **49 / 63 (77.8%)** | **8.2 s** | **157.7 tok/s** | 0.37 s/answer | Passed gate floor (Liquid AI) |
-| [**`Llama-3.2-3B-Instruct`**](https://huggingface.co/bartowski/Llama-3.2-3B-Instruct-GGUF) | Dense 3B, 2.0 GB | **49 / 63 (77.8%)** | **8.2 s** | 98.5 tok/s | 0.25 s/answer | Competent, but lacks MoE capacity |
-| [**`OLMoE-1B-7B-0125-Instruct`**](https://huggingface.co/noctrex/OLMoE-1B-7B-0125-Instruct-MXFP4_MOE-GGUF) | MoE (7B total, 1B active), 3.9 GB | 40 / 63 (63.5%) | 7.7 s | **212.9 tok/s** | 0.31 s/answer | Fastest raw decode, failed Study JSON schemas |
-| [**`Phi-mini-MoE-instruct`**](https://huggingface.co/noctrex/Phi-mini-MoE-instruct-MXFP4_MOE-GGUF) | MoE, 4.9 GB | 5 / 63 (7.9%) | 51.0 s | 87.8 tok/s | 2.52 s/answer | Excessive verbosity, failed format schemas |
-| [**`SmallThinker-4B-A0.6B-Instruct`**](https://huggingface.co/noctrex/SmallThinker-4B-A0.6B-Instruct-MXFP4_MOE-GGUF) | MoE (4B total, 0.6B active), 2.6 GB | Failed | Loop | 119.0 tok/s | Loop | Runaway loop (>137k tokens, missing EOS) |
-| [**`Ministral-8B-Instruct`**](https://huggingface.co/bartowski/Ministral-8B-Instruct-2410-GGUF) | Dense 8B, 4.9 GB | Failed | Loop | 32.6 tok/s | Loop | 22% CPU offload, runaway loop (>23k tokens) |
-| [**`gemma4:e4b`**](https://ollama.com/library/gemma) *(former default)* | Dense, 9.6 GB | 19 / 23 (82.6%)* | 39.8 s | 39.8 tok/s | Not recorded | Retired (replaced by Ling-3.0-tiny) |
-| [**`gemma4:e2b`**](https://ollama.com/library/gemma) *(former baseline)* | Dense, 7.2 GB | 20 / 23 (87.0%)* | 38.7 s | Not recorded | Not recorded | Retired |
-
-*\*Evaluated on the earlier 23-case reference subset.* Detailed logs and historical benchmarks in [`docs/model-history.md`](docs/model-history.md).
+Pass rate, latency and VRAM footprint for every model this project has
+actually measured, each figure citing the run artifact it came from, live
+in [`docs/model-history.md`](docs/model-history.md) -- not here, since a
+benchmark number copied into this file goes stale the moment a later run
+supersedes it.
 
 ---
 

--- a/docs/model-history.md
+++ b/docs/model-history.md
@@ -22,11 +22,16 @@ reading, not because a reader can open them.
 Four qualifications, all of them measured rather than assumed. Skipping them
 turns this log into a ranking, which it is not.
 
-1. **Every row is n=1.** No stage of the pipeline fixes a seed and three of
-   them sample at non-zero temperature, one of which runs *before* retrieval
-   and so changes which fragments the generator ever sees (issue #223). Two
-   runs of one model can legitimately disagree. A gap of two or three cases
-   between two rows is not a finding.
+1. **A row is one run, and one run moves by up to five cases.** No stage
+   of the pipeline fixes a seed and three of them sample at non-zero
+   temperature, one of which runs *before* retrieval and so changes which
+   fragments the generator ever sees (issue #223). Measured once on this set
+   by running tranche 1 twice under identical conditions (`20260911T032105Z`
+   against `20260911T230513Z`, four models, see "Tranche 1 repeated" below):
+   sampling alone flipped **28 of 536** comparable (case, model) pairs, 4 to
+   11 per model, with a net movement per model between -2 and +5 cases. That
+   is the error bar of the `Answered` column. A gap of five cases between two
+   rows is inside it; the `Runs` column says how many runs a row rests on.
 2. **`s/answer` is the wall time of the generation call**, not tokens divided
    by the decode rate. The older form of this column understated the wait by
    a factor of 36 -- 0.22 s against a measured 7.89 s -- because it omitted
@@ -36,11 +41,18 @@ turns this log into a ranking, which it is not.
    alongside the auxiliary, so Ollama may load one into system RAM instead,
    silently. Where that was observed the row says so, and its speed columns
    describe the degraded regime (issue #235).
-4. **The budget column is not a model property.** A generation is capped at
-   180 s (issue #229). Tranche 1 exhausted that cap 24 times and tranche 2 not
-   once under identical declared conditions, so the two groups are not
-   perfectly comparable despite matching on every recorded condition. Issue
-   #234 tracks why.
+4. **The budget column is mostly not a model property, and it counts
+   against the model anyway.** A generation is capped at 180 s (issue #229)
+   and an exhausted budget is scored as a failure of the row's model. The
+   repeat of tranche 1 showed that 19 of its 24 exhaustions did not
+   reproduce: they sat in two contiguous windows of that run, where every
+   generation of every model ran past the cap while the decode rates on
+   either side were unchanged. The 5 that did reproduce are two `study_summary`
+   cases over whole documents (`ricci-study-summary-es`, 96 chunks, in all
+   four models both times; `att-study-summary-ca` at the edge, 171 s for the
+   one model that passed it). So tranche 1's rows carry about 5 cases of
+   run-level loss the other tranches do not, and a budget count of 4-6 on a
+   small model is that, not the model (issue #234).
 
 ---
 
@@ -50,25 +62,68 @@ turns this log into a ranking, which it is not.
 model in a run. Three corpora of 17 documents (en/es/ca) plus the blind set.
 Budget 180 s, `AUX_MODEL` = `Ling-3.0-tiny` for every row.
 
-| Model | Size | Answered (of 136) | Overall (of 156) | tokens/s | tokens/answer | s/answer | Budget hit | Infra | Placement | Run |
-|---|---|---|---|---|---|---|---|---|---|---|
-| `qwen3-coder-30b:latest` | 10 GB | **125 (91.9%)** | 142 (91.0%) | 45.4 | 90 | 15.03 | 0 | 1 | **~50% CPU** | `20260911T094107Z` |
-| `qwen3:30b-a3b` | 18 GB | 121 (89.0%) | 138 (88.5%) | 39.1 | **335** | 24.93 | 6 | 2 | **~70% CPU** | `20260911T171038Z` |
-| `gemma4:e2b` | 7.2 GB | 120 (88.2%) | 137 (87.8%) | 103.2 | 28 | 7.97 | 0 | 0 | GPU | `20260911T071629Z` |
-| `qwen3:8b` | 5.2 GB | 120 (88.2%) | 137 (87.8%) | 35.8 | 35 | 8.94 | 0 | 0 | **CPU offload** | `20260911T071629Z` |
-| `gemma4:e4b` *(shipped default)* | 9.6 GB | 119 (87.5%) | 136 (87.2%) | 59.9 | 28 | 11.84 | 0 | 0 | GPU | `20260911T094107Z` |
-| `hf.co/noctrex/Ling-3.0-tiny-MXFP4_MOE-GGUF:MXFP4_MOE` | 4.9 GB | 116 (85.3%) | 133 (85.3%) | 116.3 | 27 | 7.52 | 6 | 0 | GPU | `20260911T032105Z` |
-| `granite4:small-h` | 19 GB | 116 (85.3%) | 133 (85.3%) | 17.4 | 70 | 20.52 | 5 | 0 | **~72% CPU** | `20260911T171038Z` |
-| `hf.co/noctrex/Granite-4.0-H-Tiny-MXFP4_MOE-GGUF:...` | 4.2 GB | 112 (82.4%) | 129 (82.7%) | 116.9 | 72 | 7.15 | 6 | 2 | GPU | `20260911T032105Z` |
-| `hf.co/noctrex/LFM2-8B-A1B-MXFP4_MOE-GGUF:...` | 4.9 GB | 108 (79.4%) | 125 (80.1%) | 156.2 | 56 | 6.92 | 0 | 0 | GPU | `20260911T071629Z` |
-| `mistral-small3.2:24b` | 15 GB | 107 (78.7%) | 124 (79.5%) | **5.2** | 24 | 20.94 | 12 | 0 | **~70% CPU** | `20260911T171038Z` |
-| `hf.co/bartowski/Llama-3.2-3B-Instruct-GGUF:Q4_K_M` | 2.0 GB | 105 (77.2%) | 122 (78.2%) | 101.3 | 27 | 6.70 | 6 | 0 | GPU | `20260911T032105Z` |
-| `gpt-oss:20b` | 13 GB | 96 (70.6%) | 113 (72.4%) | 29.7 | 100 | 20.80 | 0 | 4 | **~60% CPU** | `20260911T094107Z` |
-| `hf.co/noctrex/OLMoE-1B-7B-0125-Instruct-MXFP4_MOE-GGUF:...` | 3.9 GB | 91 (66.9%) | 108 (69.2%) | 213.0 | 64 | 6.56 | 6 | 0 | GPU | `20260911T032105Z` |
-| `hf.co/noctrex/Phi-mini-MoE-instruct-MXFP4_MOE-GGUF:...` | 4.9 GB | 63 (46.3%) | 80 (51.3%) | 95.3 | 118 | 9.24 | 0 | 0 | GPU | `20260911T071629Z` |
+| Model | Size | Answered (of 136) | Overall (of 156) | tokens/s | tokens/answer | s/answer | Budget hit | Infra | Placement | Run | Runs |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| `qwen3-coder-30b:latest` | 10 GB | **125 (91.9%)** | 142 (91.0%) | 45.4 | 90 | 15.03 | 0 | 1 | **~50% CPU** | `20260911T094107Z` | 1 |
+| `qwen3:30b-a3b` | 18 GB | 121 (89.0%) | 138 (88.5%) | 39.1 | **335** | 24.93 | 6 | 2 | **~70% CPU** | `20260911T171038Z` | 1 |
+| `gemma4:e2b` | 7.2 GB | 120 (88.2%) | 137 (87.8%) | 103.2 | 28 | 7.97 | 0 | 0 | GPU | `20260911T071629Z` | 1 |
+| `qwen3:8b` | 5.2 GB | 120 (88.2%) | 137 (87.8%) | 35.8 | 35 | 8.94 | 0 | 0 | **CPU offload** | `20260911T071629Z` | 1 |
+| `gemma4:e4b` *(shipped default)* | 9.6 GB | 119 (87.5%) | 136 (87.2%) | 59.9 | 28 | 11.84 | 0 | 0 | GPU | `20260911T094107Z` | 1 |
+| `hf.co/noctrex/Ling-3.0-tiny-MXFP4_MOE-GGUF:MXFP4_MOE` | 4.9 GB | 116 (85.3%) | 133 (85.3%) | 116.3 | 27 | 7.52 | 6 | 0 | GPU | `20260911T032105Z` | 2 |
+| `granite4:small-h` | 19 GB | 116 (85.3%) | 133 (85.3%) | 17.4 | 70 | 20.52 | 5 | 0 | **~72% CPU** | `20260911T171038Z` | 1 |
+| `hf.co/noctrex/Granite-4.0-H-Tiny-MXFP4_MOE-GGUF:...` | 4.2 GB | 112 (82.4%) | 129 (82.7%) | 116.9 | 72 | 7.15 | 6 | 2 | GPU | `20260911T032105Z` | 2 |
+| `hf.co/noctrex/LFM2-8B-A1B-MXFP4_MOE-GGUF:...` | 4.9 GB | 108 (79.4%) | 125 (80.1%) | 156.2 | 56 | 6.92 | 0 | 0 | GPU | `20260911T071629Z` | 1 |
+| `mistral-small3.2:24b` | 15 GB | 107 (78.7%) | 124 (79.5%) | **5.2** | 24 | 20.94 | 12 | 0 | **~70% CPU** | `20260911T171038Z` | 1 |
+| `hf.co/bartowski/Llama-3.2-3B-Instruct-GGUF:Q4_K_M` | 2.0 GB | 105 (77.2%) | 122 (78.2%) | 101.3 | 27 | 6.70 | 6 | 0 | GPU | `20260911T032105Z` | 2 |
+| `gpt-oss:20b` | 13 GB | 96 (70.6%) | 113 (72.4%) | 29.7 | 100 | 20.80 | 0 | 4 | **~60% CPU** | `20260911T094107Z` | 1 |
+| `hf.co/noctrex/OLMoE-1B-7B-0125-Instruct-MXFP4_MOE-GGUF:...` | 3.9 GB | 91 (66.9%) | 108 (69.2%) | 213.0 | 64 | 6.56 | 6 | 0 | GPU | `20260911T032105Z` | 2 |
+| `hf.co/noctrex/Phi-mini-MoE-instruct-MXFP4_MOE-GGUF:...` | 4.9 GB | 63 (46.3%) | 80 (51.3%) | 95.3 | 118 | 9.24 | 0 | 0 | GPU | `20260911T071629Z` | 1 |
 
-Retrieval-only was 17/20 in all four runs -- it does not vary by generator,
+Retrieval-only was 17/20 in all five runs -- it does not vary by generator,
 which is why it is reported once rather than folded into each row.
+
+`Runs` is how many full runs the row's model has on this set. The four with
+2 are tranche 1, repeated to measure the noise (next section); their row
+keeps the first run's figures so the table stays one artifact per row, and
+the second run sits below.
+
+### Tranche 1 repeated
+
+Same four generators, same declared conditions (`conditions` blocks equal
+field for field except `git_commit`: the repeat ran on `bbf284c`, three
+defect fixes later -- #237, #238, #239 -- none of them in the generation
+or grading path). `20260911T032105Z` first, `20260911T230513Z` second, 105
+min against 159.
+
+| Model | Answered, run 1 | Answered, run 2 | Flips (+/-) | Budget hit | Infra |
+|---|---|---|---|---|---|
+| `Ling-3.0-tiny` | 116 (85.3%) | 117 (86.0%) | +4 / -3 | 6 -> 2 | 0 -> 0 |
+| `Llama-3.2-3B` | 105 (77.2%) | 114 (83.8%) | +10 / -1 | 6 -> 1 | 0 -> 0 |
+| `Granite-4.0-H-Tiny` | 112 (82.4%) | 114 (83.8%) | +6 / -2 | 6 -> 1 | 2 -> 6 |
+| `OLMoE-1B-7B` | 91 (66.9%) | 90 (66.2%) | +5 / -6 | 6 -> 1 | 0 -> 0 |
+
+`python tests/eval/compare_runs.py --exclude-infrastructure-errors` over the
+pair: 25 flipped to PASS, 12 to FAIL, 521 unchanged, 6 pairs excluded (all
+Granite's `GGML_ASSERT` on `att-study-*`, which now hits six of the nine).
+Two effects sit in those 37 flips and they should not be read as one:
+
+- **Sampling.** Dropping every pair that exhausted the budget in either run
+  leaves 536 pairs and 28 flips (16 up, 12 down): 4 for Ling, 7 for Llama,
+  6 for Granite, 11 for OLMoE, net -2 to +5 per model. That is the noise
+  floor of one row. Decode rates and `s/answer` medians agree between the
+  runs to within 0.4 s, so the two runs measured the same machine in the
+  same state.
+- **Budget.** 24 exhaustions became 5. Llama's +9 net is mostly this: 6 of
+  its flips to PASS are cases that ran out of time in run 1 and answered in
+  9-12 s in run 2. The 19 that vanished were two contiguous windows of run 1
+  (records 225-240 and 248-255 in generation order, every model, `study`
+  and factual cases alike), and the 54 minutes of difference in wall time
+  is those 19 x 180 s. What made run 1 stall there is not in the artifact
+  (issue #234).
+
+The first-run figures stay in the table above because the repeat was made to
+measure the noise, not to pick the better of two draws; replacing a row with
+its best run is the selection bias the row count exists to expose.
 
 **The Infra column is cases the model never got to answer.** Granite's two
 are `GGML_ASSERT(buffer) failed` on `study_outline`; `gpt-oss:20b`'s four and
@@ -89,10 +144,11 @@ model in it, which is the clearest illustration available that speed and
 latency are different questions.
 
 The top is not a ranking. `qwen3-coder-30b` leads by five cases over a
-three-way cluster at 119-120, and that gap sits at the edge of what #223 and
-#234 leave uncertain; it is also the model that led the 23-case table on 2026-09-01, which
-is weak evidence but not none. `gemma4:e2b`,
-`qwen3:8b` and the shipped default `gemma4:e4b` are separated by one case.
+three-way cluster at 119-120, and five cases is inside the measured noise of
+a single run (4-11 flips per model, net up to +5); it is also the model that
+led the 23-case table on 2026-09-01, which is weak evidence but not none.
+`gemma4:e2b`, `qwen3:8b` and the shipped default `gemma4:e4b` are separated
+by one case.
 
 Placement is the finding that cuts across the table. The best measured model
 runs half in system RAM, `qwen3:8b` ties for third while never reaching the
@@ -119,7 +175,8 @@ Every generator the previous table listed, including the five rows it carried
 as "pending" or "not yet run", now has a row above measured on the same set.
 The tranches: `20260911T032105Z` (4 models, 159 min), `20260911T071629Z`
 (4, 144 min), `20260911T094107Z` (3, 144 min), `20260911T171038Z` (3, 278
-min). Total GPU time for the table: about 12 hours.
+min), plus the repeat of tranche 1, `20260911T230513Z` (4, 105 min). Total
+GPU time for the table: about 14 hours.
 
 ---
 

--- a/docs/model-history.md
+++ b/docs/model-history.md
@@ -50,44 +50,52 @@ turns this log into a ranking, which it is not.
 model in a run. Three corpora of 17 documents (en/es/ca) plus the blind set.
 Budget 180 s, `AUX_MODEL` = `Ling-3.0-tiny` for every row.
 
-| Model | Size | Answered (of 136) | Overall (of 156) | tokens/s | tokens/answer | s/answer | Budget hit | Placement | Run |
-|---|---|---|---|---|---|---|---|---|---|
-| `gemma4:e2b` | 7.2 GB | **120 (88.2%)** | 137 (87.8%) | 103.2 | 28 | 7.97 | 0 | GPU | `20260911T071629Z` |
-| `qwen3:8b` | 5.2 GB | **120 (88.2%)** | 137 (87.8%) | 35.8 | 35 | 8.94 | 0 | **CPU offload** | `20260911T071629Z` |
-| `hf.co/noctrex/Ling-3.0-tiny-MXFP4_MOE-GGUF:MXFP4_MOE` | 4.9 GB | 116 (85.3%) | 133 (85.3%) | 116.3 | 27 | 7.52 | 6 | GPU | `20260911T032105Z` |
-| `hf.co/noctrex/Granite-4.0-H-Tiny-MXFP4_MOE-GGUF:...` | 4.2 GB | 112 (82.4%) | 129 (82.7%) | 116.9 | 72 | 7.15 | 6 | GPU | `20260911T032105Z` |
-| `hf.co/noctrex/LFM2-8B-A1B-MXFP4_MOE-GGUF:...` | 4.9 GB | 108 (79.4%) | 125 (80.1%) | 156.2 | 56 | 6.92 | 0 | GPU | `20260911T071629Z` |
-| `hf.co/bartowski/Llama-3.2-3B-Instruct-GGUF:Q4_K_M` | 2.0 GB | 105 (77.2%) | 122 (78.2%) | 101.3 | 27 | 6.70 | 6 | GPU | `20260911T032105Z` |
-| `hf.co/noctrex/OLMoE-1B-7B-0125-Instruct-MXFP4_MOE-GGUF:...` | 3.9 GB | 91 (66.9%) | 108 (69.2%) | 213.0 | 64 | 6.56 | 6 | GPU | `20260911T032105Z` |
-| `hf.co/noctrex/Phi-mini-MoE-instruct-MXFP4_MOE-GGUF:...` | 4.9 GB | 63 (46.3%) | 80 (51.3%) | 95.3 | 118 | 9.24 | 0 | GPU | `20260911T071629Z` |
+| Model | Size | Answered (of 136) | Overall (of 156) | tokens/s | tokens/answer | s/answer | Budget hit | Infra | Placement | Run |
+|---|---|---|---|---|---|---|---|---|---|---|
+| `qwen3-coder-30b:latest` | 10 GB | **125 (91.9%)** | 142 (91.0%) | 45.4 | 90 | 15.03 | 0 | 1 | **~50% CPU** | `20260911T094107Z` |
+| `gemma4:e2b` | 7.2 GB | 120 (88.2%) | 137 (87.8%) | 103.2 | 28 | 7.97 | 0 | 0 | GPU | `20260911T071629Z` |
+| `qwen3:8b` | 5.2 GB | 120 (88.2%) | 137 (87.8%) | 35.8 | 35 | 8.94 | 0 | 0 | **CPU offload** | `20260911T071629Z` |
+| `gemma4:e4b` *(shipped default)* | 9.6 GB | 119 (87.5%) | 136 (87.2%) | 59.9 | 28 | 11.84 | 0 | 0 | GPU | `20260911T094107Z` |
+| `hf.co/noctrex/Ling-3.0-tiny-MXFP4_MOE-GGUF:MXFP4_MOE` | 4.9 GB | 116 (85.3%) | 133 (85.3%) | 116.3 | 27 | 7.52 | 6 | 0 | GPU | `20260911T032105Z` |
+| `hf.co/noctrex/Granite-4.0-H-Tiny-MXFP4_MOE-GGUF:...` | 4.2 GB | 112 (82.4%) | 129 (82.7%) | 116.9 | 72 | 7.15 | 6 | 2 | GPU | `20260911T032105Z` |
+| `hf.co/noctrex/LFM2-8B-A1B-MXFP4_MOE-GGUF:...` | 4.9 GB | 108 (79.4%) | 125 (80.1%) | 156.2 | 56 | 6.92 | 0 | 0 | GPU | `20260911T071629Z` |
+| `hf.co/bartowski/Llama-3.2-3B-Instruct-GGUF:Q4_K_M` | 2.0 GB | 105 (77.2%) | 122 (78.2%) | 101.3 | 27 | 6.70 | 6 | 0 | GPU | `20260911T032105Z` |
+| `gpt-oss:20b` | 13 GB | 96 (70.6%) | 113 (72.4%) | 29.7 | 100 | 20.80 | 0 | 4 | **~60% CPU** | `20260911T094107Z` |
+| `hf.co/noctrex/OLMoE-1B-7B-0125-Instruct-MXFP4_MOE-GGUF:...` | 3.9 GB | 91 (66.9%) | 108 (69.2%) | 213.0 | 64 | 6.56 | 6 | 0 | GPU | `20260911T032105Z` |
+| `hf.co/noctrex/Phi-mini-MoE-instruct-MXFP4_MOE-GGUF:...` | 4.9 GB | 63 (46.3%) | 80 (51.3%) | 95.3 | 118 | 9.24 | 0 | 0 | GPU | `20260911T071629Z` |
 
-Retrieval-only was 17/20 in both runs -- it does not vary by generator, which
-is why it is reported once rather than folded into each row.
+Retrieval-only was 17/20 in all three runs -- it does not vary by generator,
+which is why it is reported once rather than folded into each row.
 
-**Granite-4.0-H-Tiny additionally hit 2 infrastructure errors**, both on
-`study_outline` cases, both `GGML_ASSERT(buffer) failed` from the Ollama
-server. Those two cases were not evaluated for that model, so its row rests
-on 134 attempts rather than 136, and the run as a whole is formally
-inconclusive by the gate's own rule.
+**The Infra column is cases the model never got to answer.** Granite's two
+are `GGML_ASSERT(buffer) failed` on `study_outline`; `gpt-oss:20b`'s four and
+`qwen3-coder-30b`'s one are `500 Server Error` from Ollama mid-stream, the
+signature of a model that does not fit running out of memory under offload.
+A row with a non-zero Infra count rests on fewer than 136 attempts, and the
+gate marks the whole run inconclusive by its own rule -- the figures are
+still the best available, but they are not a clean 136.
 
 ### What this does and does not show
 
-The spread from 88.2% to 46.3% is far wider than the noise floor plausibly
-covers, so the bottom of the table is a real finding: `Phi-mini-MoE` is not
-usable for this pipeline, and `OLMoE` gives up 20 points for a decode rate
-nobody waits on (its `s/answer` is the best in the table, and it is the
-second worst model in it -- the clearest illustration available that speed
-and latency are different questions).
+The spread from 91.9% to 46.3% is far wider than the noise floor plausibly
+covers, so the ends of the table are real findings. `Phi-mini-MoE` is not
+usable for this pipeline. `OLMoE` gives up 25 points for a decode rate nobody
+waits on: its `s/answer` is the best in the table and it is the second worst
+model in it, which is the clearest illustration available that speed and
+latency are different questions.
 
-The top is not a ranking. `gemma4:e2b` and `qwen3:8b` tie exactly, and
-`Ling-3.0-tiny` sits four cases below them while having lost six cases to the
-budget in a tranche where nothing else exhausted it. Those four cases are
-inside the uncertainty that #223 and #234 describe.
+The top is not a ranking. `qwen3-coder-30b` leads by five cases over a
+three-way cluster at 119-120, and that gap sits at the edge of what #223 and
+#234 leave uncertain; it is also the model that led the 23-case table on 2026-09-01, which
+is weak evidence but not none. `gemma4:e2b`,
+`qwen3:8b` and the shipped default `gemma4:e4b` are separated by one case.
 
-The one unambiguous practical reading concerns `qwen3:8b`: it matches the
-best measured quality while never once reaching the GPU in 24 samples. Its
-35.8 tok/s is the cost of running from system RAM, not a property of the
-model.
+Placement is the finding that cuts across the table. The best measured model
+runs half in system RAM, `qwen3:8b` ties for second while never reaching the
+GPU, and `gpt-oss:20b` at 60% CPU is both slow and the only model to lose
+four cases to the server itself. On this card, quality and fitting in VRAM
+are not the same axis, and a wait of 15 s against 8 s is the price of the
+five extra cases.
 
 ---
 
@@ -98,14 +106,11 @@ visible rather than inferred from absence.
 
 | Model | Size | Status |
 |---|---|---|
-| `gemma4:e4b` | 9.6 GB | in progress, tranche 3 |
-| `qwen3-coder-30b:latest` | 10 GB | in progress, tranche 3 |
-| `gpt-oss:20b` | 13 GB | in progress, tranche 3 |
-| `mistral-small3.2:24b` | 15 GB | queued |
-| `qwen3:30b-a3b` | 18 GB | queued |
-| `granite4:small-h` | 19 GB | queued |
+| `mistral-small3.2:24b` | 15 GB | in progress, tranche 4 |
+| `qwen3:30b-a3b` | 18 GB | in progress, tranche 4 |
+| `granite4:small-h` | 19 GB | in progress, tranche 4 |
 
-The last four exceed the card, so they are expected to run with CPU offload
+All three exceed the card, so they are expected to run with CPU offload
 throughout, and their speed columns will describe that regime.
 
 ---

--- a/docs/model-history.md
+++ b/docs/model-history.md
@@ -53,24 +53,28 @@ Budget 180 s, `AUX_MODEL` = `Ling-3.0-tiny` for every row.
 | Model | Size | Answered (of 136) | Overall (of 156) | tokens/s | tokens/answer | s/answer | Budget hit | Infra | Placement | Run |
 |---|---|---|---|---|---|---|---|---|---|---|
 | `qwen3-coder-30b:latest` | 10 GB | **125 (91.9%)** | 142 (91.0%) | 45.4 | 90 | 15.03 | 0 | 1 | **~50% CPU** | `20260911T094107Z` |
+| `qwen3:30b-a3b` | 18 GB | 121 (89.0%) | 138 (88.5%) | 39.1 | **335** | 24.93 | 6 | 2 | **~70% CPU** | `20260911T171038Z` |
 | `gemma4:e2b` | 7.2 GB | 120 (88.2%) | 137 (87.8%) | 103.2 | 28 | 7.97 | 0 | 0 | GPU | `20260911T071629Z` |
 | `qwen3:8b` | 5.2 GB | 120 (88.2%) | 137 (87.8%) | 35.8 | 35 | 8.94 | 0 | 0 | **CPU offload** | `20260911T071629Z` |
 | `gemma4:e4b` *(shipped default)* | 9.6 GB | 119 (87.5%) | 136 (87.2%) | 59.9 | 28 | 11.84 | 0 | 0 | GPU | `20260911T094107Z` |
 | `hf.co/noctrex/Ling-3.0-tiny-MXFP4_MOE-GGUF:MXFP4_MOE` | 4.9 GB | 116 (85.3%) | 133 (85.3%) | 116.3 | 27 | 7.52 | 6 | 0 | GPU | `20260911T032105Z` |
+| `granite4:small-h` | 19 GB | 116 (85.3%) | 133 (85.3%) | 17.4 | 70 | 20.52 | 5 | 0 | **~72% CPU** | `20260911T171038Z` |
 | `hf.co/noctrex/Granite-4.0-H-Tiny-MXFP4_MOE-GGUF:...` | 4.2 GB | 112 (82.4%) | 129 (82.7%) | 116.9 | 72 | 7.15 | 6 | 2 | GPU | `20260911T032105Z` |
 | `hf.co/noctrex/LFM2-8B-A1B-MXFP4_MOE-GGUF:...` | 4.9 GB | 108 (79.4%) | 125 (80.1%) | 156.2 | 56 | 6.92 | 0 | 0 | GPU | `20260911T071629Z` |
+| `mistral-small3.2:24b` | 15 GB | 107 (78.7%) | 124 (79.5%) | **5.2** | 24 | 20.94 | 12 | 0 | **~70% CPU** | `20260911T171038Z` |
 | `hf.co/bartowski/Llama-3.2-3B-Instruct-GGUF:Q4_K_M` | 2.0 GB | 105 (77.2%) | 122 (78.2%) | 101.3 | 27 | 6.70 | 6 | 0 | GPU | `20260911T032105Z` |
 | `gpt-oss:20b` | 13 GB | 96 (70.6%) | 113 (72.4%) | 29.7 | 100 | 20.80 | 0 | 4 | **~60% CPU** | `20260911T094107Z` |
 | `hf.co/noctrex/OLMoE-1B-7B-0125-Instruct-MXFP4_MOE-GGUF:...` | 3.9 GB | 91 (66.9%) | 108 (69.2%) | 213.0 | 64 | 6.56 | 6 | 0 | GPU | `20260911T032105Z` |
 | `hf.co/noctrex/Phi-mini-MoE-instruct-MXFP4_MOE-GGUF:...` | 4.9 GB | 63 (46.3%) | 80 (51.3%) | 95.3 | 118 | 9.24 | 0 | 0 | GPU | `20260911T071629Z` |
 
-Retrieval-only was 17/20 in all three runs -- it does not vary by generator,
+Retrieval-only was 17/20 in all four runs -- it does not vary by generator,
 which is why it is reported once rather than folded into each row.
 
 **The Infra column is cases the model never got to answer.** Granite's two
 are `GGML_ASSERT(buffer) failed` on `study_outline`; `gpt-oss:20b`'s four and
-`qwen3-coder-30b`'s one are `500 Server Error` from Ollama mid-stream, the
-signature of a model that does not fit running out of memory under offload.
+`qwen3-coder-30b`'s one and `qwen3:30b-a3b`'s two are `500 Server Error`
+from Ollama mid-stream, the signature of a model that does not fit running
+out of memory under offload.
 A row with a non-zero Infra count rests on fewer than 136 attempts, and the
 gate marks the whole run inconclusive by its own rule -- the figures are
 still the best available, but they are not a clean 136.
@@ -91,27 +95,31 @@ is weak evidence but not none. `gemma4:e2b`,
 `qwen3:8b` and the shipped default `gemma4:e4b` are separated by one case.
 
 Placement is the finding that cuts across the table. The best measured model
-runs half in system RAM, `qwen3:8b` ties for second while never reaching the
-GPU, and `gpt-oss:20b` at 60% CPU is both slow and the only model to lose
-four cases to the server itself. On this card, quality and fitting in VRAM
-are not the same axis, and a wait of 15 s against 8 s is the price of the
-five extra cases.
+runs half in system RAM, `qwen3:8b` ties for third while never reaching the
+GPU, and every model above 10 GB ran at 60-72% CPU. On this card, quality and
+fitting in VRAM are not the same axis, and a wait of 15-25 s against 7-8 s is
+the price of the extra cases.
+
+The four largest models answer the question the old "pending" rows left
+open, and the answer is not uniform. `qwen3:30b-a3b` reaches 89% but does it
+by reasoning inline -- a median of **335 tokens per answer** against 24-35
+for everything else, which is the truncation risk the old file described and
+here cost it six budget exhaustions and 25 s per answer. `granite4:small-h`
+matches `Ling-3.0-tiny` on quality at a third of the speed. `mistral-small3.2`
+at 5.2 tok/s is the slowest row in the table and exhausted the budget twelve
+times; with 70% of a 15 GB model in system RAM it is not a configuration
+anyone would run. The tranche took 278 minutes against 144-159 for the
+others.
 
 ---
 
-## Still to measure
+## Coverage
 
-These have never been run against the 156-case set. Listed so the gap is
-visible rather than inferred from absence.
-
-| Model | Size | Status |
-|---|---|---|
-| `mistral-small3.2:24b` | 15 GB | in progress, tranche 4 |
-| `qwen3:30b-a3b` | 18 GB | in progress, tranche 4 |
-| `granite4:small-h` | 19 GB | in progress, tranche 4 |
-
-All three exceed the card, so they are expected to run with CPU offload
-throughout, and their speed columns will describe that regime.
+Every generator the previous table listed, including the five rows it carried
+as "pending" or "not yet run", now has a row above measured on the same set.
+The tranches: `20260911T032105Z` (4 models, 159 min), `20260911T071629Z`
+(4, 144 min), `20260911T094107Z` (3, 144 min), `20260911T171038Z` (3, 278
+min). Total GPU time for the table: about 12 hours.
 
 ---
 

--- a/docs/model-history.md
+++ b/docs/model-history.md
@@ -1,127 +1,189 @@
-# Model history — what has been measured, on what, and how fast
+# Model history -- what has been measured, on what, and how fast
 
 Append-only record of every model this project has run, so a later choice is
-made from numbers rather than from memory. Each row names the machine and the
-run artifact it came from; without those a figure is an anecdote.
+made from numbers rather than from memory. Each row names the run artifact it
+came from; without that a figure is an anecdote.
 
-**Read the caveat before the tables.** The gold set has 32 search-set cases
-and 23 of them reach a generator. The design doc puts the threshold for a
-difference not attributable to chance at about **six net flips**, so a gap of
-one or two cases between two generators is inside the noise this project has
-already measured. These tables are a log, not a ranking.
+**Conditions are not restated here.** What has to match between two runs for
+their numbers to be comparable is written once, in
+[`tests/eval/README.md`](../tests/eval/README.md) under "Experiment standard",
+together with the procedure for adding a row. A row that cannot point at an
+artifact produced under that standard belongs in "Superseded measurements"
+below, not in the current table.
 
-Run artifacts live under `tests/eval/runs/`, which is gitignored: the paths
-are cited so the machine that holds them can reproduce the reading, not
-because a reader can open them.
+Run artifacts live under `tests/eval/runs/`, which is gitignored: the
+identifiers are cited so the machine that holds them can reproduce the
+reading, not because a reader can open them.
+
+---
+
+## How to read the current table
+
+Four qualifications, all of them measured rather than assumed. Skipping them
+turns this log into a ranking, which it is not.
+
+1. **Every row is n=1.** No stage of the pipeline fixes a seed and three of
+   them sample at non-zero temperature, one of which runs *before* retrieval
+   and so changes which fragments the generator ever sees (issue #223). Two
+   runs of one model can legitimately disagree. A gap of two or three cases
+   between two rows is not a finding.
+2. **`s/answer` is the wall time of the generation call**, not tokens divided
+   by the decode rate. The older form of this column understated the wait by
+   a factor of 36 -- 0.22 s against a measured 7.89 s -- because it omitted
+   prompt evaluation, which dominates when the prompt is retrieved context
+   (issue #233). `tokens/s` still describes decoding only.
+3. **Placement is part of the measurement.** Two models do not fit in 7.6 GiB
+   alongside the auxiliary, so Ollama may load one into system RAM instead,
+   silently. Where that was observed the row says so, and its speed columns
+   describe the degraded regime (issue #235).
+4. **The budget column is not a model property.** A generation is capped at
+   180 s (issue #229). Tranche 1 exhausted that cap 24 times and tranche 2 not
+   once under identical declared conditions, so the two groups are not
+   perfectly comparable despite matching on every recorded condition. Issue
+   #234 tracks why.
+
+---
+
+## Generators on the current gold set
+
+156 cases: 136 reach a generator, 20 are retrieval-only and shared by every
+model in a run. Three corpora of 17 documents (en/es/ca) plus the blind set.
+Budget 180 s, `AUX_MODEL` = `Ling-3.0-tiny` for every row.
+
+| Model | Size | Answered (of 136) | Overall (of 156) | tokens/s | tokens/answer | s/answer | Budget hit | Placement | Run |
+|---|---|---|---|---|---|---|---|---|---|
+| `gemma4:e2b` | 7.2 GB | **120 (88.2%)** | 137 (87.8%) | 103.2 | 28 | 7.97 | 0 | GPU | `20260911T071629Z` |
+| `qwen3:8b` | 5.2 GB | **120 (88.2%)** | 137 (87.8%) | 35.8 | 35 | 8.94 | 0 | **CPU offload** | `20260911T071629Z` |
+| `hf.co/noctrex/Ling-3.0-tiny-MXFP4_MOE-GGUF:MXFP4_MOE` | 4.9 GB | 116 (85.3%) | 133 (85.3%) | 116.3 | 27 | 7.52 | 6 | GPU | `20260911T032105Z` |
+| `hf.co/noctrex/Granite-4.0-H-Tiny-MXFP4_MOE-GGUF:...` | 4.2 GB | 112 (82.4%) | 129 (82.7%) | 116.9 | 72 | 7.15 | 6 | GPU | `20260911T032105Z` |
+| `hf.co/noctrex/LFM2-8B-A1B-MXFP4_MOE-GGUF:...` | 4.9 GB | 108 (79.4%) | 125 (80.1%) | 156.2 | 56 | 6.92 | 0 | GPU | `20260911T071629Z` |
+| `hf.co/bartowski/Llama-3.2-3B-Instruct-GGUF:Q4_K_M` | 2.0 GB | 105 (77.2%) | 122 (78.2%) | 101.3 | 27 | 6.70 | 6 | GPU | `20260911T032105Z` |
+| `hf.co/noctrex/OLMoE-1B-7B-0125-Instruct-MXFP4_MOE-GGUF:...` | 3.9 GB | 91 (66.9%) | 108 (69.2%) | 213.0 | 64 | 6.56 | 6 | GPU | `20260911T032105Z` |
+| `hf.co/noctrex/Phi-mini-MoE-instruct-MXFP4_MOE-GGUF:...` | 4.9 GB | 63 (46.3%) | 80 (51.3%) | 95.3 | 118 | 9.24 | 0 | GPU | `20260911T071629Z` |
+
+Retrieval-only was 17/20 in both runs -- it does not vary by generator, which
+is why it is reported once rather than folded into each row.
+
+**Granite-4.0-H-Tiny additionally hit 2 infrastructure errors**, both on
+`study_outline` cases, both `GGML_ASSERT(buffer) failed` from the Ollama
+server. Those two cases were not evaluated for that model, so its row rests
+on 134 attempts rather than 136, and the run as a whole is formally
+inconclusive by the gate's own rule.
+
+### What this does and does not show
+
+The spread from 88.2% to 46.3% is far wider than the noise floor plausibly
+covers, so the bottom of the table is a real finding: `Phi-mini-MoE` is not
+usable for this pipeline, and `OLMoE` gives up 20 points for a decode rate
+nobody waits on (its `s/answer` is the best in the table, and it is the
+second worst model in it -- the clearest illustration available that speed
+and latency are different questions).
+
+The top is not a ranking. `gemma4:e2b` and `qwen3:8b` tie exactly, and
+`Ling-3.0-tiny` sits four cases below them while having lost six cases to the
+budget in a tranche where nothing else exhausted it. Those four cases are
+inside the uncertainty that #223 and #234 describe.
+
+The one unambiguous practical reading concerns `qwen3:8b`: it matches the
+best measured quality while never once reaching the GPU in 24 samples. Its
+35.8 tok/s is the cost of running from system RAM, not a property of the
+model.
+
+---
+
+## Still to measure
+
+These have never been run against the 156-case set. Listed so the gap is
+visible rather than inferred from absence.
+
+| Model | Size | Status |
+|---|---|---|
+| `gemma4:e4b` | 9.6 GB | in progress, tranche 3 |
+| `qwen3-coder-30b:latest` | 10 GB | in progress, tranche 3 |
+| `gpt-oss:20b` | 13 GB | in progress, tranche 3 |
+| `mistral-small3.2:24b` | 15 GB | queued |
+| `qwen3:30b-a3b` | 18 GB | queued |
+| `granite4:small-h` | 19 GB | queued |
+
+The last four exceed the card, so they are expected to run with CPU offload
+throughout, and their speed columns will describe that regime.
 
 ---
 
 ## The fixed stack
 
 Three of the five model roles are not configurable, and they decide more than
-the generator does. A generator swap moved two cases out of 23; the extractor
-version moved three (see "Stack drift" below).
+the generator does.
 
 | Role | Model | Where it runs | Notes |
 |---|---|---|---|
-| PDF extraction | **MinerU 3.4.5** | `.venv-mineru`, GPU | Downloads its own models on first use. Its 2.x line produced a different output layout and different block types — not interchangeable, see #118. |
+| PDF extraction | **MinerU 3.4.5** | `.venv-mineru`, GPU | Downloads its own models on first use. Its 2.x line produced a different output layout and different block types -- not interchangeable, see #118. |
 | Text+image embedding | **jinaai/jina-clip-v2**, 512-dim Matryoshka | `.venv-mineru`, GPU, ~2.8 GiB | Fixed by design. CC BY-NC 4.0: local use is non-commercial. |
 | Reranking | **BAAI/bge-reranker-v2-m3** | product venv, GPU, ~1.5 GiB | Cross-encoder. Not an Ollama model. |
-| Query decomposition | Ollama, `chat` role | Ollama | The gate pins this to its own `AUX_MODEL` so a `--models` sweep does not also swap the decomposer. |
-| Answer generation | Ollama, `rag` role | Ollama | The only role the tables below vary. |
+| Query decomposition, RECOMP, contextual | Ollama, `AUX_MODEL` | Ollama | Pinned for a whole run so a `--models` sweep varies only the generator. Shares the card with it -- see placement, above. |
+| Answer generation | Ollama, `rag` role | Ollama | The only role the table varies. |
+
+Since issue #222 the installed versions of these are recorded in each
+artifact's `conditions` block rather than being remembered here.
 
 ---
 
-## Generators measured
+## Superseded measurements
 
-`gemma4:e4b` is the repo default. Cases are the 23 answered ones; the other
-42 never call a generator.
+Kept because they are the only record of what was observed at the time, and
+separated because none of them can be compared with the table above or with
+each other. The gold set changed twice, and the second change also altered
+what a percentage means.
 
-| Model | Params / size | Answered cases passed | Median s/case | tokens/s | tokens/answer | s/answer | Run |
-|---|---|---|---|---|---|---|---|
-| `qwen3-coder-30b:latest` | 30B MoE, 10 GB | **21 / 23** | 41.7 | not recorded | not recorded | not recorded | `20260901T023915Z` |
-| `gemma4:e2b` | 7.2 GB | 20 / 23 | 38.7 | not recorded | not recorded | not recorded | `20260901T023915Z` |
-| `gemma4:e4b` *(default)* | 9.6 GB | 19 / 23 | 39.8 | not recorded | not recorded | not recorded | `20260901T023915Z` |
-| `hf.co/bartowski/Llama-3.2-3B-Instruct-GGUF:Q4_K_M` | 3B dense, 2.0 GB | **49 / 63** (77.8%) | 8.2 | 98.5 | 25 | 0.25 | `20260903T115934Z` |
-| `hf.co/noctrex/Ling-3.0-tiny-MXFP4_MOE-GGUF:MXFP4_MOE` | MoE, 4.9 GB | **56 / 63** (88.9%) | 8.1 | 109.3 | 18 *(of 50)* | 0.15 | `20260903T124819Z` |
-| `hf.co/noctrex/Granite-4.0-H-Tiny-MXFP4_MOE-GGUF:Granite-4.0-H-Tiny-MXFP4_MOE` | MoE, 4.2 GB | **53 / 63** (84.1%) | 8.4 | 117.2 | 75 *(of 51)* | 0.63 | `20260903T134407Z` |
-| `hf.co/noctrex/OLMoE-1B-7B-0125-Instruct-MXFP4_MOE-GGUF:OLMoE-1B-7B-0125-Instruct-MXFP4_MOE` | MoE, 3.9 GB | **40 / 63** (63.5%) | 7.7 | 212.9 | 66 *(of 51)* | 0.31 | `20260903T143414Z` |
-| `hf.co/noctrex/LFM2-8B-A1B-MXFP4_MOE-GGUF:LFM2-8B-A1B-MXFP4_MOE` | MoE, 4.9 GB | **49 / 63** (77.8%) | 8.2 | 157.7 | 54 *(of 51)* | 0.37 | `20260903T161257Z` |
-| `hf.co/noctrex/Ling-3.0-tiny-MXFP4_MOE-GGUF:MXFP4_MOE` *(re-measured)* | MoE, 4.9 GB | **61 / 63** (96.8%) | 7.8 | 110.1 | 16 *(of 51)* | 0.15 | `20260908T130135Z` |
-| `hf.co/noctrex/Ling-3.0-tiny-MXFP4_MOE-GGUF:MXFP4_MOE` *(156-case set)* | MoE, 4.9 GB | **120 / 136** (88.2%) | 7.9 | 113.9 | 25 *(of 124)* | 0.22 | `20260908T200256Z` |
-| `hf.co/noctrex/Phi-mini-MoE-instruct-MXFP4_MOE-GGUF:Phi-mini-MoE-instruct-MXFP4_MOE` | MoE, 4.9 GB | **5 / 63** (7.9%) | 51.0 | 87.8 | 229 *(of 13)* | 2.52 | `20260903T180057Z` |
-| `qwen3:30b-a3b` | 30B MoE, 3B active, 18 GB | pending | | | | | in progress |
-| `qwen3:8b` | 8B dense, 5.2 GB | pending | | | | | in progress |
-| `mistral-small3.2:24b` | 24B dense, 15 GB | pending | | | | | in progress |
-| `gpt-oss:20b` | 20B MoE, 13 GB | not yet run | | | | | |
-| `granite4:small-h` | MoE, 19 GB | not yet run | | | | | |
+**On a 32-case search set, 23 answered (2026-09-01, `20260901T023915Z`):**
 
-**Speed is not latency, and this is the column that says so.** `tokens/s` is
-how fast a model decodes; `s/answer` is how long the user waits, and it is
-tokens divided by that rate. A model that reasons inline spends its budget
-before it starts answering, so the two columns can rank the same pair of models
-in opposite orders. Measured 2026-09-01, one representative prompt, `think:
-false`, `num_predict: 96`, `temperature: 0`:
+| Model | Answered passed |
+|---|---|
+| `qwen3-coder-30b:latest` | 21 / 23 |
+| `gemma4:e2b` | 20 / 23 |
+| `gemma4:e4b` | 19 / 23 |
 
-| Model | tokens/s | tokens used | s/answer |
-|---|---|---|---|
-| `qwen3-coder-30b:latest` | 43.5 | 5 | **0.11** |
-| `qwen3:30b-a3b` | 38.2 | 96 | **2.51** |
+Paired over identical fragments, 21 of those 23 cases gave the same verdict
+under all three models; only `dpo-model-scale` and `planck-h0` discriminated,
+and two more failed under all three, making them system failures rather than
+model failures. The conclusion drawn at the time -- that the generator was not
+where the remaining failures were -- was drawn from two discriminating cases
+in one language. Full analysis in issue #134.
 
-Fourteen per cent apart on the column this table used to show; twenty-three
-times apart on the wait. Both answered correctly. `think: false` controls
-Ollama's *thinking channel* — the separate field a model emits its trace into —
-and does not stop a model whose chat template reasons inline from doing it in
-the body of the answer. Qwen3 does exactly that. Full analysis in issue #146.
+**On an 83-case set, 63 answered, six English papers plus the blind set
+(2026-09-03 to 2026-09-08):**
 
-The second consequence is worse than the wait. At `num_predict: 96` the
-reasoning consumed the whole budget, and the answer survived by luck; a longer
-preamble truncates into something that grades as a plain `FAIL`,
-indistinguishable from the model not knowing. So a high `tokens/answer` is not
-only a cost, it is a **truncation risk**, and that is the number to check first
-when a capable model grades badly.
+| Model | Answered passed | Run |
+|---|---|---|
+| `Ling-3.0-tiny` | 61 / 63 (96.8%) | `20260908T130135Z` |
+| `Ling-3.0-tiny` | 56 / 63 (88.9%) | `20260903T124819Z` |
+| `Granite-4.0-H-Tiny` | 53 / 63 (84.1%) | `20260903T134407Z` |
+| `LFM2-8B-A1B` | 49 / 63 (77.8%) | `20260903T161257Z` |
+| `Llama-3.2-3B-Instruct` | 49 / 63 (77.8%) | `20260903T115934Z` |
+| `OLMoE-1B-7B` | 40 / 63 (63.5%) | `20260903T143414Z` |
+| `Phi-mini-MoE-instruct` | 5 / 63 (7.9%) | `20260903T180057Z` |
 
-**Why the tokens/s column is empty above.** The gate recorded
-`elapsed_seconds` per case, which includes the retrieval every model shares —
-so it mostly measured how busy the card was, not how fast the model decoded.
-Ollama reports `eval_count` and `eval_duration` on its final chunk and the
-streaming path always collected them; the silent path the gate uses dropped
-them. Fixed 2026-09-01: every record now carries `eval_count`,
-`eval_duration_s`, `generation_seconds` and `tokens_per_second`, and the
-column fills from the next run onward. Earlier rows stay empty rather than
-being back-filled with a number nobody measured.
+The es and ca corpora did not exist in this set: every figure above describes
+English-only behaviour, and the file did not say so at the time.
 
-### What the three-model comparison actually showed
+**One row on the 156-case set before the budget existed**
+(`20260908T200256Z`): `Ling-3.0-tiny`, 120/136 (88.2%). Not comparable with
+the current table because nothing bounded a generation then; the same model
+under the 180 s budget scored 116/136 with six cases exhausting the cap,
+which is the difference the budget makes rather than a regression.
 
-Paired over identical retrieved fragments, **21 of 23 cases gave the same
-verdict under all three models**. Only two discriminated:
+### The MoE argument, and what it actually rests on
 
-| Case | `gemma4:e2b` | `gemma4:e4b` | `qwen3-coder-30b` |
-|---|---|---|---|
-| `dpo-model-scale` | PASS | fail | PASS |
-| `planck-h0` | fail | fail | **PASS** |
+Earlier versions of this file argued at length that compact MoE models
+outperform dense models on 8 GB, citing bandwidth per token and zero
+offloading. The mechanism is sound and the second half is now directly
+observed -- `qwen3:8b` at 5.2 GB never reached the GPU and decoded at 35.8
+tok/s, against 95-213 for models that fit.
 
-Two more (`planck-h0-tension`, `planck-sigma8-es`) fail under all three, which
-makes them system failures rather than model failures.
-
-The practical reading: **the generator is not where the remaining failures
-are**, and a 30B MoE that does not fit in 8 GB costs about 2 s per case more
-than a 2B that does. Full analysis in issue #134.
-
----
-
-## Why compact MoE models outperform dense models on consumer hardware (8 GB VRAM)
-
-Empirical evaluations across the 83 gold cases show that compact Mixture-of-Experts (MoE) architectures (e.g. `Ling-3.0-tiny`, `Granite-4.0-H-Tiny`) substantially outperform dense models of comparable or larger sizes (e.g. `gemma4:e4b`, `Llama-3.2-3B`) in both accuracy and latency:
-
-1. **Decoupling Parameter Capacity from FLOPs and Memory Bandwidth per Token**:
-   - A dense model activates all weights for every decoded token. On an 8 GB consumer GPU (such as an RTX 4060 with a 128-bit bus, ~272 GB/s VRAM bandwidth), streaming a dense 8B model requires reading ~5–8 GB of weights per token, capping decoding throughput at ~30–45 tok/s.
-   - A compact MoE (e.g. `Ling-3.0-tiny`: 7.9B total, 1.3B active) retains the representational knowledge of a ~8B model, but only routes to and reads ~1.3B parameters per token. This reduces memory bandwidth load by ~4× to 5×, driving decoding throughput to **109–117 tokens/s**.
-2. **Zero Offloading to System RAM**:
-   - Dense models of 8B–14B at FP16/Q8 or even Q4 frequently collide with the 8 GB VRAM ceiling once KV cache and 16k context are allocated, forcing Ollama into partial CPU offloading (as observed with `gpt-oss:20b` at 60% CPU offload and 21 s/answer).
-   - Compact MoEs quantized to MXFP4/Q4 fit entirely (100%) in GPU VRAM (4.2–4.9 GB), leaving ample headroom for embeddings and KV caches with zero host-to-device bus penalties.
-3. **Specialization in RAG and Cross-Lingual Tasks**:
-   - In multimodal and multilang RAG (English, Spanish, Valencian), distinct expert routing handles syntax, factual grounding, and structured JSON formatting without the catastrophic forgetting or capacity bottlenecks that constrain dense 2B–3B models.
+The accuracy half is not supported by the current table. The two best
+measured models are `gemma4:e2b` and `qwen3:8b`, and the worst two
+(`Phi-mini-MoE`, `OLMoE`) are both compact MoE. Architecture is not what
+separates the top of this table from the bottom.
 
 ---
 
@@ -136,59 +198,20 @@ version:
 | 2026-09-01 | MinerU 3.4.5 | 26 / 32 |
 
 Three flips: one recovered (`dpo-pipeline-figure-es`), two lost
-(`dpo-model-scale`, `planck-h0`). The measured noise floor of this gate is
-**zero flips**, so three is not noise.
+(`dpo-model-scale`, `planck-h0`). The measured noise floor of that gate was
+zero flips, so three was not noise.
 
 One honest qualification, added after the three-model comparison: both "lost"
-cases are among the two that discriminate between generators, so they sit near
-a decision boundary. The drift is real; attributing those two specifically to
-MinerU's version is not supportable. See issue #107.
+cases are among the two that discriminate between generators, so they sit
+near a decision boundary. The drift is real; attributing those two
+specifically to MinerU's version is not supportable. See issue #107. Both
+figures are on the retired 32-case set.
 
 ---
 
 ## Hardware these numbers came from
 
-RTX 4060 Laptop, 8 GB (7.6 GiB usable), Ryzen 9 8945HS, 30 GB RAM. Every run
-above used `OLLAMA_KEEP_ALIVE=0`, which was required to fit the pipeline on
-this card before #143 and changes timing — a run made that way is not
-comparable with ledger history that was not.
-
----
-
-## How to add a row
-
-Run the gate, then read the artifact rather than the terminal:
-
-```bash
-python tests/eval/run_eval.py --models <model> [<model>...]
-```
-
-Then let the tool read the artifact and print the row:
-
-```bash
-python tools/diagnostics/model_history_row.py tests/eval/runs/<artifact>.json
-```
-
-> [!IMPORTANT]
-> **The denominator changed on 2026-09-08.** Runs up to and including
-> `20260908T130135Z` scored 63 answered cases out of an 83-case gold set,
-> built from 6 English papers plus the blind set. From `20260908T200256Z` on
-> it is 136 answered out of 156, over three corpora of 17 documents each --
-> the es and ca stores had never been evaluated at all. Percentages either
-> side of that line are not comparable, and a drop across it is a bigger,
-> harder set rather than a regression. The gate floor moved with it, 0.90 to
-> 0.82, which is the only time in this file's history it has gone down:
-> `--update-baseline` only ever raises, so this one was written by hand,
-> against a conclusive run (zero infrastructure errors) and using the value
-> the tool itself proposed.
-
-It reports the median of `tokens_per_second`, `eval_count` and their quotient
-per model, skipping records that lack the counts — a missing key means the
-model reported none, and treating it as zero drags the average toward "faster
-and cheaper" for a reason that is not real. When a model's medians come from
-fewer records than it answered, the row says so in the `tokens/answer` cell:
-three medians over two generations deserve less trust than over twenty-three,
-and a table that hides its denominator stops saying which it is.
-
-The median rather than the mean, because one runaway generation should not
-move a figure that goes into an append-only table.
+RTX 4060 Laptop, 8 GB (7.6 GiB usable), Ryzen 9 8945HS, 30 GB RAM. Recorded
+per run in the artifact's `conditions` block since #222; stated here because
+every row currently in the tables above came from this one machine, and the
+placement column only means anything against a known VRAM budget.

--- a/harness/README.md
+++ b/harness/README.md
@@ -161,21 +161,35 @@ fake evaluator that raises on a declared key makes startup fail loudly
 
 ## Sets
 
-- **Search set** (32 `source: corpus` cases) — the loop's objective.
-- **Blind set** (19 `source: arxiv` cases) — never requested. Structurally
-  unreachable: `evaluator.search_set_case_ids()`/`blind_set_case_ids()` both
-  filter `gold_cases.jsonl` by `source`, and every case-id list `loop.py`
-  ever hands an evaluator comes from one of those two functions or
-  `load_fast_tier()` (itself validated as a search-set subset) — never from
-  a proposer, which can only emit config overrides. Proven, not assumed:
-  `harness/tests/test_evaluator.py` asserts the blind set is disjoint from
-  both the search set and the fast tier.
-- **Fast tier** (13 fixed ids, `fast_tier.txt`) — regression filter only, it
-  **never declares an improvement**. Costs ~4 min at current measured rates
-  (8 answered cases × ~28.5 s + 5 retrieval-only × ~4.1 s), against a ~13 min
-  full search set — a real but much smaller saving than the design's ~32 min
-  estimate assumed (see the search-space note above); its job is rejecting a
-  bad candidate before it can contaminate the ratchet, not the minutes it
+- **Search set** (123 cases, `source != "arxiv"`) -- the loop's objective.
+  Not a whitelist of `source == "corpus"`: `evaluator.search_set_case_ids()`
+  returns the *complement* of the blind set, because the product grew from
+  one evaluated corpus to three (`corpus`, `corpus_es`, `corpus_ca`) and a
+  whitelist would have quietly dropped two thirds of the objective while
+  still looking like it partitioned everything (see the function's own
+  docstring; issue #225). Counted directly from `gold_cases.jsonl`: 75
+  `corpus` + 24 `corpus_es` + 24 `corpus_ca` = 123 -- a count, not a target;
+  recount it (a `Counter` over the `source` field) rather than trust this
+  number if the file has grown since.
+- **Blind set** (33 `source: arxiv` cases, also counted directly from
+  `gold_cases.jsonl`) -- never requested.
+  Structurally unreachable: `evaluator.search_set_case_ids()`/
+  `blind_set_case_ids()` both filter `gold_cases.jsonl` by `source`, and
+  every case-id list `loop.py` ever hands an evaluator comes from one of
+  those two functions or `load_fast_tier()` (itself validated as a
+  search-set subset) -- never from a proposer, which can only emit config
+  overrides. Proven, not assumed: `harness/tests/test_evaluator.py` asserts
+  the blind set is disjoint from both the search set and the fast tier.
+- **Fast tier** (16 fixed ids, `fast_tier.txt`) -- regression filter only, it
+  **never declares an improvement**. 13 of the 16 (8 answered + 5
+  retrieval-only) cost ~4 min at current measured rates (8 × ~28.5 s + 5 ×
+  ~4.1 s); the remaining three are study-artifact cases (issue #140) with
+  no per-case timing measured yet, so they are not priced into that total
+  (issue #226 -- see the file's own header for the full accounting). The
+  ~13 min comparison against a full search-set run this bullet used to make
+  is gone: that run measured the pre-#213 32-case search set, not today's
+  123, and nobody has re-timed a full run since. Its job is rejecting a bad
+  candidate before it can contaminate the ratchet, not the minutes it
   happens to save. Includes all 5 of today's known search-set failures
   (three figure-retrieval failures cost ~4 s each, nearly free to include,
   and give the regression filter real signal on the retrieval side).
@@ -244,18 +258,35 @@ the 32-case search set: still 0 flips. A delta of 0 is not an improvement
 
 ## Resolution warning
 
-The search set can win at most **5** cases today (27/32 pass on the
-reference run) — below the **~6 net flips** the design doc sets as the
-threshold for a paired difference not attributable to chance. Restricting
-the same paired comparison to the known-catastrophic sabotage used for
-criterion 2 (`RAG_TOP_K_FINAL=1`) gives only **3 net flips** on the search
-set, versus 7 on the full 51-case gate — the loop's own objective set is
-under-powered against the most destructive single-field change anyone has
-measured, not merely against subtle ones. Every `run_loop` report carries
-this as `resolution_warning`, so an accepted improvement on today's corpus
-reads as a candidate for confirmation, not a demonstrated result. This is
-the quantitative case for block B (#30, corpus expansion) — sharper than the
-design doc's own estimate — not a reason to withhold the harness.
+Stale in exactly the way `evaluator.search_set_case_ids()`'s own docstring
+warns about (issue #225): every number below was measured against the
+32-case search set that existed before #213 (the corpus expansion, block B
+of issue #30) grew it to 123 (see Sets above), and nobody has re-run either
+measurement against the current set.
+
+The **~6 net flips** the design doc (§3) sets as the threshold for a paired
+difference not attributable to chance is a fixed methodological constant,
+not derived from search-set size, so it does not by itself need
+re-measuring. What does: **"the search set can win at most 5 cases" (27/32
+pass on the 2026-08-19 reference run)** is a capacity claim that scales with
+the search set's size, and **"3 net flips under `RAG_TOP_K_FINAL=1`"**
+(criterion 2's known-catastrophic sabotage, versus 7 on the old 51-case
+gate) is a paired comparison that only means something re-run on the cases
+it is meant to describe. Both are hardcoded in `harness/loop.py`'s
+`RESOLUTION_WARNING` dict (`SEARCH_SET_AVAILABLE_FAILURES`,
+`SEARCH_SET_NET_FLIPS_UNDER_KNOWN_SABOTAGE`) and attached verbatim, via
+`message`, to every real campaign's `resolution_warning` -- so a report run
+today still describes a search set a quarter the size of the one the code
+actually evaluates against.
+
+Recomputing them for real needs two things nobody has measured yet, not an
+estimate: a reference evaluation over all 123 search-set cases (to count
+today's failures) and a paired comparison against a `RAG_TOP_K_FINAL=1`
+candidate over the same 123 (to count net flips). Until one of those runs
+exists, the honest statement is that the search set has roughly quadrupled
+since these figures were produced, and whether that changes the resolution
+picture for better or worse is not yet known -- not that it is still "5
+cases" and "3 net flips" today.
 
 > [!NOTE]
 > All of the numbers above come from four local, gitignored artifacts

--- a/harness/RUNBOOK.md
+++ b/harness/RUNBOOK.md
@@ -146,15 +146,22 @@ nvidia-smi --query-compute-apps=pid,used_memory --format=csv
 
 > [!TIP]
 > **A campaign fits on 8 GB even though a full gate run does not.** The
-> harness only ever asks for search-set ids (`source: corpus`), and
-> `evaluate()` builds a corpus's stack only when the filtered case list
-> needs it -- so a campaign builds one embedder where a full `run_eval.py`
-> builds two, and two do not fit (#123). Measured: 32 cases, zero
-> `infrastructure_error`, ~6.6 of 7.6 GiB resident.
+> harness only ever asks for search-set ids (the complement of the blind
+> set, `source != "arxiv"` -- see `harness/README.md`'s Sets section, issue
+> #225), and `evaluate()` builds a corpus's stack only when the filtered
+> case list needs it -- so a campaign builds one embedder where a full
+> `run_eval.py` builds two, and two do not fit (#123). Measured 2026-09-01:
+> 32 cases, zero `infrastructure_error`, ~6.6 of 7.6 GiB resident -- the
+> search set has since grown to 123 cases (#213) and this headroom has not
+> been re-measured at that size.
 >
 > **The gate does fit here too, with `OLLAMA_KEEP_ALIVE=0`.** Measured
 > 2026-09-08 on the 4060 8 GB: all 83 gold cases, both corpora, 79/83 (95.2%)
-> in 20.0 minutes with zero `infrastructure_error`. This section previously
+> in 20.0 minutes with zero `infrastructure_error`. `gold_cases.jsonl` grew
+> to 156 cases over four sources via #213 (2026-09-08; see
+> `tests/eval/README.md`'s Corpus section for the current count) -- this
+> capacity claim describes the 83-case, two-corpus gate that existed just
+> before that change, not the full gate as it runs today. This section previously
 > said "on a card this size you can run the loop but not the gate", which was
 > written from the 2026-09-01 run that had no keep-alive set; with it, the
 > second embedder starts. #123 is still the reason the workaround is needed at
@@ -251,7 +258,7 @@ as universal is how someone budgets a night for something that takes seven.
 | retrieval-only case | ~4.1 s | **~30 s** |
 | answered case | ~28.5 s | ~9-11 s |
 | full search-set evaluation | ~20 min | ~25 min (phase 1 dominates) |
-| fast tier (13 cases) | ~4 min | not measured here |
+| fast tier (16 cases) | ~4 min for 13 of them (unmeasured for the 3 study-artifact cases, issue #226) | not measured here |
 
 The 4060 figures are from a run with `OLLAMA_KEEP_ALIVE=0` (which the warning
 above now restricts to gate runs -- a campaign measured without it answers
@@ -322,12 +329,16 @@ red test.
 State these when reporting a campaign; they are not disclaimers, they are the
 measurement's actual resolution.
 
-- **The search set can win at most 5 cases**, and it registered only 3 net
-  flips under a known-catastrophic sabotage — below the ~6 flips the design
-  sets as the threshold for a difference not attributable to chance. An
-  accepted improvement on today's corpus is **a candidate for confirmation,
-  not a demonstrated result**. This is issue #30, the binding constraint on
-  the whole loop, and every report carries it as `resolution_warning`.
+- **The search-set win-margin and sabotage-flip numbers are stale.** "At
+  most 5 cases" and "3 net flips" were measured on the 32-case search set
+  that existed before #213 (block B, issue #30) grew it to 123 -- see
+  `harness/README.md`'s Resolution warning section (issue #225) for the
+  full account and what re-measuring them for real needs. `harness/loop.py`
+  still hardcodes those numbers into every report's `resolution_warning`,
+  so an accepted improvement on today's corpus still reads as **a candidate
+  for confirmation, not a demonstrated result** -- that conclusion holds
+  regardless; the specific numbers behind it just don't describe today's
+  search set yet.
 - **Index-time knobs are still not searched, but the tier is now costed.**
   Chunking and the index-time flags force a full reindex, which no budget
   survives inside a search loop. Declaring one in `SEARCH_SPACE` is still a red
@@ -336,7 +347,9 @@ measurement's actual resolution.
   share one rebuild — and a campaign is priced in fast-tier evaluations, the
   unit the patience budget is already spent in. It measures nothing itself; the
   reindex and evaluation seconds come from a real run. Whether such a candidate
-  can pay off at all is still block B's question (#30).
+  can pay off at all is still block B's question (#30) -- #213 grew the search
+  set, but the resolution warning above has not been re-measured against it,
+  so the answer still isn't in.
 - **Stage 1 is a single-field sweep from a fixed reference**, not a
   compounding hill climb. Two accepted single-field changes cannot combine
   within a run.

--- a/harness/cli.py
+++ b/harness/cli.py
@@ -19,9 +19,9 @@ feasibility, ledger, latency constraint, termination -- can be exercised
 with no GPU, no Ollama and no PDFs, writing its ledger to a fresh temporary
 directory unless ``--ledger-dir`` is given (so a demo run never litters
 ``harness/ledger/``). Without it, the CLI uses the real evaluator
-(``evaluator.real_evaluate``), which depends on the sibling PR (issue #31
-spec section 5.2, #56) landing ``tests/eval/run_eval.evaluate()`` -- it
-fails with an actionable message, not a stack trace, until that lands.
+(``evaluator.real_evaluate``, issue #31 spec section 5.2), which runs the
+actual gate through ``tests/eval/run_eval.evaluate()`` -- GPU, Ollama and
+every model role this run needs.
 """
 
 from __future__ import annotations

--- a/harness/evaluator.py
+++ b/harness/evaluator.py
@@ -101,11 +101,13 @@ class EvaluationResult:
             evaluation actually ran with (reference config plus the expanded
             overrides) -- kept alongside the raw ``config_overrides`` deltas
             in the ledger so a default changing later cannot silently change
-            what an old entry meant (issue #31 spec section 5.3).
+            what an old entry meant (issue #31 spec section 5.3). ``None``
+            only for ``real_evaluate()``'s empty-``case_ids`` reachability
+            probe, which stages no corpus at all.
     """
 
     records: Tuple[CaseRecord, ...]
-    effective_config: Dict[str, Any]
+    effective_config: Optional[Dict[str, Any]]
 
 
 EvaluatorFn = Callable[[Mapping[str, Any], Sequence[str]], EvaluationResult]
@@ -375,7 +377,7 @@ def verify_reachable(evaluate: EvaluatorFn, probe_case_ids: Sequence[str] = ()) 
         ) from exc
 
 
-# REAL EVALUATOR (depends on sibling PR #56)
+# REAL EVALUATOR
 
 
 def _run_eval_module():
@@ -385,6 +387,23 @@ def _run_eval_module():
     ``import run_eval`` convention, so this is the one place harness/ reaches
     into tests/eval/ from, and every caller resolves to the same module
     object.
+
+    Deliberately a function-scoped import, not a module-level one, for two
+    still-live reasons (the original one -- waiting on the sibling PR #56 to
+    land ``run_eval.evaluate()`` -- ended when #56 merged):
+
+    - ``harness/tests/`` imports ``harness.evaluator`` in CI with no engine
+      dependencies installed. ``run_eval.py`` itself only needs the standard
+      library plus ``grade`` at its own module level (see this module's
+      docstring), so that alone would not force laziness -- but it means
+      importing ``harness.evaluator`` cannot regress this by growing a heavier
+      module-level dependency without anyone noticing here.
+    - ``harness/tests/test_evaluator.py`` replaces ``sys.modules["run_eval"]``
+      with a stub per test to exercise this function without the real
+      pipeline. A module-level ``import run_eval`` would bind the real module
+      the first time anything imports ``harness.evaluator`` -- before any
+      test's ``monkeypatch.setitem`` runs -- and the stub would never take
+      effect.
     """
     if str(EVAL_DIR) not in sys.path:
         sys.path.insert(0, str(EVAL_DIR))
@@ -393,23 +412,95 @@ def _run_eval_module():
     return run_eval
 
 
+# Every AppConfig section except ``paths`` (issue #230). ``paths`` is the one
+# section that names which corpus a config came from -- ``docs_folder``
+# identifies it, ``path_db``/``collection_name`` are derived from it via
+# ``derive_db_paths`` -- so it is the one section legitimately different
+# between two corpora ``real_evaluate()`` staged in the same call (measured:
+# today that is exactly ``docs_folder``, ``path_db`` and ``collection_name``,
+# nothing else). Every other section is built the same way regardless of
+# which corpus ``_eval_app_config`` indexes -- straight from
+# ``rag.chat_pdfs``'s module globals and this call's ``config_overrides`` --
+# so two corpora disagreeing on any of them is not a legitimate difference.
+# See ``_select_effective_config``.
+_CORPUS_INVARIANT_SECTIONS: Tuple[str, ...] = ("models", "chunking", "retrieval", "reranking", "context", "flags")
+
+
+class ConfigDivergenceError(RuntimeError):
+    """Raised when two corpora evaluated in one call disagree outside ``paths``.
+
+    ``real_evaluate()`` used to assume the harness only ever asked for
+    ``source: corpus`` cases and could record ``raw["config"]["dev"]``
+    unconditionally. That premise ended when ``search_set_case_ids()`` became
+    the complement of the blind set (issue #230): a campaign now requests all
+    three product corpora, and ``run_eval.evaluate()`` returns one config per
+    corpus it staged. Rather than pick one arbitrarily, ``_select_effective_config``
+    proves the thing that makes picking one safe -- that every corpus this
+    call touched agrees with the others on everything but ``paths`` -- and
+    raises this instead of silently recording a configuration that only
+    described a fraction of what ran.
+    """
+
+
+def _select_effective_config(
+    config_by_corpus: Mapping[str, Optional[Mapping[str, Any]]],
+) -> Optional[Dict[str, Any]]:
+    """Pick one corpus's config, after proving it speaks for every corpus evaluated.
+
+    ``EvaluationResult.effective_config`` is consumed everywhere (the ledger,
+    ``loop._comparable_config_view``, every harness test that builds one) as
+    a single flat ``AppConfig``-shaped dict, one corpus's worth -- not a dict
+    per corpus. This does not change that shape; it changes what justifies
+    handing back just one of them: every present, non-blind corpus must agree
+    with the others on every section but ``paths`` (``_CORPUS_INVARIANT_SECTIONS``).
+
+    Args:
+        config_by_corpus: ``raw["config"]`` from ``run_eval.evaluate()`` --
+            one entry per corpus key (``"dev"``, ``"blind"``, ``"corpus_es"``,
+            ``"corpus_ca"``), ``None`` for a corpus this call's ``case_ids``
+            never touched. ``"blind"`` is always ignored: the harness never
+            requests blind-set case ids (``search_set_case_ids()``), so it is
+            always ``None``/absent here in practice.
+
+    Returns:
+        The first present, non-blind corpus's config dict. ``None`` when
+        ``case_ids`` touched no corpus at all -- the empty-tuple reachability
+        probe (``verify_reachable``'s ``probe_case_ids`` defaults to
+        ``()``), which stages nothing to disagree about.
+
+    Raises:
+        ConfigDivergenceError: Two present corpora disagree on a section
+            outside ``paths``.
+    """
+    present = [(corpus, cfg) for corpus, cfg in config_by_corpus.items() if corpus != "blind" and cfg]
+    if not present:
+        return None
+    base_corpus, base_config = present[0]
+    for corpus, config in present[1:]:
+        for section in _CORPUS_INVARIANT_SECTIONS:
+            if config.get(section) != base_config.get(section):
+                raise ConfigDivergenceError(
+                    f"corpus {corpus!r} and {base_corpus!r} disagree on config.{section}, which "
+                    "should be identical across every corpus one real_evaluate() call indexes: "
+                    f"{config.get(section)!r} != {base_config.get(section)!r}"
+                )
+    return base_config
+
+
 def real_evaluate(config_overrides: Mapping[str, Any], case_ids: Sequence[str]) -> EvaluationResult:
     """Adapt ``tests/eval/run_eval.evaluate()`` (issue #31 spec section 5.2) to ``EvaluatorFn``.
 
-    Return shape confirmed against #56's actual contract (not the spec
-    sketch): ``{"records": [...], "config": {"dev": <AppConfig-as-dict>,
-    "blind": <...>}, ...}`` -- ``"results"``/``"effective_config"`` from an
-    earlier draft of this function do not exist on that dict and would raise
-    ``KeyError`` on the first real call. This harness only ever requests
-    ``source: corpus`` (dev-corpus) case ids -- see ``search_set_case_ids``/
-    ``load_fast_tier`` -- so ``config["dev"]`` is always the config this
-    evaluation actually ran with; ``config["blind"]`` is never read here.
-
-    TODO: depends on the sibling PR (#56) landing ``run_eval.evaluate()`` on
-    main. Guarded rather than imported at module level so importing
-    ``harness.evaluator`` (which ``harness/tests/`` does, in CI, with no
-    engine dependencies installed) never fails on this function's account --
-    only *calling* it before #56 lands does, with a message that says why.
+    Return shape confirmed against the real contract: ``{"records": [...],
+    "config": {"dev": <AppConfig-as-dict-or-None>, "blind": <...>,
+    "corpus_es": <...>, "corpus_ca": <...>}}`` -- the last two keys are only
+    present when this call's ``case_ids`` touched that corpus (``run_eval.py``'s
+    ``EXTRA_DEV_CORPORA``). ``search_set_case_ids()`` is the complement of the
+    blind set (issue #230), so a campaign requests cases from all three
+    product corpora and one call can return up to three non-blind configs.
+    ``_select_effective_config`` picks one to record -- but only after proving
+    every present corpus agrees with it outside ``paths``; see that function
+    and ``ConfigDivergenceError``. ``config["blind"]`` is never read here --
+    the harness never requests blind-set case ids.
 
     Args:
         config_overrides: Dotted-key overrides, as a proposer emits them
@@ -421,15 +512,10 @@ def real_evaluate(config_overrides: Mapping[str, Any], case_ids: Sequence[str]) 
         The adapted ``EvaluationResult``.
 
     Raises:
-        NotImplementedError: ``run_eval.py`` has no ``evaluate()`` yet.
+        ConfigDivergenceError: Two corpora this call evaluated disagree on a
+            config field outside ``paths``.
     """
     run_eval = _run_eval_module()
-    if not hasattr(run_eval, "evaluate"):
-        raise NotImplementedError(
-            "tests/eval/run_eval.py has no evaluate() yet -- the real evaluator "
-            "depends on the sibling PR (issue #31 spec section 5.2, #56). Use "
-            "evaluator.build_demo_evaluator() to exercise the harness without it."
-        )
     raw = run_eval.evaluate(
         models=run_eval.DEFAULT_MODELS,
         case_ids=tuple(case_ids),
@@ -450,7 +536,7 @@ def real_evaluate(config_overrides: Mapping[str, Any], case_ids: Sequence[str]) 
         )
         for r in raw["records"]
     )
-    return EvaluationResult(records=records, effective_config=raw["config"]["dev"])
+    return EvaluationResult(records=records, effective_config=_select_effective_config(raw["config"]))
 
 
 # DEMO EVALUATOR (no GPU, no Ollama -- harness/cli.py --dry-run)

--- a/harness/fast_tier.txt
+++ b/harness/fast_tier.txt
@@ -1,5 +1,5 @@
 # Fast tier -- regression filter only (never declares an improvement).
-# Fixed, versioned subset of the search set: 13 cases spanning every
+# Fixed, versioned subset of the search set: 16 cases spanning every
 # case_type and every paper.
 #
 # Its job is not to save minutes -- it is to reject a bad candidate without
@@ -20,8 +20,16 @@
 # generator the keep-alive fix affects):
 #   8 answered cases  x ~28.5s = ~228s
 #   5 retrieval-only  x ~4.1s  =  ~21s
-#   total ~249s ~= 4 min, against a ~13 min full search set (32 cases) --
-#   still worth running first, just not for the reason originally assumed.
+#   total ~249s ~= 4 min for these 13 cases -- still worth running first,
+#   just not for the reason originally assumed. The three study-artifact
+#   cases below (issue #140) are not priced into that total: no per-case
+#   timing exists for study_summary/study_outline/study_quiz, so say that
+#   instead of guessing -- the tier's real cost is ~249s plus an unmeasured
+#   amount for three full-document generations (see the note below).
+#   The ~13 min full-search-set comparison this line used to make is gone
+#   for the same reason harness/README.md's Sets section was rewritten
+#   (issue #225): it measured a 32-case search set that #213 grew to 123
+#   cases, and nobody has re-timed a full run since.
 #
 # Includes all 5 of today's known search-set failures (dpo-pipeline-figure-es,
 # higgs-diphoton-figure, planck-contours-figure, planck-sigma8-es,

--- a/harness/tests/test_evaluator.py
+++ b/harness/tests/test_evaluator.py
@@ -2,6 +2,7 @@
 plus the objective/latency helpers those tests and loop.py both rely on.
 """
 
+import re
 import sys
 import types
 from pathlib import Path
@@ -85,6 +86,19 @@ def test_fast_tier_covers_every_case_type_in_the_search_set():
 def test_fast_tier_has_no_duplicate_ids():
     fast = ev.load_fast_tier()
     assert len(fast) == len(set(fast))
+
+
+def test_fast_tier_header_count_matches_the_ids_it_lists():
+    # Issue #226: #140 added three study-artifact ids without updating the
+    # "N cases" the header opens with, and the header stayed wrong (13,
+    # really 16) until someone counted by hand. Parsing the number back out
+    # of the header and comparing it to what load_fast_tier() actually
+    # returns is what makes that drift loud instead of silent.
+    header = ev.FAST_TIER_FILE.read_text(encoding="utf-8")
+    match = re.search(r"subset of the search set:\s*(\d+)\s*cases", header)
+    assert match, "fast_tier.txt header no longer states a case count this test can parse"
+    declared = int(match.group(1))
+    assert declared == len(ev.load_fast_tier())
 
 
 # UNREACHABLE CASES -- starts empty (see harness/unreachable_cases.txt header).

--- a/harness/tests/test_evaluator.py
+++ b/harness/tests/test_evaluator.py
@@ -200,16 +200,24 @@ def test_every_declared_search_space_key_is_honoured_by_the_real_evaluate_contra
 
 
 # real_evaluate() -- HIGH 1 regression (#65 PR review): mapped raw["results"]/
-# raw.get("effective_config") from an earlier sketch of #56's API. The
-# actual contract #56 returns is {"records": [...], "config": {"dev": ...,
-# "blind": ...}}; the old mapping raised KeyError on the very first real
-# call. A stub `run_eval` module carrying the real shape is injected into
-# sys.modules so this is exercised without landing #56 or touching Ollama
-# (this round's constraint: no GPU/Ollama -- the full eval gate owns the card).
+# raw.get("effective_config") from an earlier sketch of the run_eval.evaluate()
+# API. The actual contract it returns is {"records": [...], "config":
+# {"dev": ..., "blind": ...}}; the old mapping raised KeyError on the very
+# first real call. A stub `run_eval` module carrying the real shape is
+# injected into sys.modules so this is exercised without touching Ollama or
+# a real corpus (no GPU/Ollama in this environment -- the full eval gate owns
+# the card).
 
 
-def _fake_run_eval_module(records, config_dev, seen=None):
-    """A stub `run_eval` module whose evaluate() carries #56's real return shape."""
+def _fake_run_eval_module(records, config_dev, seen=None, extra_config=None):
+    """A stub `run_eval` module whose evaluate() carries the real return shape.
+
+    Args:
+        extra_config: Extra non-dev, non-blind entries for ``config`` (e.g.
+            ``{"corpus_es": {...}}``) -- issue #230's ``real_evaluate()`` must
+            pick among every present corpus, not assume ``"dev"`` is the only
+            one a call can return.
+    """
     module = types.ModuleType("run_eval")
     module.DEFAULT_MODELS = ["gemma4:e2b"]
 
@@ -217,7 +225,9 @@ def _fake_run_eval_module(records, config_dev, seen=None):
         del models, case_ids, config_overrides, update_baseline
         if seen is not None:
             seen["write_report"] = write_report
-        return {"records": records, "config": {"dev": config_dev, "blind": {}}}
+        config = {"dev": config_dev, "blind": {}}
+        config.update(extra_config or {})
+        return {"records": records, "config": config}
 
     module.evaluate = evaluate
     return module
@@ -248,12 +258,101 @@ def test_real_evaluate_maps_the_actual_56_contract(monkeypatch):
     assert seen["write_report"] is False
 
 
-def test_real_evaluate_raises_not_implemented_without_an_evaluate_function(monkeypatch):
-    stub = types.ModuleType("run_eval")  # no .evaluate attribute -- matches pre-#56 main
-    monkeypatch.setitem(sys.modules, "run_eval", stub)
+# _select_effective_config -- issue #230: search_set_case_ids() is now the
+# complement of the blind set, so a campaign requests corpus/corpus_es/
+# corpus_ca cases in one call and evaluate() can return a config per corpus.
+# real_evaluate() used to record raw["config"]["dev"] unconditionally, which
+# would silently describe only a fraction of a multi-corpus run. These pin
+# the replacement: pick one corpus's config only after proving every present
+# corpus agrees with it on everything but paths (docs_folder/path_db/
+# collection_name -- the fields that legitimately name which corpus a config
+# came from), and raise loudly the moment that stops being true.
 
-    with pytest.raises(NotImplementedError):
-        ev.real_evaluate({}, ())
+
+def test_real_evaluate_accepts_agreeing_multi_corpus_configs(monkeypatch):
+    """Corpora that agree on everything but paths -- true today, per the
+    issue's own measurement -- must not raise, and dev (first in raw["config"])
+    is what gets recorded."""
+    records = [
+        {"id": "a", "case_type": "factual_number", "passed": True, "elapsed_seconds": 1.0},
+        {"id": "b", "case_type": "factual_number", "passed": True, "elapsed_seconds": 1.0},
+    ]
+    config_dev = {
+        "retrieval": {"top_k_final": 8},
+        "paths": {"docs_folder": "rag/docs/en", "collection_name": "docs_dev_docs"},
+    }
+    config_es = {
+        "retrieval": {"top_k_final": 8},
+        "paths": {"docs_folder": "rag/docs/es", "collection_name": "docs_dev_docs_es"},
+    }
+    monkeypatch.setitem(
+        sys.modules, "run_eval",
+        _fake_run_eval_module(records, config_dev, extra_config={"corpus_es": config_es}),
+    )
+
+    result = ev.real_evaluate({}, ("a", "b"))
+
+    assert result.effective_config == config_dev
+
+
+def test_real_evaluate_raises_when_a_second_corpus_diverges_on_a_searched_parameter(monkeypatch):
+    """Demonstration case for issue #230's closure criterion: two corpora
+    disagreeing on retrieval.top_k_final -- a field harness/search_space.py
+    declares in SEARCH_SPACE, i.e. one the harness actually searches over --
+    must fail loudly instead of silently recording whichever corpus
+    real_evaluate() happened to pick."""
+    records = [{"id": "a", "case_type": "factual_number", "passed": True, "elapsed_seconds": 1.0}]
+    config_dev = {"retrieval": {"top_k_final": 8}, "paths": {"docs_folder": "rag/docs/en"}}
+    config_es = {"retrieval": {"top_k_final": 4}, "paths": {"docs_folder": "rag/docs/es"}}
+    monkeypatch.setitem(
+        sys.modules, "run_eval",
+        _fake_run_eval_module(records, config_dev, extra_config={"corpus_es": config_es}),
+    )
+
+    with pytest.raises(ev.ConfigDivergenceError, match="retrieval"):
+        ev.real_evaluate({}, ("a",))
+
+
+def test_real_evaluate_ignores_the_blind_config_when_selecting(monkeypatch):
+    """config["blind"] is never requested by the harness (search_set_case_ids
+    is the blind set's complement) and must never be compared against -- a
+    real run leaves it populated with whatever the blind-set run produced,
+    unrelated to what corpus/corpus_es/corpus_ca ran under."""
+    records = [{"id": "a", "case_type": "factual_number", "passed": True, "elapsed_seconds": 1.0}]
+    config_dev = {"retrieval": {"top_k_final": 8}}
+    module = types.ModuleType("run_eval")
+    module.DEFAULT_MODELS = ["gemma4:e2b"]
+
+    def evaluate(**kwargs):
+        del kwargs
+        return {"records": records, "config": {"dev": config_dev, "blind": {"retrieval": {"top_k_final": 999}}}}
+
+    module.evaluate = evaluate
+    monkeypatch.setitem(sys.modules, "run_eval", module)
+
+    result = ev.real_evaluate({}, ("a",))
+
+    assert result.effective_config == config_dev
+
+
+def test_real_evaluate_returns_none_for_the_empty_case_ids_reachability_probe(monkeypatch):
+    """verify_reachable's probe_case_ids defaults to () (evaluator.py's own
+    docstring), and evaluate() then stages no corpus at all (run_eval.py's
+    own empty-case_ids early return) -- nothing to pick a config from, so
+    this must not raise ConfigDivergenceError against an empty set."""
+    module = types.ModuleType("run_eval")
+    module.DEFAULT_MODELS = ["gemma4:e2b"]
+
+    def evaluate(**kwargs):
+        del kwargs
+        return {"records": [], "config": {"dev": None, "blind": None}}
+
+    module.evaluate = evaluate
+    monkeypatch.setitem(sys.modules, "run_eval", module)
+
+    result = ev.real_evaluate({}, ())
+
+    assert result.effective_config is None
 
 
 # CRITERION 7 -- reconstruct-and-rerun pass vector.

--- a/rag/README.md
+++ b/rag/README.md
@@ -40,6 +40,13 @@ caller its docstring points at. `release_embedder()` frees that worker after
 an indexing run that failed, where it would otherwise sit on ~1.7 GiB that
 the next attempt needs.
 
+The Cross-Encoder reranker is cached the same way, and `release_reranker()`
+drops its GPU weights on demand -- called from `/api/settings` when the
+reranker flag is turned off, since nothing will use it again until it is
+turned back on. It is deliberately not called on the per-query retrieval
+path itself: `wiring.rag_chat_model()`'s docstring has the measurement that
+decision rests on.
+
 [`engine/settings.py`](engine/settings.py) owns the other half of that
 agreement: the model roles, active store and pipeline flags the web control
 panel saves are read at startup so the session reopens under the user's

--- a/rag/chat_pdfs.py
+++ b/rag/chat_pdfs.py
@@ -176,6 +176,21 @@ PIPELINE_RUNTIME_FLAGS = (
     "USAR_RECOMP_SYNTHESIS",
 )
 
+# Every flag rag.engine.settings.PERSISTED_FLAGS can overwrite via
+# cargar_ajustes_persistidos(): PIPELINE_RUNTIME_FLAGS plus the three
+# index-time flags set_pipeline_flags deliberately refuses as overrides (its
+# own docstring above). Snapshotted at this module's own import time, before
+# rag/web/app.py's import-time cargar_ajustes_persistidos() call can apply
+# this machine's gitignored settings.json onto any of them (issue #231) --
+# restored by _restaurar_roles_y_flags_por_defecto for tests/conftest.py's
+# session fixture, the same idea _DEFAULT_CARPETA_DOCS below serves for
+# set_docs_folder_runtime.
+_DEFAULT_PIPELINE_FLAGS: Dict[str, bool] = {
+    name: globals()[name]
+    for name in PIPELINE_RUNTIME_FLAGS
+    + ("USAR_CONTEXTUAL_RETRIEVAL", "USAR_EMBEDDINGS_IMAGEN", "USAR_DESCRIPCION_IMAGEN")
+}
+
 
 def get_pipeline_flags() -> Dict[str, bool]:
     """Return the runtime-toggleable pipeline flags used during inference."""
@@ -327,6 +342,12 @@ MODEL_ROLE_VARS = {
     "recomp": "MODELO_RECOMP",
 }
 
+# Snapshotted at this module's own import time, before rag/web/app.py's
+# import-time cargar_ajustes_persistidos() call can apply this machine's
+# gitignored settings.json onto any of the four roles (issue #231) -- see
+# _DEFAULT_PIPELINE_FLAGS above for the same reasoning applied to the flags.
+_DEFAULT_MODEL_ROLES: Dict[str, str] = {role: globals()[var] for role, var in MODEL_ROLE_VARS.items()}
+
 # The variable that pins each role, mirroring the ``os.getenv`` calls that read
 # them above. A role listed here whose variable is set keeps its environment
 # value: persisted UI choices describe an earlier run, the environment describes
@@ -373,6 +394,31 @@ def set_model_roles_runtime(overrides: Dict[str, str]) -> Dict[str, str]:
     if (overrides.get("rag") or "").strip():
         MODELO_DESC = _inferir_descripcion_modelo(MODELO_RAG)
     return get_model_roles()
+
+
+def _restaurar_roles_y_flags_por_defecto() -> None:
+    """Reset model roles and pipeline flags to this module's import-time defaults.
+
+    Used only by tests/conftest.py's session fixture (issue #231). pytest
+    collection imports every test module before any test runs; a file that
+    imports rag.web.app at module level (e.g.
+    tests/test_web_indexing_releases_worker.py) triggers that module's own
+    top-level cargar_ajustes_persistidos() (rag/engine/settings.py), which
+    applies this machine's real, gitignored rag/settings.json onto
+    MODELO_RAG/MODELO_CHAT/MODELO_CONTEXTUAL/MODELO_RECOMP and every flag in
+    _DEFAULT_PIPELINE_FLAGS -- for the rest of the process, independent of
+    which test happens to run first. A test asserting one of these equals
+    its module default then depends on a file no other machine has (issue
+    #231's concrete case: USAR_RERANKER/USAR_BUSQUEDA_HIBRIDA/
+    USAR_LLM_QUERY_DECOMPOSITION only pass on a machine whose settings.json
+    happens to agree). set_docs_folder_runtime(None) already restores
+    CARPETA_DOCS/PATH_DB/COLLECTION_NAME this same way (issue #227); this is
+    the same idea for the two pieces of state that had no import-time
+    default to fall back to.
+    """
+    set_model_roles_runtime(dict(_DEFAULT_MODEL_ROLES))
+    for name, value in _DEFAULT_PIPELINE_FLAGS.items():
+        globals()[name] = value
 
 
 # SYSTEM PROMPTS

--- a/rag/chat_pdfs.py
+++ b/rag/chat_pdfs.py
@@ -554,6 +554,7 @@ from rag.engine.settings import (
 from rag.engine.wiring import (
     app_config_from_runtime,
     release_embedder,
+    release_reranker,
     reset_vector_store_cache,
     vector_store,
 )

--- a/rag/engine/wiring.py
+++ b/rag/engine/wiring.py
@@ -245,8 +245,18 @@ def rag_chat_model(config: AppConfig) -> OllamaChatModel:
     ``num_predict`` is unbounded because a truncated answer to a document
     question is indistinguishable from a wrong one.
 
-    The unloader is wired in here because this model runs last and needs the
-    VRAM the embedder and reranker were holding.
+    The unloader is wired in here because this model runs last, but it only
+    reaches other Ollama-served roles (query decomposer, RECOMP, contextual)
+    via keep_alive=0 -- it has no path to the embedder's worker process or
+    the reranker's in-process CUDA weights (issue #239), so neither is
+    implied to be free by the time this model loads. Both stay resident
+    across queries by design: #25's 2026-07-29 measurement found
+    embedder+reranker+a small Ollama model coexisting at 7514 of 8188 MiB
+    with 2-5s of contention, not the multi-minute stall once feared, so
+    reloading either on every query traded a measured, small cost for an
+    unmeasured one. ``release_embedder`` and ``release_reranker`` exist for
+    callers who know a reload is due anyway (a failed re-index; the reranker
+    flag being turned off) rather than for the per-query path itself.
     """
     ollama = config.models.ollama
     return OllamaChatModel(
@@ -362,10 +372,13 @@ def reranker(config: AppConfig) -> CrossEncoderReranker:
     megabytes of weights on first ``rerank()`` call, competing for the same
     GPU (#46).
 
-    Like ``embedder``, this slot is a singleton with no reset path today,
-    so the #57 read race does not apply -- see that function's docstring
-    for why, and for what adding an invalidation path here would require
-    instead of the tuple trick used by ``vector_store``/``lexical_index``.
+    Like ``embedder``, this slot is a singleton the #57 read race does not
+    apply to -- see that function's docstring for why, and for what adding
+    an invalidation path here would require instead of the tuple trick used
+    by ``vector_store``/``lexical_index``. Unlike ``embedder``,
+    ``release_reranker`` below drops the cached instance's weights without
+    discarding the singleton itself: ``CrossEncoderReranker.rerank()``
+    reloads lazily on next use, so there is no worker process to rebuild.
 
     Args:
         config: Current pipeline configuration.
@@ -379,6 +392,29 @@ def reranker(config: AppConfig) -> CrossEncoderReranker:
             if _reranker_cache["reranker"] is None:
                 _reranker_cache["reranker"] = CrossEncoderReranker()
     return _reranker_cache["reranker"]
+
+
+def release_reranker() -> None:
+    """Drop the cached reranker's GPU weights, keeping the singleton slot.
+
+    Issue #239: the reranker loads once and its weights stayed resident for
+    the rest of the process's life, since nothing ever called
+    ``CrossEncoderReranker.release()``. Not wired into the per-query
+    retrieval path itself -- see ``rag_chat_model``'s docstring for why that
+    would trade a measured, small VRAM-contention cost for an unmeasured
+    latency one on every question. Exists for callers who know the reranker
+    will not be needed again soon: today, that is ``/api/settings`` turning
+    ``USAR_RERANKER`` off (``rag/web/app.py``), where the alternative is
+    weights held for nothing until the flag is turned back on.
+
+    Safe to call before ``reranker()`` has ever built one (the cache slot is
+    still empty) and after weights are already released -- both leave
+    nothing to do.
+    """
+    with _reranker_cache_lock:
+        instance = _reranker_cache["reranker"]
+    if instance is not None:
+        instance.release()
 
 
 def answer(store: VectorStore, config: AppConfig) -> Answer:
@@ -570,6 +606,7 @@ __all__ = [
     "recomp_chat_model",
     "reranker",
     "release_embedder",
+    "release_reranker",
     "reset_vector_store_cache",
     "retrieval_metrics_to_legacy",
     "vector_store",

--- a/rag/engine/wiring.py
+++ b/rag/engine/wiring.py
@@ -52,6 +52,31 @@ _RUNTIME_OVERRIDES = {
     "flags.guardar_debug_rag": "GUARDAR_DEBUG_RAG",
 }
 
+# Sampling options per Ollama role, used verbatim by the three builders below.
+# Pulled out as module constants (issue #222) so the eval artifact can record
+# exactly what a run used instead of a second, hand-copied literal living in
+# tests/eval/run_eval.py.
+RAG_SAMPLING_OPTIONS: Dict[str, Any] = {
+    "temperature": 0.15,
+    "top_p": 0.9,
+    "repeat_penalty": 1.15,
+    "repeat_last_n": 64,
+    "num_predict": -1,
+}
+
+RECOMP_SAMPLING_OPTIONS: Dict[str, Any] = {
+    "temperature": 0.1,
+    "num_predict": 1500,
+    "top_p": 0.9,
+    "repeat_penalty": 1.15,
+}
+
+QUERY_DECOMPOSER_SAMPLING_OPTIONS: Dict[str, Any] = {
+    "temperature": 0.5,
+    "num_predict": 400,
+    "stop": ["\n\n\n"],
+}
+
 
 def app_config_from_runtime() -> AppConfig:
     """Build an ``AppConfig`` reflecting the current runtime state.
@@ -231,13 +256,7 @@ def rag_chat_model(config: AppConfig) -> OllamaChatModel:
         request_timeout=ollama.request_timeout,
         generate_retries=ollama.generate_retries,
         generate_retry_delay=ollama.generate_retry_delay,
-        options={
-            "temperature": 0.15,
-            "top_p": 0.9,
-            "repeat_penalty": 1.15,
-            "repeat_last_n": 64,
-            "num_predict": -1,
-        },
+        options=RAG_SAMPLING_OPTIONS,
         base_url=ollama.base_url,
         model_unloader=OllamaModelUnloader(config.models, base_url=ollama.base_url),
     )
@@ -253,12 +272,7 @@ def recomp_chat_model(config: AppConfig) -> OllamaChatModel:
         request_timeout=ollama.request_timeout,
         generate_retries=ollama.generate_retries,
         generate_retry_delay=ollama.generate_retry_delay,
-        options={
-            "temperature": 0.1,
-            "num_predict": 1500,
-            "top_p": 0.9,
-            "repeat_penalty": 1.15,
-        },
+        options=RECOMP_SAMPLING_OPTIONS,
         base_url=ollama.base_url,
     )
 
@@ -282,7 +296,7 @@ def query_decomposer(config: AppConfig) -> OllamaChatModel:
         request_timeout=ollama.request_timeout,
         generate_retries=ollama.generate_retries,
         generate_retry_delay=ollama.generate_retry_delay,
-        options={"temperature": 0.5, "num_predict": 400, "stop": ["\n\n\n"]},
+        options=QUERY_DECOMPOSER_SAMPLING_OPTIONS,
         base_url=ollama.base_url,
     )
 

--- a/rag/web/app.py
+++ b/rag/web/app.py
@@ -223,6 +223,13 @@ def _reset_db():
 def _chat_stream(pregunta: str) -> Generator[str, None, None]:
     """Generate tokens from chat mode via streaming.
 
+    Bypasses OllamaChatModel (which would apply the same deadline) because
+    this path predates it and still talks to ollama_client_for directly; see
+    issue #237. The client is built with OLLAMA_REQUEST_TIMEOUT baked in, so
+    a wedged server raises instead of blocking the Flask worker forever --
+    api_chat's generate() already turns any exception from this generator
+    into an SSE `error` event.
+
     Args:
         pregunta: User question text.
 
@@ -236,7 +243,7 @@ def _chat_stream(pregunta: str) -> Generator[str, None, None]:
     messages.extend(mensajes_recientes)
     messages.append({"role": "user", "content": pregunta})
 
-    stream = ollama_client_for(OLLAMA_BASE_URL).chat(
+    stream = ollama_client_for(OLLAMA_BASE_URL, timeout=rag_engine.OLLAMA_REQUEST_TIMEOUT).chat(
         model=rag_engine.MODELO_CHAT,
         messages=messages,
         stream=True,
@@ -1137,6 +1144,11 @@ def api_settings_post():
                 continue
             setattr(rag_engine, engine_var, val)
             updated[fe_key] = val
+            # Turned off: no query will call reranker() again until this is
+            # flipped back on, so its resident CUDA weights are now held for
+            # nothing (issue #239) -- give the VRAM back.
+            if engine_var == "USAR_RERANKER" and not val:
+                rag_engine.release_reranker()
     rag_engine.guardar_ajustes_persistidos()
     # contextualRetrieval, imageIndexing and imageDescription are index-time
     # flags (part of index_recipe): flipping any of them is the most likely

--- a/src/monkeygrab/adapters/chat/ollama_chat.py
+++ b/src/monkeygrab/adapters/chat/ollama_chat.py
@@ -24,19 +24,26 @@ _DEFAULT_BASE_URL = DEFAULT_OLLAMA_BASE_URL
 
 
 @lru_cache(maxsize=None)
-def ollama_client_for(base_url: str) -> ollama.Client:
-    """Return the shared ``ollama.Client`` for one endpoint.
+def ollama_client_for(base_url: str, *, timeout: Optional[float] = None) -> ollama.Client:
+    """Return the shared ``ollama.Client`` for one endpoint (and timeout).
 
-    Cached per URL because ``wiring`` builds a fresh adapter for every query:
-    a client per instance would open a new HTTP connection pool per question
-    and never close it. The module-level ``ollama.chat`` this replaced had the
-    same one-client-per-process behaviour, minus the configurable host.
+    Cached per ``(base_url, timeout)`` because ``wiring`` builds a fresh
+    adapter for every query: a client per instance would open a new HTTP
+    connection pool per question and never close it. The module-level
+    ``ollama.chat`` this replaced had the same one-client-per-process
+    behaviour, minus the configurable host.
+
+    ``timeout`` has to be baked into the client at construction time: the
+    ``ollama`` package forwards it to ``httpx.Client(timeout=...)``, and
+    ``Client.chat()`` takes no per-call timeout argument to override it with.
+    Defaults to ``None`` (httpx's own "no timeout"), matching the client's
+    behaviour before ``OllamaChatModel.generate()`` started requesting one.
 
     Public because the CLI and web ``/chat`` modes call ``ollama.chat``
     directly instead of going through this adapter, and they must reach the
     same server the RAG pipeline does.
     """
-    return ollama.Client(host=base_url)
+    return ollama.Client(host=base_url, timeout=timeout)
 
 
 class OllamaChatModel:
@@ -56,7 +63,8 @@ class OllamaChatModel:
     image bytes. ``stream`` instead talks to ``/api/generate`` over raw HTTP,
     because it needs line-by-line JSON and a retry policy limited to 5xx --
     neither of which the client exposes. Both are bound to ``base_url``, so
-    the two paths cannot end up talking to different servers.
+    the two paths cannot end up talking to different servers, and both are
+    bound to ``request_timeout``, so neither can block past its deadline.
 
     ``model_unloader`` frees VRAM before streaming starts, and again before
     retrying a 5xx. It is injected rather than computed here because
@@ -86,7 +94,10 @@ class OllamaChatModel:
                 ``options``, overriding any ``num_ctx`` already in ``options``).
             keep_alive: Seconds to keep the model loaded after the call
                 (``0`` unloads immediately, matching ``OLLAMA_KEEP_ALIVE``).
-            request_timeout: HTTP timeout in seconds for ``stream``.
+            request_timeout: HTTP timeout in seconds, applied to both
+                ``generate`` and ``stream``. ``generate`` bakes it into the
+                ``ollama.Client`` it uses (see ``ollama_client_for``);
+                ``stream`` passes it straight to ``requests.post``.
             generate_retries: Total attempts for ``stream`` on repeated 5xx
                 responses (``1`` = no retry).
             generate_retry_delay: Seconds to wait between ``stream`` retries.
@@ -143,7 +154,9 @@ class OllamaChatModel:
             The complete generated text.
 
         Raises:
-            RuntimeError: On any generation failure.
+            RuntimeError: On any generation failure, including a request
+                that exceeds ``request_timeout`` -- this call has no other
+                deadline, so a stalled server would otherwise hang forever.
         """
         message: Dict[str, Any] = {"role": "user", "content": prompt}
         if images:
@@ -163,7 +176,9 @@ class OllamaChatModel:
             }
             if response_format is not None:
                 chat_kwargs["format"] = response_format
-            response = ollama_client_for(self._base_url).chat(**chat_kwargs)
+            response = ollama_client_for(self._base_url, timeout=self._request_timeout).chat(
+                **chat_kwargs
+            )
         except Exception as exc:
             raise RuntimeError(f"Ollama generate failed for model {self._model!r}: {exc}") from exc
 

--- a/src/monkeygrab/adapters/lexical/bm25_index.py
+++ b/src/monkeygrab/adapters/lexical/bm25_index.py
@@ -1,5 +1,6 @@
 """LexicalIndex adapter over rank_bm25's Okapi BM25 implementation."""
 
+import threading
 from typing import List, Optional, Tuple
 
 from rank_bm25 import BM25Okapi
@@ -12,6 +13,8 @@ from monkeygrab.ports.vector_store import VectorStore
 # Not subclassed from monkeygrab.ports.lexical_index.LexicalIndex: Protocol
 # conformance here is structural (duck typing), the same contract every other
 # adapter in this package satisfies without inheriting its port.
+
+_IndexSnapshot = Tuple[Optional[Tuple[int, float, float]], List[Fragment], Optional[BM25Okapi]]
 
 
 class Bm25LexicalIndex:
@@ -31,6 +34,11 @@ class Bm25LexicalIndex:
     in-place edit keeping the same chunk count will not refresh the index;
     reindexing changes the count and does.
 
+    ``rag/engine/wiring.py`` caches one instance per ``(store, k1, b)`` and
+    hands it to every concurrent Flask request thread (``threaded=True``).
+    ``_ensure_index`` is written for that: see its docstring for the race a
+    shared instance is exposed to and how the lock closes it (#238).
+
     Failure policy: hard-fail for anything reaching the underlying
     ``VectorStore`` -- its own hard-fail policy applies transitively, since
     nothing here catches its exceptions. A query with no positive BM25 match
@@ -46,22 +54,71 @@ class Bm25LexicalIndex:
         self._vector_store = vector_store
         self._k1 = retrieval.bm25_k1
         self._b = retrieval.bm25_b
-        self._cache_key: Optional[Tuple[int, float, float]] = None
-        self._bm25: Optional[BM25Okapi] = None
-        self._entries: List[Fragment] = []
+        # (cache_key, entries, bm25) published as one immutable tuple behind
+        # one attribute rather than three separate ones, so a reader gets a
+        # matched triple from a single dereference -- never entries from one
+        # rebuild paired with a bm25 from another, which three independently
+        # read/written attributes cannot promise (this is the same technique
+        # rag/engine/wiring.py's vector_store()/lexical_index() caches use,
+        # for the identical reason -- see that module's #57 docstrings).
+        self._index: _IndexSnapshot = (None, [], None)
+        self._rebuild_lock = threading.Lock()
 
-    def _ensure_index(self) -> None:
-        """Rebuild the BM25 index iff the corpus size or BM25 parameters changed."""
+    def _ensure_index(self) -> Tuple[List[Fragment], Optional[BM25Okapi]]:
+        """Return the current ``(entries, bm25)`` pair, rebuilding iff the
+        corpus size or the BM25 parameters changed since the last rebuild.
+
+        ``rag/engine/wiring.py`` shares one instance across concurrent Flask
+        request threads. Rebuilding was previously three unsynchronized
+        writes (``self._entries``, then ``self._bm25``, then
+        ``self._cache_key``) with no lock at all: a thread scheduled out
+        mid-rebuild -- a slow ``BM25Okapi()`` call, or plain GIL contention
+        under load -- could resume and publish its own snapshot, read
+        *before* a concurrent ``delete_source()``, *after* a second thread's
+        rebuild (triggered by that same delete) had already published a
+        fresher one. The slower write landed last and won for all three
+        fields at once, silently reverting the index to cite content the
+        caller had just deleted (#238).
+
+        The whole rebuild -- read corpus, tokenize, construct ``BM25Okapi``,
+        publish -- now runs inside ``_rebuild_lock``, not just the publish
+        step. That serializes rebuilds end to end: whichever one starts
+        later can only do so after the earlier one has already published, so
+        it always builds from a corpus snapshot at least as fresh, and it is
+        the one left standing. A request whose own read began before a
+        concurrent mutation can still see the pre-mutation corpus for that
+        one call -- there is no way to retroact on data already read without
+        locking the vector store itself during a rebuild, which is out of
+        this adapter's scope -- but that state is never a torn mix, and a
+        slower rebuild can never overwrite a fresher one that a concurrent
+        caller already observed.
+
+        The cheap, unlocked key check outside the lock keeps the common case
+        (cache already valid) lock-free, mirroring the double-checked
+        locking ``vector_store()``/``lexical_index()`` use in
+        ``rag/engine/wiring.py``.
+
+        Returns:
+            The fragments backing the index and the built ``BM25Okapi``
+            (``None`` when every chunk tokenized to nothing).
+        """
+        cache_key, entries, bm25 = self._index
         key = (self._vector_store.count(), self._k1, self._b)
-        if key == self._cache_key:
-            return
+        if key == cache_key:
+            return entries, bm25
 
-        entries = self._vector_store.get_page(limit=None, offset=0)
-        corpus_tokens = [tokenize_bm25(entry.doc) for entry in entries]
+        with self._rebuild_lock:
+            cache_key, entries, bm25 = self._index
+            key = (self._vector_store.count(), self._k1, self._b)
+            if key == cache_key:
+                return entries, bm25
 
-        self._entries = entries
-        self._bm25 = BM25Okapi(corpus_tokens, k1=self._k1, b=self._b) if any(corpus_tokens) else None
-        self._cache_key = key
+            entries = self._vector_store.get_page(limit=None, offset=0)
+            corpus_tokens = [tokenize_bm25(entry.doc) for entry in entries]
+            bm25 = BM25Okapi(corpus_tokens, k1=self._k1, b=self._b) if any(corpus_tokens) else None
+
+            self._index = (key, entries, bm25)
+            return entries, bm25
 
     def search(self, query: str, top_n: int) -> List[Fragment]:
         """Rank stored chunks against ``query`` by Okapi BM25 relevance.
@@ -80,18 +137,18 @@ class Bm25LexicalIndex:
         if not query_tokens:
             return []
 
-        self._ensure_index()
-        if self._bm25 is None:
+        entries, bm25 = self._ensure_index()
+        if bm25 is None:
             return []
 
-        scores = self._bm25.get_scores(query_tokens)
+        scores = bm25.get_scores(query_tokens)
         ranked_idx = sorted(range(len(scores)), key=lambda i: scores[i], reverse=True)
 
         results: List[Fragment] = []
         for i in ranked_idx:
             if scores[i] <= 0:
                 break
-            results.append(self._entries[i])
+            results.append(entries[i])
             if len(results) >= top_n:
                 break
         return results

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,13 +15,20 @@ the engine is unavailable. The same pytest command then works in both
 environments: everything runs where the stack is installed, and only the pure
 layers run where it is not.
 
-Dependencies: stdlib only (ast, importlib.util) -- this file must import in an
-environment with nothing but pytest available.
+Also resets a module-level leak in rag.chat_pdfs before the first test runs
+(see the fixture below) -- unrelated to the skip logic above, but this is the
+one conftest.py both environments load, and the leak needs to be undone
+before anything else in the session observes it.
+
+Dependencies: stdlib only (ast, importlib.util) plus pytest -- this file must
+import in an environment with nothing else available.
 """
 
 import ast
 import importlib.util
 from pathlib import Path
+
+import pytest
 
 # What importing rag.chat_pdfs pulls in, directly or through the adapters its
 # pipeline entry points wire up. Any one missing means the engine cannot be
@@ -93,3 +100,28 @@ else:
         for path in sorted(_HERE.rglob("test_*.py"))
         if _imports_engine(path)
     ]
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _restore_chat_pdfs_docs_folder():
+    """Undo rag/web/app.py's import-time settings load before any test runs.
+
+    Collection imports every test module up front, before any test-scoped
+    fixture gets a chance to run. Any file that imports rag.web.app (e.g.
+    tests/test_web_indexing_releases_worker.py, first in file order to do so)
+    triggers that module's own top-level ``rag_engine.cargar_ajustes_persistidos()``
+    (rag/web/app.py), which applies whatever ``active_store`` this machine's
+    real, gitignored rag/settings.json holds onto rag.chat_pdfs's shared
+    CARPETA_DOCS / PATH_DB / COLLECTION_NAME globals -- for the rest of the
+    process, independent of which test happens to run first or last. A
+    characterization test asserting those globals equal rag.chat_pdfs's own
+    import-time default then fails only in the full suite, never alone
+    (issue #227). Reset to that default here, once, before the first test
+    in the session executes -- restoring what the import silently changed,
+    not what any one test changed.
+    """
+    try:
+        import rag.chat_pdfs as rag_engine
+    except ImportError:
+        return
+    rag_engine.set_docs_folder_runtime(None)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,25 +103,32 @@ else:
 
 
 @pytest.fixture(autouse=True, scope="session")
-def _restore_chat_pdfs_docs_folder():
+def _restore_chat_pdfs_settings_globals():
     """Undo rag/web/app.py's import-time settings load before any test runs.
 
     Collection imports every test module up front, before any test-scoped
     fixture gets a chance to run. Any file that imports rag.web.app (e.g.
     tests/test_web_indexing_releases_worker.py, first in file order to do so)
     triggers that module's own top-level ``rag_engine.cargar_ajustes_persistidos()``
-    (rag/web/app.py), which applies whatever ``active_store`` this machine's
-    real, gitignored rag/settings.json holds onto rag.chat_pdfs's shared
-    CARPETA_DOCS / PATH_DB / COLLECTION_NAME globals -- for the rest of the
-    process, independent of which test happens to run first or last. A
-    characterization test asserting those globals equal rag.chat_pdfs's own
-    import-time default then fails only in the full suite, never alone
-    (issue #227). Reset to that default here, once, before the first test
-    in the session executes -- restoring what the import silently changed,
-    not what any one test changed.
+    (rag/web/app.py), which applies whatever this machine's real, gitignored
+    rag/settings.json holds -- active store, model roles and pipeline flags
+    -- onto rag.chat_pdfs's shared globals, for the rest of the process,
+    independent of which test happens to run first or last. A test asserting
+    one of those globals equals rag.chat_pdfs's own import-time default then
+    passes or fails depending on a file no other machine has, rather than on
+    the default it claims to check.
+
+    The docs-folder trio (``CARPETA_DOCS`` / ``PATH_DB`` / ``COLLECTION_NAME``)
+    was fixed this way first (issue #227, via ``set_docs_folder_runtime(None)``).
+    Model roles and pipeline flags had no equivalent restore-to-default path
+    until ``_restaurar_roles_y_flags_por_defecto`` (issue #231) -- both are
+    reset here, once, before the first test in the session executes,
+    restoring what the import silently changed rather than what any one test
+    changed.
     """
     try:
         import rag.chat_pdfs as rag_engine
     except ImportError:
         return
     rag_engine.set_docs_folder_runtime(None)
+    rag_engine._restaurar_roles_y_flags_por_defecto()

--- a/tests/eval/README.md
+++ b/tests/eval/README.md
@@ -258,7 +258,8 @@ pre-#222 rows as rows of undocumented conditions, not as rows comparable to a la
    model. Retrieval is computed once per case and shared across every model in that invocation
    (step 5 above), which is what makes the comparison paired instead of two independent
    samples -- separate invocations give every model its own retrieval draw and lose that.
-   Issue #220 covers the reload cost this causes on an 8 GB card.
+   Generation runs model-major (every pending case for one model, then the next), so a sweep
+   loads each generator once rather than once per case (issue #220).
 4. Read the resulting artifact with `tools/diagnostics/model_history_row.py
    tests/eval/runs/<artifact>.json`, not by re-deriving numbers from the console output.
 5. Record the artifact's filename (or timestamp) in the row -- that is what lets someone else

--- a/tests/eval/README.md
+++ b/tests/eval/README.md
@@ -28,19 +28,41 @@ implementation that happens to live in the test tree.
 
 ## Corpus
 
-Two sets of papers, mixed deliberately:
+Four sources, mixed deliberately (the `source` field in `gold_cases.jsonl`):
 
-- **Dev set** (`source: "corpus"`): the six papers already in `rag/docs/en/`. Their retrieved
-  chunks and reranking behavior are what the pipeline's heuristics were tuned against.
-- **Blind set** (`source: "arxiv"`, `arxiv_id` set): three papers never used to tune anything
-  — ResNet (`1512.03385`), BERT (`1810.04805`), ViT (`2010.11929`). A judge calibrated only on
-  the dev set can't tell "the pipeline retrieves well" from "the pipeline overfits these six
-  PDFs"; the blind set is what makes that distinction possible.
+- **`corpus`** -- the dev set: `rag/docs/en/`, 17 documents. Retrieved chunks and reranking
+  behavior here are what the pipeline's heuristics were tuned against.
+- **`arxiv`** (`arxiv_id` set) -- the blind set: ML papers fetched on demand by
+  `fetch_papers.py`, never used to tune anything. A judge calibrated only on the dev set can't
+  tell "the pipeline retrieves well" from "the pipeline overfits these PDFs"; the blind set is
+  what makes that distinction possible.
+- **`corpus_es`** / **`corpus_ca`** -- the product's own `rag/docs/es/` and `rag/docs/ca/`
+  stores (17 documents each), evaluated the same way and for the same reason `corpus` is: they
+  are what the product actually serves, not a probe of it. Each gets its own isolated FAISS
+  collection (`EXTRA_DEV_CORPORA` in `run_eval.py`), so evaluating them never touches the store
+  the web UI writes into.
+
+Counted directly from `gold_cases.jsonl`: 156 cases, of which 136 reach a generator and 20 are
+retrieval-only (`figure_retrieval` / `table_retrieval`); 85 `en`, 37 `es`, 34 `ca`; 75 cases
+over 17 `corpus` documents, 33 over 6 `arxiv` documents, 24 over 12 `corpus_es` documents, 24
+over 12 `corpus_ca` documents -- not every document in a store has a gold case yet. This is a
+count, not a target: recount it (one `json.loads` per line, a `Counter` over the field you
+care about) rather than trust a number written here if the file has grown since -- a stale
+count transcribed by hand is exactly how this section went stale before (#221).
+
+Some questions are deliberately cross-lingual: 10 `ca` and 13 `es` questions ask about
+`corpus`/`arxiv` (English) documents, not about `corpus_es`/`corpus_ca`. `run_eval.py`'s own
+comment on `EXTRA_DEV_CORPORA` explains why: "the gold set has always had Spanish and Catalan
+questions asked against English papers." `lang` is the question's language, never the
+document's -- `corpus_es`/`corpus_ca` cases are always asked in their own language, but
+`corpus`/`arxiv` mix a majority of `en` questions with that deliberate cross-lingual minority.
 
 Every `accepted_answers` / `expect_kind_any` value was checked by hand against the PDF (see
-each case's `verified_pages` — the physical page numbers, 1-indexed, as read directly from the
+each case's `verified_pages` -- the physical page numbers, 1-indexed, as read directly from the
 source PDF) before being added. A case whose answer could not be confirmed in the text does not
-go in the file.
+go in the file. The three `study_*` case types (see the schema below) are the exception: they
+grade a whole generated artifact against a document, not a literal against a page, so they
+carry no `verified_pages`.
 
 ## Schema (`gold_cases.jsonl`)
 
@@ -49,11 +71,11 @@ One case per line:
 | Field | Meaning |
 |---|---|
 | `id` | Unique, `<paper-slug>-<short-name>`. |
-| `paper` | Paper slug. Matches the corpus filename stem for `source: "corpus"`. |
-| `source` | `"corpus"` (already in `rag/docs/en/`) or `"arxiv"` (fetch first). |
+| `paper` | Paper slug. Matches the corpus filename stem for every `source` but `"arxiv"`. |
+| `source` | `"corpus"` / `"corpus_es"` / `"corpus_ca"` (already in the matching `rag/docs/<lang>/`) or `"arxiv"` (fetch first). |
 | `arxiv_id` | Only when `source == "arxiv"`; passed to `fetch_papers.py`. |
-| `case_type` | `factual_number` \| `factual_concept` \| `figure_retrieval` \| `table_retrieval`. |
-| `lang` | `en` \| `es` — the question's language, not the document's. |
+| `case_type` | `factual_number` \| `factual_concept` \| `figure_retrieval` \| `table_retrieval` \| `study_summary` \| `study_outline` \| `study_quiz`. |
+| `lang` | `en` \| `es` \| `ca` -- the question's language, not the document's. |
 | `question` | The query text (a retrieval query for the two `*_retrieval` types). |
 | `accepted_answers` | List of literals, any one of which counts as correct. Required for the two factual types. |
 | `expect_kind_any` | List among `text`/`table`/`image` — the content kind expected in the top-k. Required for the two retrieval types. |
@@ -63,6 +85,15 @@ One case per line:
 `table` and `image` match the content taxonomy produced by the current MinerU
 indexer. Tables retain their structured HTML and figures are embedded directly
 with Jina CLIP.
+
+The three `study_*` types (issue #140; graded by `grade_study` in `grade.py`) score a whole
+generated artifact against its source document, not a literal against a page -- they carry no
+`question` and no `verified_pages`, since the paper itself is the scope. Each carries its own
+bound instead: `study_summary` needs `min_sections` (optionally `required_all`, terms every
+section's text must mention); `study_outline` needs `min_nodes` (optionally
+`expect_titles_any`, real section titles the outline should hit at least one of);
+`study_quiz` needs `min_questions`. `test_grade.py`'s schema check is the authoritative list of
+what each actually requires.
 
 ## Adding a case
 
@@ -109,13 +140,14 @@ something is missing:
    not Ollama roles.
 2. Downloads any missing blind-set arXiv papers (reusing `fetch_papers.py`)
    and stages them under `blind_docs/<paper-slug>.pdf`.
-3. Indexes whatever is not already indexed -- dev-set papers read from
-   `rag/docs/en/` but stored in the eval's own isolated collection, blind-set
-   papers into their own collection under `blind_docs/` -- via the real
-   `indexar_documentos` pipeline. A paper is reused only when the store's
-   recorded index recipe (chunking, embeddings, index-time flags) matches
-   the configuration this run will use; a changed recipe discards the store
-   and rebuilds it.
+3. Indexes whatever is not already indexed -- dev-set papers for each of the three
+   language stores (`rag/docs/en/`, `rag/docs/es/`, `rag/docs/ca/`) read from the
+   product's own folders but stored in the eval's own isolated collections
+   (`EXTRA_DEV_CORPORA` in `run_eval.py`), blind-set papers into their own collection
+   under `blind_docs/` -- via the real `indexar_documentos` pipeline. A paper is reused
+   only when the store's recorded index recipe (chunking, embeddings, index-time flags)
+   matches the configuration this run will use; a changed recipe discards the store and
+   rebuilds it.
 4. Verifies every paper referenced by a gold case actually has an index
    entry before running anything.
 5. Runs every case through the real retrieval + (for factual cases)
@@ -145,9 +177,108 @@ something is missing:
 Infrastructure failures leave the run inconclusive. Only an unfiltered gold-set
 run (`case_ids is None`, the CLI) is compared against the baseline. A subset
 (the harness search set / fast tier / empty reachability probe) still reports
-`pass_rate` and can raise the baseline when asked, but is not the 51-case gate.
+`pass_rate` and can raise the baseline when asked, but is not the same thing as the
+full, unfiltered run the baseline is calibrated against -- see Corpus above for
+what "full" currently means.
+
+## Experiment standard
+
+`docs/model-history.md` exists so a model choice comes from numbers instead of memory, but a
+row is only worth comparing to another row if both were produced under the same conditions.
+Issue #218 is what happens when that goes unchecked: rows in that table were measured against
+three different gold sets side by side, with nothing in the artifact saying so. This section is
+what "same conditions" means for a `run_eval.py` invocation, so a later row can be trusted
+instead of re-derived from memory.
+
+### What the gate fixes for you
+
+- `flags.usar_contextual_retrieval` is forced to `False` regardless of the running
+  configuration (`_eval_app_config` in `run_eval.py`, the `with_overrides` call right after the
+  full flag block) -- the only one of the nine pipeline flags the gate overrides itself.
+- Generation's `keep_alive` is forced to 120 seconds for the run's duration
+  (`_EVAL_GENERATION_KEEP_ALIVE_SECONDS` in `run_eval.py`), so a cold first call per model is
+  not read as steady-state latency.
+- The `chat`, `contextual` and `recomp` roles are all pinned to `AUX_MODEL` for the whole
+  evaluation (`_scoped_model_roles` around the `evaluate()` call in `run_eval.py`). A
+  `--models` sweep varies only the `rag` role; the query decomposer a sweep might otherwise
+  also swap along with the generator is held fixed.
+
+### What it does not fix -- you have to, from outside
+
+- The other eight pipeline flags inherit whatever `rag/chat_pdfs.py`'s module globals resolve
+  to at import time (environment > `settings.json` > module default, per `AGENTS.md` §3). A
+  flag flipped in the environment or left over in `settings.json` changes the measurement with
+  nothing in the console output saying so.
+- Every numeric parameter -- `RAG_CHUNK_SIZE`, `RAG_TOP_K_FINAL`, `RAG_N_RESULTADOS_SEMANTICOS`,
+  the reranker threshold (`RAG_UMBRAL_SCORE_RERANKER`), the fusion weights
+  (`RAG_PESO_SEMANTICO_RRF` / `RAG_PESO_BM25_RRF`), `OLLAMA_RAG_NUM_CTX` and the rest -- reads
+  an `RAG_*`/`OLLAMA_*` environment variable with a module default in `rag/chat_pdfs.py`. An
+  exported variable changes the run and nothing flags it.
+- Sampling is fixed in code rather than read from the environment, but it still has to match
+  across runs being compared: `RAG_SAMPLING_OPTIONS`, `RECOMP_SAMPLING_OPTIONS` and
+  `QUERY_DECOMPOSER_SAMPLING_OPTIONS` in `rag/engine/wiring.py` set the `rag` role's
+  temperature to 0.15, `recomp` to 0.1, and the decomposer (the `chat` role, the same one
+  pinned to `AUX_MODEL` above) to 0.5.
+
+### Determinism -- the part that matters most
+
+No stage of the pipeline the gate exercises pins a random seed (issue #223); the `conditions`
+block records `"seed": null` because that is what actually happens, not because the field was
+left blank. Three stages sample at non-zero temperature -- the generator under test at 0.15,
+RECOMP synthesis at 0.1, and query decomposition at 0.5 -- and the decomposer is the one that
+matters beyond wording: it runs *before* retrieval, so a different sub-query on an otherwise
+identical run changes which fragments come back, which changes what generation ever sees.
+Variance is not confined to how the final answer happens to be phrased.
+
+The practical consequence: **a row in `docs/model-history.md` is n=1.** A gap of two or three
+cases between two models' pass rates is not distinguishable from resampling the same model
+twice; nothing in this repo currently re-runs a model to check. Treat a difference that size as
+noise, not as a finding, until it is checked against a measured noise floor -- see below, and
+note that the floor on record there needs re-measuring on the current 156-case set before it
+can be used for that check.
+
+### What now gets recorded
+
+Since issue #222, every run artifact under `runs/` carries a `conditions` block: the per-corpus
+`AppConfig` actually used, installed package and Ollama-server versions, GPU info, the git
+commit, a sha256 of `gold_cases.jsonl`, the sampling options per role, `seed: null`, and the
+`keep_alive` in effect. That block is what makes a row in `docs/model-history.md` verifiable
+after the fact instead of merely asserted -- read it with `tools/diagnostics/model_history_row.py`
+before trusting a row. Anything measured before this was added has no such record; treat
+pre-#222 rows as rows of undocumented conditions, not as rows comparable to a later one.
+
+### Adding a row to `docs/model-history.md`
+
+1. Confirm the GPU is actually free. `ollama ps` reporting nothing does **not** mean it is --
+   check `nvidia-smi --query-compute-apps=pid,process_name,used_memory --format=csv` for who
+   actually holds VRAM, and stop the web app and any other resident model server first.
+2. Watch the console for `[index] <label>: cache hit, ...` for every corpus label, not
+   `indexing N missing paper(s)` or `recipe changed ... discarding and rebuilding`. A reindex
+   mid-run changes what is being measured, not just how long the run takes.
+3. Measure every model that fits in one `--models` invocation, rather than one invocation per
+   model. Retrieval is computed once per case and shared across every model in that invocation
+   (step 5 above), which is what makes the comparison paired instead of two independent
+   samples -- separate invocations give every model its own retrieval draw and lose that.
+   Issue #220 covers the reload cost this causes on an 8 GB card.
+4. Read the resulting artifact with `tools/diagnostics/model_history_row.py
+   tests/eval/runs/<artifact>.json`, not by re-deriving numbers from the console output.
+5. Record the artifact's filename (or timestamp) in the row -- that is what lets someone else
+   open its `conditions` block later and check what was actually measured.
+6. Confirm `infrastructure_errors` is empty in the artifact before treating the run as
+   conclusive; a run that had infrastructure failures answers a different question than the
+   one the row claims to answer.
 
 ## Measuring the noise floor and the gate's sensitivity
+
+The runs cited below are historical, measured 2026-07-29 against a 51-case gold set: six
+English papers as the dev set, three arXiv papers (ResNet, BERT, ViT) as the blind set, `lang`
+limited to `en`/`es`, and four `case_type` values -- not the 156-case, three-language,
+four-source set `gold_cases.jsonl` holds today (see Corpus above). The fractions below
+(`44/51`, `39/51`, `40/51`) belong to that older, smaller set and do not rescale to a
+denominator of 156; nobody has re-run this measurement against the current file. The procedure
+-- run twice, diff with `compare_runs.py` -- is unchanged and is exactly what a fresh
+measurement should still follow; only the numbers already on record here are frozen at the set
+they were measured on.
 
 Both need a GPU machine with Ollama running — the fast CI gate cannot run
 them. `compare_runs.py` itself is pure and is covered by the fast gate.

--- a/tests/eval/README.md
+++ b/tests/eval/README.md
@@ -128,7 +128,12 @@ something is missing:
    generator at all.
 6. Writes a dated JSON report to `runs/<timestamp>.json` (per-case detail:
    pass/fail, timing, and on failure the generated answer and retrieved
-   fragments) plus a console summary by case type and by model.
+   fragments) plus a console summary by case type and by model. The report
+   also carries a `conditions` block recording what produced that pass rate
+   -- the per-corpus `AppConfig` (chunking, retrieval, flags), sampling
+   parameters per Ollama role, installed stack versions, GPU, git commit and
+   a hash of `gold_cases.jsonl` -- so two runs measured under different
+   setups are distinguishable from the files alone (issue #222).
 7. Compares the overall pass rate against `baseline_min_pass_rate.txt` and
    exits non-zero if it dropped -- that comparison is the gate. `--update-baseline`
    additionally raises the file to `pass_rate - 0.05` (rounded down to the

--- a/tests/eval/README.md
+++ b/tests/eval/README.md
@@ -294,6 +294,13 @@ python tests/eval/compare_runs.py tests/eval/runs/<first>.json tests/eval/runs/<
 Every flip is noise. Record the observed number: no delta at or below it counts
 as a real change, and an optimisation loop must not treat one as an improvement.
 
+`compare_runs.py` refuses a report that carries an `infrastructure_error`, because a run
+that measured nothing must not compare as noise-free. A sweep that includes a model with a
+reproducible Ollama crash (Granite's `GGML_ASSERT` on the `att-study-*` cases, for one)
+trips that rule on every run. Pass `--exclude-infrastructure-errors` to drop the (case,
+model) pairs that never ran in either report and compare the rest; the output lists what
+was excluded, so the number you record says what it rests on (issue #240).
+
 **Measured 2026-07-29**, two full-gate runs, identical configuration and code,
 same index (both logged `cache hit` on the dev and blind sets, so neither
 reindexed): `tests/eval/runs/20260729T020233Z_mineru-jina_clip-faiss.json` and

--- a/tests/eval/README.md
+++ b/tests/eval/README.md
@@ -417,10 +417,45 @@ decides whether it is worth it.
 
 This is that batch for the **language axis**: the `es/` (Castilian) and
 `ca/` (Valencian) document stores the product already ships in
-`rag/docs/es/` and `rag/docs/ca/` -- two of its three fixed language stores
--- which `gold_cases.jsonl` never exercises today. Provisioning cost is
-zero, since the PDFs already ship; the domain and form axes are out of
-scope here (see the design doc's composition table).
+`rag/docs/es/` and `rag/docs/ca/` -- two of its three fixed language
+stores. Measured 2026-08-12, before #213: `gold_cases.jsonl` had zero
+`corpus_es`/`corpus_ca` cases, so both stores were entirely unmeasured by
+the gate, which is the gap this probe was built to diagnose. Provisioning
+cost was zero, since the PDFs already shipped; the domain and form axes
+are out of scope here (see the design doc's composition table).
+
+**That gap in the gate is closed, but not by this file.** #213 gave the
+gate 24 `corpus_es` and 24 `corpus_ca` cases (see Corpus above for the
+current count), so "the language axis is unmeasured" is no longer true.
+Those 48 cases, though, sit entirely on the twelve documents per store
+that #213 added by fetching through `tools/fetch_corpus.py` (gitignored,
+downloaded on demand from a versioned manifest) -- none of them touch the
+five `es` and five `ca` documents that were already committed to git
+before #213 existed (`git ls-files rag/docs/es rag/docs/ca`), which
+include this probe's six. Those ten original documents carry zero
+`gold_cases.jsonl` cases, exactly as before #213:
+`Ciudad_de_las_Artes_y_las_Ciencias` and `Fallas_de_Valencia` (`es`),
+`Història_de_València` and `Paella_d'arròs` (`ca`) were never in this
+probe either, and remain unmeasured by both files. The probe and the gate
+now both cover the language axis, on entirely disjoint documents -- which
+is why none of the 18 ids below appear in `gold_cases.jsonl`, and why that
+overlap check is not the thing to fix here.
+
+The two also answer different questions, which is the more important
+reason this file stays. The gate's question, since #213, is "does the
+shipped product answer correctly in `es`/`ca`." This probe's question,
+per the design doc's section 3 ("Sonda previa"), is "does the language
+axis produce failures a self-improving loop can learn from" -- checked
+against the loop's own search set (`harness/evaluator.py`'s
+`search_set_case_ids()`, the complement of the blind set, which now
+includes #213's `corpus_es`/`corpus_ca` cases too). The verdict recorded
+below already answered that second question, on 2026-08-13, before #213:
+*viable tras arreglo* -- these six documents are too easy (17/18) to
+distinguish a loop improvement from a regression, not because the
+pipeline mishandles `es`/`ca`. #213 does not revisit that verdict: it
+added general product coverage, not the harder search-set documents the
+design doc's fix calls for, so the probe's seed cases are still waiting
+on that later batch (see the closing paragraph below).
 
 - **`probe_cases_lang.jsonl`**: 18 hand-verified cases (every
   `verified_pages` checked against the actual PDF page) over 6 documents --

--- a/tests/eval/README.md
+++ b/tests/eval/README.md
@@ -230,12 +230,11 @@ matters beyond wording: it runs *before* retrieval, so a different sub-query on 
 identical run changes which fragments come back, which changes what generation ever sees.
 Variance is not confined to how the final answer happens to be phrased.
 
-The practical consequence: **a row in `docs/model-history.md` is n=1.** A gap of two or three
-cases between two models' pass rates is not distinguishable from resampling the same model
-twice; nothing in this repo currently re-runs a model to check. Treat a difference that size as
-noise, not as a finding, until it is checked against a measured noise floor -- see below, and
-note that the floor on record there needs re-measuring on the current 156-case set before it
-can be used for that check.
+The practical consequence: **a row in `docs/model-history.md` is one run, and one run moves
+by up to five cases.** Measured on this 156-case set on 2026-09-11 (four models run twice, see
+"Measuring the noise floor" below): resampling alone flipped 28 of 536 (case, model) pairs, a
+net movement of -2 to +5 cases per model. A gap that size between two models' pass rates is
+not distinguishable from running one of them again. Treat it as noise, not as a finding.
 
 ### What now gets recorded
 
@@ -327,6 +326,23 @@ threshold at roughly six net flips, with a usable margin of about five cases
 once figure cases are excluded. This note does not retract that count, it
 only sets the floor it is interpreted against; the inference also rests on a
 single pair of runs.
+
+**Measured 2026-09-11 on the current 156-case set**, tranche 1 of the model campaign
+(#218) run twice: `tests/eval/runs/20260911T032105Z_mineru-jina_clip-faiss.json` and
+`tests/eval/runs/20260911T230513Z_mineru-jina_clip-faiss.json`, four generators
+(`Ling-3.0-tiny`, `Llama-3.2-3B`, `Granite-4.0-H-Tiny`, `OLMoE-1B-7B`), `conditions`
+blocks equal field for field except `git_commit`. `compare_runs.py
+--exclude-infrastructure-errors` over the pair: 25 flipped to PASS, 12 flipped to FAIL, 521
+unchanged, 6 pairs excluded (Granite's `GGML_ASSERT` crash on `att-study-*`, 2 in the first
+run and 6 in the second). Two things move in those 37 flips. Nineteen are the 180 s
+generation budget (#229): the first run exhausted it 24 times, in two contiguous windows
+where every model ran past the cap, and the second run 5 times, all on two `study_summary`
+cases that exhaust it for every small model (#234). Dropping every pair that exhausted the
+budget in either run leaves 536 pairs and **28 flips, 16 up and 12 down, 4 to 11 per model,
+net -2 to +5 per model** -- that is the sampling floor of one row on this set. It is a floor
+for this `gold_cases.jsonl` and this `grade.py`, and it rests on one pair of runs, like the
+2026-07-29 figure above; the retrieval-only cases scored 17/20 in both, so the variance is
+in generation, as #223 predicted.
 
 **Sensitivity.** Compare a healthy run (either one from the noise-floor pair
 above) against a deliberately degraded one:

--- a/tests/eval/compare_runs.py
+++ b/tests/eval/compare_runs.py
@@ -15,6 +15,12 @@ Pure over parsed JSON: no network, no GPU, no model.
 
 Usage:
     python tests/eval/compare_runs.py runs/<a>.json runs/<b>.json
+    python tests/eval/compare_runs.py --exclude-infrastructure-errors runs/<a>.json runs/<b>.json
+
+The second form is for a pair where one model crashed on a few cases in
+either run (issue #240): those (case, model) pairs are dropped from both
+sides and counted in the output, so the rest of the sweep can still be
+compared. The default refuses such a run outright.
 """
 
 from __future__ import annotations
@@ -34,6 +40,15 @@ def _outcomes(report: Dict[str, Any]) -> Dict[str, bool]:
     return {
         f"{r['id']} / {r['model'] or 'n-a'}": bool(r["passed"])
         for r in report["results"]
+    }
+
+
+def _infrastructure_keys(report: Dict[str, Any]) -> set:
+    """The ``"<case id> / <model>"`` keys whose record never really ran."""
+    return {
+        f"{r['id']} / {r['model'] or 'n-a'}"
+        for r in report["results"]
+        if r.get("infrastructure_error")
     }
 
 
@@ -71,6 +86,7 @@ def compare(
     *,
     label_a: str = "report_a",
     label_b: str = "report_b",
+    exclude_infrastructure_errors: bool = False,
 ) -> Dict[str, Any]:
     """Compare two run reports case by case.
 
@@ -81,17 +97,36 @@ def compare(
             passes the actual file path so a failure names the file, not the
             generic parameter name.
         label_b: Same, for ``report_b``.
+        exclude_infrastructure_errors: Drop every (case, model) pair that
+            hit an infrastructure error in either run instead of refusing
+            the run (issue #240). A pair that never ran is not a pass or a
+            fail, so counting it as a flip would inflate the noise floor,
+            and refusing the whole file throws away the hundreds of pairs
+            that did run. Off by default: the gate's own comparison keeps
+            the strict rule.
 
     Returns:
         ``flipped_to_pass`` and ``flipped_to_fail`` (sorted case keys),
-        ``stable`` (count unchanged) and ``pass_rate_delta`` (b minus a).
+        ``stable`` (count unchanged), ``pass_rate_delta`` (b minus a) and
+        ``excluded`` (sorted keys dropped under the flag, empty otherwise).
 
     Raises:
         ValueError: The two runs do not cover the same cases (a partial run
             would otherwise compare as a large improvement or regression),
             or either run is inconclusive or empty -- a run that measured
-            nothing must not be treated as a noise-free result.
+            nothing must not be treated as a noise-free result. Under the
+            flag, "inconclusive" narrows to "no comparable pair left".
     """
+    excluded: List[str] = []
+    if exclude_infrastructure_errors:
+        excluded = sorted(_infrastructure_keys(report_a) | _infrastructure_keys(report_b))
+        report_a = _without(report_a, excluded)
+        report_b = _without(report_b, excluded)
+        if not report_a["results"] or not report_b["results"]:
+            raise ValueError(
+                f"no comparable pair left: every record of {label_a} or {label_b} "
+                "hit an infrastructure error"
+            )
     _reject_unusable(report_a, label_a)
     _reject_unusable(report_b, label_b)
     a, b = _outcomes(report_a), _outcomes(report_b)
@@ -114,6 +149,19 @@ def compare(
         "flipped_to_fail": flipped_to_fail,
         "stable": total - len(flipped_to_pass) - len(flipped_to_fail),
         "pass_rate_delta": round(delta, 4),
+        "excluded": excluded,
+    }
+
+
+def _without(report: Dict[str, Any], keys: List[str]) -> Dict[str, Any]:
+    """A shallow copy of ``report`` with the records for ``keys`` removed."""
+    dropped = set(keys)
+    return {
+        **report,
+        "results": [
+            r for r in report["results"]
+            if f"{r['id']} / {r['model'] or 'n-a'}" not in dropped
+        ],
     }
 
 
@@ -131,17 +179,32 @@ def _print(result: Dict[str, Any]) -> None:
     for key in to_fail:
         print(f"  - {key}")
     print(f"pass rate delta: {result['pass_rate_delta']:+.4f}")
+    excluded: List[str] = result["excluded"]
+    if excluded:
+        print(f"{len(excluded)} pair(s) excluded (infrastructure error in one run):")
+        for key in excluded:
+            print(f"  ! {key}")
 
 
 def main(argv: List[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     parser.add_argument("report_a", type=Path)
     parser.add_argument("report_b", type=Path)
+    parser.add_argument(
+        "--exclude-infrastructure-errors",
+        action="store_true",
+        help="drop the (case, model) pairs that hit an infrastructure error in "
+             "either run instead of refusing the run; the count is printed",
+    )
     args = parser.parse_args(argv)
 
     report_a = json.loads(args.report_a.read_text(encoding="utf-8"))
     report_b = json.loads(args.report_b.read_text(encoding="utf-8"))
-    _print(compare(report_a, report_b, label_a=str(args.report_a), label_b=str(args.report_b)))
+    _print(compare(
+        report_a, report_b,
+        label_a=str(args.report_a), label_b=str(args.report_b),
+        exclude_infrastructure_errors=args.exclude_infrastructure_errors,
+    ))
     return 0
 
 

--- a/tests/eval/run_eval.py
+++ b/tests/eval/run_eval.py
@@ -37,6 +37,7 @@ import math
 import os
 import shutil
 import sys
+import threading
 import time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -120,6 +121,17 @@ AUX_MODEL = os.getenv(
 # variance (model sampling, Ollama warmup) from flipping the gate red.
 BASELINE_MARGIN = 0.05
 
+# Wall-clock ceiling on a single generation -- one model x one case call in
+# phase 2 -- covering the whole attempt, any internal HTTP retry included
+# (issue #229). Measured 2026-09-11 on 289 generations from a real campaign:
+# the 255 factual ones cluster at median 6.8s, max 10.9s, while the 34
+# study_* ones alone cost ~90 minutes, one of them (ricci-study-summary-es)
+# 26 minutes on its own. 180s is ~16x both the factual median and the factual
+# max -- generous for a legitimate long summary, still a real ceiling on the
+# pathological case. Configurable so this default is not the only way to
+# change it.
+GENERATION_BUDGET_SECONDS = int(os.getenv("EVAL_GENERATION_BUDGET_SECONDS", "180"))
+
 # Case types decided entirely by retrieval: they skip generation in
 # run_all_cases (a pass says a fragment of the right kind was surfaced, not
 # that any answer used it) and are reported in their own build_summary bucket,
@@ -134,6 +146,18 @@ class EvalSetupError(RuntimeError):
 
     Caught in main() and printed as a clean actionable message -- this is a
     self-sufficiency failure, not a bug, so it does not need a traceback.
+    """
+
+
+class GenerationBudgetExceeded(Exception):
+    """Raised when one generation call runs past GENERATION_BUDGET_SECONDS.
+
+    Deliberately not an EvalSetupError or anything caught as
+    infrastructure_error (issue #229): the model was reachable and it was
+    generating -- it simply did not stop in time, which is a property of
+    that generation, not evidence the run measured nothing. Grading it as a
+    plain FAIL would lose that distinction just as badly in the other
+    direction, so callers give it its own record field instead.
     """
 
 
@@ -629,6 +653,60 @@ def _decoding_metrics(stats: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
+# GENERATION BUDGET (issue #229)
+
+
+def _run_with_budget(fn, *, budget_seconds: float) -> Any:
+    """Call ``fn()`` on a daemon thread, bounded by ``budget_seconds`` wall clock.
+
+    Used to bound run_factual_case's and run_study_case's one call to the
+    model under test. ``fn`` runs as a single opaque unit, so an adapter that
+    retries internally (OllamaChatModel.stream's 5xx retry, generate_retries
+    in rag/chat_pdfs.py) is still bounded by one wall-clock ceiling rather
+    than multiplied by however many attempts it makes -- the alternative
+    would have been shortening the HTTP timeout instead, which retries would
+    have multiplied by generate_retries (2).
+
+    Args:
+        fn: Zero-argument callable; wrap the real call in a lambda/closure.
+        budget_seconds: Seconds to wait before giving up on ``fn``.
+
+    Returns:
+        Whatever ``fn()`` returned, if it returned within the budget.
+
+    Raises:
+        GenerationBudgetExceeded: ``fn`` was still running when the budget
+            expired.
+        BaseException: Whatever ``fn()`` raised, if it raised within the
+            budget -- re-raised as-is so callers keep classifying real
+            failures (a dead Ollama, a malformed artifact) exactly as before.
+    """
+    box: Dict[str, Any] = {}
+
+    def _target() -> None:
+        try:
+            box["result"] = fn()
+        except BaseException as exc:  # noqa: BLE001 - forwarded to the caller's thread
+            box["exc"] = exc
+
+    # Not cancelled on timeout -- Python cannot interrupt a blocking socket
+    # read, so an abandoned call may keep running against Ollama after this
+    # function returns. Daemonized so that residual call cannot also block
+    # interpreter shutdown; the harness accepts the leftover GPU cost of one
+    # orphaned call as the trade-off for the run itself staying bounded and
+    # able to move on to the next case.
+    thread = threading.Thread(target=_target, daemon=True)
+    thread.start()
+    thread.join(timeout=budget_seconds)
+    if thread.is_alive():
+        raise GenerationBudgetExceeded(
+            f"generation exceeded the {budget_seconds:.0f}s budget"
+        )
+    if "exc" in box:
+        raise box["exc"]
+    return box["result"]
+
+
 # STUDY ARTIFACTS (issue #140)
 
 # Study reads a whole document, not a query's top-k, so these cases take a
@@ -687,7 +765,15 @@ def run_study_case(
 
     for model in models:
         t0 = time.perf_counter()
-        try:
+
+        def _generate() -> Dict[str, Any]:
+            # Bound as one call for the budget below (issue #229) -- config
+            # and fragment conversion are local and instant, only
+            # study.summarize/outline/quiz talks to Ollama, but wrapping the
+            # setup too keeps this a single opaque unit like run_factual_case's.
+            # Reading `model`/`case`/`fragments` from the loop is safe despite
+            # the closure: _run_with_budget joins before this loop advances,
+            # so the values cannot change out from under an in-flight call.
             config = wiring.app_config_from_runtime().with_overrides(
                 **{"models.rag": model}
             )
@@ -704,51 +790,78 @@ def run_study_case(
                     lang_label = "English"
 
             if case["case_type"] == "study_summary":
-                artifact = summary_to_dict(
+                return summary_to_dict(
                     study.summarize(domain_fragments, config, language=lang_label)
                 )
             elif case["case_type"] == "study_outline":
-                artifact = outline_to_dict(
+                return outline_to_dict(
                     study.outline(domain_fragments, config, language=lang_label)
                 )
-            else:
-                artifact = quiz_to_dict(
-                    study.quiz(
-                        domain_fragments,
-                        config,
-                        language=lang_label,
-                        question_count=int(case.get("question_count", 5)),
-                    )
+            return quiz_to_dict(
+                study.quiz(
+                    domain_fragments,
+                    config,
+                    language=lang_label,
+                    question_count=int(case.get("question_count", 5)),
                 )
+            )
+
+        try:
+            artifact = _run_with_budget(
+                _generate, budget_seconds=GENERATION_BUDGET_SECONDS
+            )
+        except GenerationBudgetExceeded as exc:
+            elapsed = retrieval_elapsed + time.perf_counter() - t0
+            records.append({
+                "id": case["id"], "paper": case["paper"], "case_type": case["case_type"],
+                "lang": case["lang"], "model": model, "passed": False,
+                "budget_exceeded": True,
+                "reason": str(exc),
+                "elapsed_seconds": round(elapsed, 2),
+            })
+            print(f"  [BUDGET] {case['id']} / {model} ({elapsed:.1f}s) -- {exc}", flush=True)
+            continue
         except malformed as exc:
+            elapsed = retrieval_elapsed + time.perf_counter() - t0
             records.append({
                 "id": case["id"], "paper": case["paper"], "case_type": case["case_type"],
                 "lang": case["lang"], "model": model, "passed": False,
                 "reason": f"malformed artifact -- {type(exc).__name__}: {str(exc)[:120]}",
-                "elapsed_seconds": round(retrieval_elapsed + time.perf_counter() - t0, 2),
+                "elapsed_seconds": round(elapsed, 2),
             })
-            print(f"  [FAIL] {case['id']} / {model} -- malformed artifact", flush=True)
+            print(
+                f"  [FAIL] {case['id']} / {model} ({elapsed:.1f}s) -- malformed artifact",
+                flush=True,
+            )
             continue
         except Exception as exc:
+            elapsed = retrieval_elapsed + time.perf_counter() - t0
             records.append({
                 "id": case["id"], "paper": case["paper"], "case_type": case["case_type"],
                 "lang": case["lang"], "model": model, "passed": False,
                 "infrastructure_error": True,
                 "reason": f"study failed -- {type(exc).__name__}: {exc}",
-                "elapsed_seconds": round(retrieval_elapsed + time.perf_counter() - t0, 2),
+                "elapsed_seconds": round(elapsed, 2),
             })
-            print(f"  [ERROR] {case['id']} / {model}: {type(exc).__name__}: {exc}", flush=True)
+            print(
+                f"  [ERROR] {case['id']} / {model} ({elapsed:.1f}s): {type(exc).__name__}: {exc}",
+                flush=True,
+            )
             continue
 
+        elapsed = retrieval_elapsed + time.perf_counter() - t0
         result = grade.grade_study(artifact, case)
         records.append({
             "id": case["id"], "paper": case["paper"], "case_type": case["case_type"],
             "lang": case["lang"], "model": model, "passed": result["pass"],
             "reason": result["reason"],
-            "elapsed_seconds": round(retrieval_elapsed + time.perf_counter() - t0, 2),
+            "elapsed_seconds": round(elapsed, 2),
         })
         status = "PASS" if result["pass"] else "FAIL"
-        print(f"  [{status}] {case['id']} / {model} -- {result['reason']}", flush=True)
+        print(
+            f"  [{status}] {case['id']} / {model} ({elapsed:.1f}s) -- {result['reason']}",
+            flush=True,
+        )
 
     return records
 
@@ -788,9 +901,29 @@ def run_factual_case(
         t0 = time.perf_counter()
         gen_stats: Dict[str, Any] = {}
         try:
-            answer = rag.generar_respuesta_silenciosa(
-                case["question"], list(fragments), stats=gen_stats
+            answer = _run_with_budget(
+                lambda: rag.generar_respuesta_silenciosa(
+                    case["question"], list(fragments), stats=gen_stats
+                ),
+                budget_seconds=GENERATION_BUDGET_SECONDS,
             )
+        except GenerationBudgetExceeded as exc:
+            gen_elapsed = time.perf_counter() - t0
+            records.append(
+                {
+                    "id": case["id"],
+                    "paper": case["paper"],
+                    "case_type": case["case_type"],
+                    "lang": case["lang"],
+                    "model": model,
+                    "passed": False,
+                    "budget_exceeded": True,
+                    "reason": str(exc),
+                    "elapsed_seconds": round(retrieval_elapsed + gen_elapsed, 2),
+                }
+            )
+            print(f"  [BUDGET] {case['id']} / {model} ({gen_elapsed:.1f}s) -- {exc}", flush=True)
+            continue
         except Exception as exc:
             # A dead or overloaded Ollama must not be reported as a quality
             # regression: the run is inconclusive, which is a different verdict
@@ -949,6 +1082,55 @@ def _release_gpu_models(*retrievers) -> None:
                     print(f"[phase] {attribute}.{method}() failed, continuing: {exc}", flush=True)
 
 
+class _RecordSink(list):
+    """A ``list`` that also appends each record to a JSONL file as it lands.
+
+    Issue #219: before this, every record lived only in memory until
+    ``evaluate()``'s single ``report_path.write_text(...)`` at the very end,
+    so a run killed partway (crash, OOM, power cut, ^C) left nothing on
+    disk -- a multi-hour sweep's measurements gone with it. Subclassing
+    ``list`` instead of threading a callback through every call site means
+    ``run_all_cases``, ``_run_retrieval_for_corpus``, ``run_study_case`` and
+    ``run_factual_case`` keep doing plain ``records.append(...)`` /
+    ``records.extend(...)`` -- this is the one place that knows they should
+    also be durable.
+
+    Each line is flushed and fsynced immediately: the failure mode named in
+    the issue is a power cut, which OS write buffering alone would not
+    survive.
+
+    No header line and no run metadata -- just the records, in the order
+    they were produced. That is enough to know which (case, model) pairs
+    already ran; the operator already knows which run this belongs to, since
+    they are the one who started it. ``sink_path`` is ``None`` when the
+    caller has no on-disk artifact at all (``write_report=False``), in which
+    case this behaves like a plain list.
+    """
+
+    def __init__(self, sink_path: Optional[Path] = None):
+        super().__init__()
+        self._sink_path = sink_path
+
+    def append(self, record: Dict[str, Any]) -> None:
+        super().append(record)
+        self._write(record)
+
+    def extend(self, records: Iterable[Dict[str, Any]]) -> None:
+        records = list(records)
+        super().extend(records)
+        for record in records:
+            self._write(record)
+
+    def _write(self, record: Dict[str, Any]) -> None:
+        if self._sink_path is None:
+            return
+        with self._sink_path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(record, ensure_ascii=False))
+            f.write("\n")
+            f.flush()
+            os.fsync(f.fileno())
+
+
 def run_all_cases(
     rag,
     cases: Sequence[Dict[str, Any]],
@@ -961,6 +1143,7 @@ def run_all_cases(
     stack_dev=None,
     stack_blind=None,
     extra_corpora: Sequence[tuple] = (),
+    partial_sink: Optional[Path] = None,
 ) -> List[Dict[str, Any]]:
     """Run every gold case via ``Retrieve``, retrieving everything before
     generating anything.
@@ -976,8 +1159,16 @@ def run_all_cases(
     The cost is memory: every case's retrieved fragments are held until the
     generation phase. At 51 cases and a handful of fragments each, that is
     kilobytes.
+
+    Args:
+        partial_sink: When given, every record (both phases) is appended to
+            this path as JSONL as soon as it is produced, so a run that dies
+            partway still leaves its already-computed records on disk (issue
+            #219). ``None`` (the default) keeps this in-memory only, which
+            every caller that predates #219 -- and every test that stubs
+            this function out entirely -- still gets.
     """
-    records: List[Dict[str, Any]] = []
+    records: List[Dict[str, Any]] = _RecordSink(partial_sink)
     pending: List[Dict[str, Any]] = []
 
     print("[phase 1/2] retrieval for every case (embedder + reranker on GPU)", flush=True)
@@ -1377,6 +1568,10 @@ def _run_conditions(
         # having to read the pipeline source to find out.
         "seed": None,
         "keep_alive_seconds": int(_EVAL_GENERATION_KEEP_ALIVE_SECONDS),
+        # In effect for this run (issue #229) -- without it, two runs with a
+        # different budget are indistinguishable in the artifact, the same
+        # gap #222 closed for keep_alive_seconds above.
+        "generation_budget_seconds": GENERATION_BUDGET_SECONDS,
     }
 
 
@@ -1775,6 +1970,19 @@ def evaluate(
             required_models.add(chat_override)
     stack_slug = "mineru-jina_clip-faiss"
 
+    # Computed before any case runs, so phase 1/2 can stream records to disk
+    # as they are produced (issue #219) -- the final report_path is still
+    # only written once, at the end, on success; this is its own timestamp
+    # (run start, not run end) since the two files are never meant to coexist
+    # for long: the partial is removed the moment the final report lands.
+    # None when write_report is False, matching that mode's existing
+    # contract of leaving nothing on disk at all.
+    partial_path: Optional[Path] = None
+    if write_report:
+        RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+        partial_timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        partial_path = RESULTS_DIR / f"{partial_timestamp}_{stack_slug}.partial.jsonl"
+
     stacks_to_close = []
     config_effective: Dict[str, Any] = {"dev": None, "blind": None}
     try:
@@ -1902,6 +2110,7 @@ def evaluate(
                     evidence_blind, models,
                     stack_dev=stack_dev, stack_blind=stack_blind,
                     extra_corpora=extra_corpora,
+                    partial_sink=partial_path,
                 )
     finally:
         for stack in stacks_to_close:
@@ -1968,6 +2177,14 @@ def evaluate(
             ),
             encoding="utf-8",
         )
+        # The consolidated report above now holds everything the partial
+        # sink was for -- same records, plus the summary/conditions it could
+        # never have had mid-run. Removing it here, only after a completed
+        # write, is what keeps a leftover .partial.jsonl meaning "this run
+        # never finished" (issue #219): a run that dies never reaches this
+        # line, so its partial survives exactly when it should.
+        if partial_path is not None:
+            partial_path.unlink(missing_ok=True)
 
     print_summary(summary)
     if report_path is not None:

--- a/tests/eval/run_eval.py
+++ b/tests/eval/run_eval.py
@@ -745,6 +745,28 @@ def run_study_case(
     produces is the thing under test, so a model swap has to be visible here
     the same way it is there.
 
+    Loops ``models`` case-major (one case, every model) -- kept for callers
+    that still want that shape (the probe scripts). ``run_all_cases`` instead
+    calls ``_run_study_case_for_model`` directly, model-major (issue #220).
+    """
+    return [
+        _run_study_case_for_model(case, fragments, model, retrieval_elapsed)
+        for model in models
+    ]
+
+
+def _run_study_case_for_model(
+    case: Dict[str, Any],
+    fragments: Sequence[Dict[str, Any]],
+    model: str,
+    retrieval_elapsed: float,
+) -> Dict[str, Any]:
+    """Build and grade one Study artifact for a single model.
+
+    Extracted from ``run_study_case``'s per-model loop body (issue #220) so
+    ``run_all_cases`` can run every pending case for one model before moving
+    to the next, instead of switching models inside a per-case loop.
+
     A ``Malformed*Error`` is a FAIL, not an ``infrastructure_error``. The model
     was reachable and answered; it answered in a shape the parse refuses, which
     is a quality result about that model and belongs in its score.
@@ -761,109 +783,103 @@ def run_study_case(
     from rag.engine import wiring
 
     malformed = (MalformedSummaryError, MalformedOutlineError, MalformedQuizError)
-    records: List[Dict[str, Any]] = []
 
-    for model in models:
-        t0 = time.perf_counter()
+    t0 = time.perf_counter()
 
-        def _generate() -> Dict[str, Any]:
-            # Bound as one call for the budget below (issue #229) -- config
-            # and fragment conversion are local and instant, only
-            # study.summarize/outline/quiz talks to Ollama, but wrapping the
-            # setup too keeps this a single opaque unit like run_factual_case's.
-            # Reading `model`/`case`/`fragments` from the loop is safe despite
-            # the closure: _run_with_budget joins before this loop advances,
-            # so the values cannot change out from under an in-flight call.
-            config = wiring.app_config_from_runtime().with_overrides(
-                **{"models.rag": model}
-            )
-            domain_fragments = [wiring.fragment_from_dict(f) for f in fragments]
-            study = Study(wiring.rag_chat_model(config))
-            lang_label = case.get("language")
-            if not lang_label:
-                lang = case.get("lang")
-                if lang == "es":
-                    lang_label = "Castellano"
-                elif lang == "ca":
-                    lang_label = "Valencià"
-                elif lang == "en":
-                    lang_label = "English"
+    def _generate() -> Dict[str, Any]:
+        # Bound as one call for the budget below (issue #229) -- config
+        # and fragment conversion are local and instant, only
+        # study.summarize/outline/quiz talks to Ollama, but wrapping the
+        # setup too keeps this a single opaque unit like run_factual_case's.
+        config = wiring.app_config_from_runtime().with_overrides(
+            **{"models.rag": model}
+        )
+        domain_fragments = [wiring.fragment_from_dict(f) for f in fragments]
+        study = Study(wiring.rag_chat_model(config))
+        lang_label = case.get("language")
+        if not lang_label:
+            lang = case.get("lang")
+            if lang == "es":
+                lang_label = "Castellano"
+            elif lang == "ca":
+                lang_label = "Valencià"
+            elif lang == "en":
+                lang_label = "English"
 
-            if case["case_type"] == "study_summary":
-                return summary_to_dict(
-                    study.summarize(domain_fragments, config, language=lang_label)
-                )
-            elif case["case_type"] == "study_outline":
-                return outline_to_dict(
-                    study.outline(domain_fragments, config, language=lang_label)
-                )
-            return quiz_to_dict(
-                study.quiz(
-                    domain_fragments,
-                    config,
-                    language=lang_label,
-                    question_count=int(case.get("question_count", 5)),
-                )
+        if case["case_type"] == "study_summary":
+            return summary_to_dict(
+                study.summarize(domain_fragments, config, language=lang_label)
             )
-
-        try:
-            artifact = _run_with_budget(
-                _generate, budget_seconds=GENERATION_BUDGET_SECONDS
+        elif case["case_type"] == "study_outline":
+            return outline_to_dict(
+                study.outline(domain_fragments, config, language=lang_label)
             )
-        except GenerationBudgetExceeded as exc:
-            elapsed = retrieval_elapsed + time.perf_counter() - t0
-            records.append({
-                "id": case["id"], "paper": case["paper"], "case_type": case["case_type"],
-                "lang": case["lang"], "model": model, "passed": False,
-                "budget_exceeded": True,
-                "reason": str(exc),
-                "elapsed_seconds": round(elapsed, 2),
-            })
-            print(f"  [BUDGET] {case['id']} / {model} ({elapsed:.1f}s) -- {exc}", flush=True)
-            continue
-        except malformed as exc:
-            elapsed = retrieval_elapsed + time.perf_counter() - t0
-            records.append({
-                "id": case["id"], "paper": case["paper"], "case_type": case["case_type"],
-                "lang": case["lang"], "model": model, "passed": False,
-                "reason": f"malformed artifact -- {type(exc).__name__}: {str(exc)[:120]}",
-                "elapsed_seconds": round(elapsed, 2),
-            })
-            print(
-                f"  [FAIL] {case['id']} / {model} ({elapsed:.1f}s) -- malformed artifact",
-                flush=True,
+        return quiz_to_dict(
+            study.quiz(
+                domain_fragments,
+                config,
+                language=lang_label,
+                question_count=int(case.get("question_count", 5)),
             )
-            continue
-        except Exception as exc:
-            elapsed = retrieval_elapsed + time.perf_counter() - t0
-            records.append({
-                "id": case["id"], "paper": case["paper"], "case_type": case["case_type"],
-                "lang": case["lang"], "model": model, "passed": False,
-                "infrastructure_error": True,
-                "reason": f"study failed -- {type(exc).__name__}: {exc}",
-                "elapsed_seconds": round(elapsed, 2),
-            })
-            print(
-                f"  [ERROR] {case['id']} / {model} ({elapsed:.1f}s): {type(exc).__name__}: {exc}",
-                flush=True,
-            )
-            continue
-
-        elapsed = retrieval_elapsed + time.perf_counter() - t0
-        result = grade.grade_study(artifact, case)
-        records.append({
-            "id": case["id"], "paper": case["paper"], "case_type": case["case_type"],
-            "lang": case["lang"], "model": model, "passed": result["pass"],
-            "reason": result["reason"],
-            "elapsed_seconds": round(elapsed, 2),
-        })
-        status = "PASS" if result["pass"] else "FAIL"
-        print(
-            f"  [{status}] {case['id']} / {model} ({elapsed:.1f}s) -- {result['reason']}",
-            flush=True,
         )
 
-    return records
+    try:
+        artifact = _run_with_budget(
+            _generate, budget_seconds=GENERATION_BUDGET_SECONDS
+        )
+    except GenerationBudgetExceeded as exc:
+        elapsed = retrieval_elapsed + time.perf_counter() - t0
+        record = {
+            "id": case["id"], "paper": case["paper"], "case_type": case["case_type"],
+            "lang": case["lang"], "model": model, "passed": False,
+            "budget_exceeded": True,
+            "reason": str(exc),
+            "elapsed_seconds": round(elapsed, 2),
+        }
+        print(f"  [BUDGET] {case['id']} / {model} ({elapsed:.1f}s) -- {exc}", flush=True)
+        return record
+    except malformed as exc:
+        elapsed = retrieval_elapsed + time.perf_counter() - t0
+        record = {
+            "id": case["id"], "paper": case["paper"], "case_type": case["case_type"],
+            "lang": case["lang"], "model": model, "passed": False,
+            "reason": f"malformed artifact -- {type(exc).__name__}: {str(exc)[:120]}",
+            "elapsed_seconds": round(elapsed, 2),
+        }
+        print(
+            f"  [FAIL] {case['id']} / {model} ({elapsed:.1f}s) -- malformed artifact",
+            flush=True,
+        )
+        return record
+    except Exception as exc:
+        elapsed = retrieval_elapsed + time.perf_counter() - t0
+        record = {
+            "id": case["id"], "paper": case["paper"], "case_type": case["case_type"],
+            "lang": case["lang"], "model": model, "passed": False,
+            "infrastructure_error": True,
+            "reason": f"study failed -- {type(exc).__name__}: {exc}",
+            "elapsed_seconds": round(elapsed, 2),
+        }
+        print(
+            f"  [ERROR] {case['id']} / {model} ({elapsed:.1f}s): {type(exc).__name__}: {exc}",
+            flush=True,
+        )
+        return record
+
+    elapsed = retrieval_elapsed + time.perf_counter() - t0
+    result = grade.grade_study(artifact, case)
+    record = {
+        "id": case["id"], "paper": case["paper"], "case_type": case["case_type"],
+        "lang": case["lang"], "model": model, "passed": result["pass"],
+        "reason": result["reason"],
+        "elapsed_seconds": round(elapsed, 2),
+    }
+    status = "PASS" if result["pass"] else "FAIL"
+    print(
+        f"  [{status}] {case['id']} / {model} ({elapsed:.1f}s) -- {result['reason']}",
+        flush=True,
+    )
+    return record
 
 
 def run_factual_case(
@@ -879,100 +895,126 @@ def run_factual_case(
     ``preparar_fragmentos_para_generacion`` does not depend on the generator,
     only on retrieval + reranking, so re-running it per model would be pure
     waste (and, more importantly, would not exercise anything different).
+
+    Loops ``models`` case-major (one case, every model), setting the "rag"
+    role before each generation call -- kept for callers that still want that
+    shape (the probe scripts). ``run_all_cases`` instead calls
+    ``_run_factual_case_for_model`` directly, model-major (issue #220), and
+    sets the role once per model rather than once per (case, model) pair.
     """
     if not fragments:
         return [
-            {
-                "id": case["id"],
-                "paper": case["paper"],
-                "case_type": case["case_type"],
-                "lang": case["lang"],
-                "model": model,
-                "passed": False,
-                "reason": "no fragments retrieved",
-                "elapsed_seconds": round(retrieval_elapsed, 2),
-            }
+            _run_factual_case_for_model(rag, case, fragments, model, retrieval_elapsed)
             for model in models
         ]
 
     records = []
     for model in models:
         rag.set_model_roles_runtime({"rag": model})
-        t0 = time.perf_counter()
-        gen_stats: Dict[str, Any] = {}
-        try:
-            answer = _run_with_budget(
-                lambda: rag.generar_respuesta_silenciosa(
-                    case["question"], list(fragments), stats=gen_stats
-                ),
-                budget_seconds=GENERATION_BUDGET_SECONDS,
-            )
-        except GenerationBudgetExceeded as exc:
-            gen_elapsed = time.perf_counter() - t0
-            records.append(
-                {
-                    "id": case["id"],
-                    "paper": case["paper"],
-                    "case_type": case["case_type"],
-                    "lang": case["lang"],
-                    "model": model,
-                    "passed": False,
-                    "budget_exceeded": True,
-                    "reason": str(exc),
-                    "elapsed_seconds": round(retrieval_elapsed + gen_elapsed, 2),
-                }
-            )
-            print(f"  [BUDGET] {case['id']} / {model} ({gen_elapsed:.1f}s) -- {exc}", flush=True)
-            continue
-        except Exception as exc:
-            # A dead or overloaded Ollama must not be reported as a quality
-            # regression: the run is inconclusive, which is a different verdict
-            # from "the system got worse". Marked as an infrastructure error so
-            # the gate can refuse to compare against the baseline at all.
-            gen_elapsed = time.perf_counter() - t0
-            records.append(
-                {
-                    "id": case["id"],
-                    "paper": case["paper"],
-                    "case_type": case["case_type"],
-                    "lang": case["lang"],
-                    "model": model,
-                    "passed": False,
-                    "infrastructure_error": True,
-                    "reason": f"{type(exc).__name__}: {exc}",
-                    "elapsed_seconds": round(retrieval_elapsed + gen_elapsed, 2),
-                }
-            )
-            print(f"  [ERROR] {case['id']} / {model} -- {type(exc).__name__}: {exc}", flush=True)
-            continue
+        records.append(
+            _run_factual_case_for_model(rag, case, fragments, model, retrieval_elapsed)
+        )
+    return records
+
+
+def _run_factual_case_for_model(
+    rag,
+    case: Dict[str, Any],
+    fragments: Sequence[Dict[str, Any]],
+    model: str,
+    retrieval_elapsed: float,
+) -> Dict[str, Any]:
+    """Generate and grade one factual_number/factual_concept answer for a
+    single already-selected model.
+
+    Extracted from ``run_factual_case``'s per-model loop body (issue #220).
+    Does not touch the "rag" role itself -- the caller sets it (once per
+    model in ``run_all_cases``'s model-major loop, or once per (case, model)
+    pair in ``run_factual_case``'s own case-major loop). The generation
+    budget (issue #229) is applied here, so both callers get it.
+    """
+    if not fragments:
+        return {
+            "id": case["id"],
+            "paper": case["paper"],
+            "case_type": case["case_type"],
+            "lang": case["lang"],
+            "model": model,
+            "passed": False,
+            "reason": "no fragments retrieved",
+            "elapsed_seconds": round(retrieval_elapsed, 2),
+        }
+
+    t0 = time.perf_counter()
+    gen_stats: Dict[str, Any] = {}
+    try:
+        answer = _run_with_budget(
+            lambda: rag.generar_respuesta_silenciosa(
+                case["question"], list(fragments), stats=gen_stats
+            ),
+            budget_seconds=GENERATION_BUDGET_SECONDS,
+        )
+    except GenerationBudgetExceeded as exc:
         gen_elapsed = time.perf_counter() - t0
-        result = grade.grade_answer(answer, case)
         record = {
             "id": case["id"],
             "paper": case["paper"],
             "case_type": case["case_type"],
             "lang": case["lang"],
             "model": model,
-            "passed": result["pass"],
-            "reason": result["reason"],
+            "passed": False,
+            "budget_exceeded": True,
+            "reason": str(exc),
             "elapsed_seconds": round(retrieval_elapsed + gen_elapsed, 2),
-            # Generation only, so models are comparable. elapsed_seconds
-            # includes the retrieval this case shares across every model, and
-            # on this corpus retrieval dominates it -- comparing generators by
-            # that number mostly compares how busy the card was.
-            "generation_seconds": round(gen_elapsed, 2),
-            **_decoding_metrics(gen_stats),
         }
-        if not result["pass"]:
-            record["answer"] = answer
-            record["retrieved"] = _fragment_diag(fragments)
-        records.append(record)
-        status = "PASS" if result["pass"] else "FAIL"
-        print(
-            f"  [{status}] {case['id']} / {model} ({gen_elapsed:.1f}s) -- {result['reason']}",
-            flush=True,
-        )
-    return records
+        print(f"  [BUDGET] {case['id']} / {model} ({gen_elapsed:.1f}s) -- {exc}", flush=True)
+        return record
+    except Exception as exc:
+        # A dead or overloaded Ollama must not be reported as a quality
+        # regression: the run is inconclusive, which is a different verdict
+        # from "the system got worse". Marked as an infrastructure error so
+        # the gate can refuse to compare against the baseline at all.
+        gen_elapsed = time.perf_counter() - t0
+        record = {
+            "id": case["id"],
+            "paper": case["paper"],
+            "case_type": case["case_type"],
+            "lang": case["lang"],
+            "model": model,
+            "passed": False,
+            "infrastructure_error": True,
+            "reason": f"{type(exc).__name__}: {exc}",
+            "elapsed_seconds": round(retrieval_elapsed + gen_elapsed, 2),
+        }
+        print(f"  [ERROR] {case['id']} / {model} -- {type(exc).__name__}: {exc}", flush=True)
+        return record
+    gen_elapsed = time.perf_counter() - t0
+    result = grade.grade_answer(answer, case)
+    record = {
+        "id": case["id"],
+        "paper": case["paper"],
+        "case_type": case["case_type"],
+        "lang": case["lang"],
+        "model": model,
+        "passed": result["pass"],
+        "reason": result["reason"],
+        "elapsed_seconds": round(retrieval_elapsed + gen_elapsed, 2),
+        # Generation only, so models are comparable. elapsed_seconds
+        # includes the retrieval this case shares across every model, and
+        # on this corpus retrieval dominates it -- comparing generators by
+        # that number mostly compares how busy the card was.
+        "generation_seconds": round(gen_elapsed, 2),
+        **_decoding_metrics(gen_stats),
+    }
+    if not result["pass"]:
+        record["answer"] = answer
+        record["retrieved"] = _fragment_diag(fragments)
+    status = "PASS" if result["pass"] else "FAIL"
+    print(
+        f"  [{status}] {case['id']} / {model} ({gen_elapsed:.1f}s) -- {result['reason']}",
+        flush=True,
+    )
+    return record
 
 
 # Measured in issue #27 (2026-07-29): with the product default KEEP_ALIVE=0,
@@ -1207,15 +1249,34 @@ def run_all_cases(
 
     print(f"\n[phase 2/2] generation for {len(pending)} case(s) (Ollama alone on GPU)", flush=True)
     with _generation_keep_alive(set(models) | {AUX_MODEL}):
-        for item in pending:
-            if item["case"]["case_type"] in _STUDY_CASE_TYPES:
-                records.extend(
-                    run_study_case(item["case"], item["fragments"], models, item["elapsed"])
-                )
-            else:
-                records.extend(
-                    run_factual_case(rag, item["case"], item["fragments"], models, item["elapsed"])
-                )
+        # Model-major, case-minor (issue #220): this 8 GB card holds one
+        # generator at a time, so switching models inside the case loop
+        # reloaded it len(pending) x len(models) times where len(models)
+        # loads are enough -- the same reasoning phase 1 already applied to
+        # corpora (issue #123, see the comment above it). Retrieval was
+        # already computed once and is shared via `pending`, so every model
+        # still sees identical fragments; only execution order changes.
+        #
+        # Each record still lands in `records` the moment it exists, so the
+        # partial artifact (issue #219) keeps its guarantee under the new
+        # order; only the in-memory tail is regrouped afterwards.
+        first_generation = len(records)
+        for model in models:
+            rag.set_model_roles_runtime({"rag": model})
+            for item in pending:
+                if item["case"]["case_type"] in _STUDY_CASE_TYPES:
+                    records.append(
+                        _run_study_case_for_model(
+                            item["case"], item["fragments"], model, item["elapsed"]
+                        )
+                    )
+                else:
+                    records.append(
+                        _run_factual_case_for_model(
+                            rag, item["case"], item["fragments"], model, item["elapsed"]
+                        )
+                    )
+        _restore_generation_order(records, cases, start=first_generation)
     return records
 
 
@@ -1231,6 +1292,31 @@ def _restore_case_order(records, pending, cases) -> None:
     position = {case["id"]: index for index, case in enumerate(cases)}
     records.sort(key=lambda record: position.get(record["id"], len(position)))
     pending.sort(key=lambda item: position.get(item["case"]["id"], len(position)))
+
+
+def _restore_generation_order(records, cases, *, start: int = 0) -> None:
+    """Sort phase 2's records, ``records[start:]``, back into the order
+    ``cases`` came in.
+
+    Phase 2 now runs model-major, case-minor (issue #220), so its records
+    arrive grouped by model rather than by case. ``sorted`` is stable, and
+    within a case each model contributes exactly one record, appended while
+    iterating ``models`` in the caller's order -- so this single sort by case
+    position also restores the original model order inside each case, making
+    the result identical to what the previous case-major loop wrote. Same
+    principle as ``_restore_case_order`` (issue #123): execution order
+    changes, result order does not.
+
+    Only the tail from ``start`` is touched: phase 1's records already sit
+    in case order ahead of it, and the previous loop appended phase 2 after
+    them rather than interleaving. Slice assignment goes through
+    ``list.__setitem__``, not ``_RecordSink.append``/``extend``, so nothing
+    is written to the partial artifact twice.
+    """
+    position = {case["id"]: index for index, case in enumerate(cases)}
+    records[start:] = sorted(
+        records[start:], key=lambda record: position.get(record["id"], len(position))
+    )
 
 
 def _run_retrieval_for_corpus(cases, retrieve, evidence, records, pending, store=None) -> None:

--- a/tests/eval/run_eval.py
+++ b/tests/eval/run_eval.py
@@ -1214,6 +1214,172 @@ def _update_baseline(pass_rate: float) -> None:
     )
 
 
+# RUN CONDITIONS (issue #222)
+
+# Distribution name importlib.metadata.version() takes for each package this
+# run cares about -- the PyPI name, not always the import name (faiss ships as
+# faiss-cpu; see rag/requirements.txt). MinerU normally lives in the isolated
+# .venv-mineru, not in the interpreter running this script, so reading back
+# None for it there is the degrade this dict exists to make legible, not a
+# bug in the lookup.
+_VERSION_PACKAGES = {
+    "mineru": "mineru",
+    "sentence_transformers": "sentence-transformers",
+    "torch": "torch",
+    "transformers": "transformers",
+    "faiss": "faiss-cpu",
+}
+
+
+def _package_version(distribution: str) -> Optional[str]:
+    """Installed version of a PyPI distribution, or None if it is not installed.
+
+    Reads package metadata only -- never imports the package, so this is
+    cheap even for torch and never triggers a CUDA init.
+    """
+    import importlib.metadata
+
+    try:
+        return importlib.metadata.version(distribution)
+    except importlib.metadata.PackageNotFoundError:
+        return None
+
+
+def _ollama_server_version() -> Optional[str]:
+    """Ollama server version, via the same /api/ endpoint family preflight uses.
+
+    Best-effort, like _release_ollama_models: this runs after the pipeline has
+    already produced real pass/fail results, so a version lookup failing must
+    not cost the run its report.
+    """
+    import requests
+
+    try:
+        response = requests.get(f"{OLLAMA_BASE_URL}/api/version", timeout=5)
+        response.raise_for_status()
+        return response.json().get("version")
+    except Exception:  # noqa: BLE001 - best-effort, see docstring
+        return None
+
+
+def _gpu_info() -> Dict[str, Optional[Any]]:
+    """GPU name and total VRAM, read the cheapest way available.
+
+    Prefers torch.cuda when torch is already imported -- true for a real run
+    by the time this executes, since retrieval/generation already pulled it
+    in -- so this never pays torch's own import cost. Falls back to
+    nvidia-smi when torch was never loaded (e.g. a case_ids subset with
+    nothing to index). Either path degrades to None rather than raising.
+    """
+    torch = sys.modules.get("torch")
+    if torch is not None:
+        try:
+            if torch.cuda.is_available():
+                props = torch.cuda.get_device_properties(0)
+                return {
+                    "name": props.name,
+                    "vram_total_mib": round(props.total_memory / 2**20),
+                }
+        except Exception:  # noqa: BLE001 - best-effort, see docstring
+            pass
+        return {"name": None, "vram_total_mib": None}
+
+    import subprocess
+
+    try:
+        output = subprocess.run(
+            ["nvidia-smi", "--query-gpu=name,memory.total", "--format=csv,noheader,nounits"],
+            capture_output=True, text=True, timeout=5, check=True,
+        ).stdout.strip().splitlines()[0]
+        name, vram = (part.strip() for part in output.split(","))
+        return {"name": name, "vram_total_mib": int(vram)}
+    except Exception:  # noqa: BLE001 - best-effort, see docstring
+        return {"name": None, "vram_total_mib": None}
+
+
+def _git_info() -> Dict[str, Optional[Any]]:
+    """Short HEAD hash and whether the working tree is dirty.
+
+    Two separate subprocess calls rather than one combined format, so a
+    shallow clone or detached HEAD that breaks the dirty check does not also
+    lose the commit hash.
+    """
+    import subprocess
+
+    def _git(args: List[str]) -> str:
+        return subprocess.run(
+            ["git", *args], cwd=REPO_ROOT, capture_output=True, text=True,
+            timeout=5, check=True,
+        ).stdout.strip()
+
+    try:
+        commit_hash = _git(["rev-parse", "--short", "HEAD"])
+    except Exception:  # noqa: BLE001 - best-effort, see docstring
+        return {"hash": None, "dirty": None}
+
+    try:
+        dirty: Optional[bool] = bool(_git(["status", "--porcelain"]))
+    except Exception:  # noqa: BLE001 - best-effort, see docstring
+        dirty = None
+
+    return {"hash": commit_hash, "dirty": dirty}
+
+
+def _gold_cases_sha256() -> Optional[str]:
+    """SHA-256 of gold_cases.jsonl -- an edit that keeps the case count changes this."""
+    import hashlib
+
+    try:
+        return hashlib.sha256(GOLD_FILE.read_bytes()).hexdigest()
+    except OSError:
+        return None
+
+
+def _run_conditions(
+    config_effective: Dict[str, Any],
+    sampling: Dict[str, Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Everything that decides what a pass rate means, gathered in one block.
+
+    Additive to the artifact: none of this feeds grading, it only lets two
+    runs that used a different AppConfig, flag, sampling parameter or stack
+    version be told apart after the fact -- which the eight fields the
+    artifact carried before this could not do (issue #222). Every sub-lookup
+    degrades to None on its own instead of raising: the pipeline has already
+    produced real pass/fail results by the time this runs, and losing the
+    report over, say, a missing nvidia-smi would throw those away for
+    nothing.
+
+    Args:
+        config_effective: The per-corpus AppConfig dict evaluate() already
+            builds via dataclasses.asdict() -- its own "config" return value,
+            reused rather than rebuilt so there is exactly one place that
+            turns runtime state into this shape.
+        sampling: Per-role sampling options. Read by the caller from
+            rag.engine.wiring's module constants and passed in rather than
+            imported here, so this function needs no engine import of its
+            own and stays testable with a plain dict.
+
+    Returns:
+        The "conditions" block written into the run artifact.
+    """
+    versions = {key: _package_version(dist) for key, dist in _VERSION_PACKAGES.items()}
+    versions["ollama_server"] = _ollama_server_version()
+    return {
+        "config": config_effective,
+        "versions": versions,
+        "hardware": _gpu_info(),
+        "git_commit": _git_info(),
+        "gold_sha256": _gold_cases_sha256(),
+        "sampling": sampling,
+        # No run has ever pinned a generation seed (issue #223) -- explicit
+        # None so a future reader learns that from the artifact instead of
+        # having to read the pipeline source to find out.
+        "seed": None,
+        "keep_alive_seconds": int(_EVAL_GENERATION_KEEP_ALIVE_SECONDS),
+    }
+
+
 # LIBRARY API
 
 # The dotted AppConfig keys evaluate()'s threaded config_overrides carries end
@@ -1754,6 +1920,17 @@ def evaluate(
         RESULTS_DIR.mkdir(parents=True, exist_ok=True)
         timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
         report_path = RESULTS_DIR / f"{timestamp}_{stack_slug}.json"
+        # rag.engine.wiring is already loaded by this point -- evaluate() has
+        # gone through generation to get here -- so this costs nothing. It
+        # stays deferred rather than a top-level import so run_eval.py keeps
+        # importing with nothing but the standard library when this function
+        # is never called (see e.g. test_preflight_model_tags.py).
+        from rag.engine.wiring import (
+            QUERY_DECOMPOSER_SAMPLING_OPTIONS,
+            RAG_SAMPLING_OPTIONS,
+            RECOMP_SAMPLING_OPTIONS,
+        )
+
         report_path.write_text(
             json.dumps(
                 {
@@ -1769,6 +1946,22 @@ def evaluate(
                     },
                     "summary": summary,
                     "results": records,
+                    # Sibling to "run", not nested inside it (issue #222):
+                    # "run" answers "what happened" (models, counts), this
+                    # answers "under what setup" -- separate questions with
+                    # separate readers. Neither existing reader is touched:
+                    # tools/diagnostics/model_history_row.py only reads
+                    # "results" and "run"/"id", and tests/eval/compare_runs.py
+                    # only reads "results" -- both ignore an unknown sibling
+                    # key by construction.
+                    "conditions": _run_conditions(
+                        config_effective,
+                        sampling={
+                            "rag": dict(RAG_SAMPLING_OPTIONS),
+                            "chat": dict(QUERY_DECOMPOSER_SAMPLING_OPTIONS),
+                            "recomp": dict(RECOMP_SAMPLING_OPTIONS),
+                        },
+                    ),
                 },
                 indent=2,
                 ensure_ascii=False,

--- a/tests/eval/test_compare_runs.py
+++ b/tests/eval/test_compare_runs.py
@@ -109,3 +109,21 @@ def test_rejection_messages_name_the_files_when_labels_are_given():
     b = _report({"x": True})
     with pytest.raises(ValueError, match="runs/2026-01-01.json"):
         compare(a, b, label_a="runs/2026-01-01.json", label_b="runs/2026-01-02.json")
+
+
+def test_an_added_conditions_sibling_key_does_not_break_the_comparison():
+    # Issue #222 adds a top-level "conditions" key next to "run"/"results" --
+    # compare() must keep reading "results" the same way regardless of what
+    # else a real artifact carries.
+    a = _report({"x": True, "y": False})
+    b = _report({"x": True, "y": False})
+    a["conditions"] = {"git_commit": {"hash": "aaa1111", "dirty": False}}
+    b["conditions"] = {"git_commit": {"hash": "bbb2222", "dirty": True}}
+    a["run"] = {"timestamp": "2026-01-01T00:00:00Z"}
+    b["run"] = {"timestamp": "2026-01-02T00:00:00Z"}
+
+    result = compare(a, b)
+
+    assert result["flipped_to_pass"] == []
+    assert result["flipped_to_fail"] == []
+    assert result["stable"] == 2

--- a/tests/eval/test_compare_runs.py
+++ b/tests/eval/test_compare_runs.py
@@ -127,3 +127,60 @@ def test_an_added_conditions_sibling_key_does_not_break_the_comparison():
     assert result["flipped_to_pass"] == []
     assert result["flipped_to_fail"] == []
     assert result["stable"] == 2
+
+
+# --exclude-infrastructure-errors (issue #240)
+
+
+def _report_two_models(outcomes):
+    """Like _report, but ``outcomes`` maps "case / model" keys, so a fixture
+    can put an infrastructure error on one model without touching the
+    other's record of the same case."""
+    results = []
+    for key, passed in outcomes.items():
+        case_id, model = key.split(" / ")
+        results.append({"id": case_id, "model": model, "passed": passed})
+    return {"results": results}
+
+
+def test_excluding_infrastructure_errors_drops_the_pair_from_both_sides():
+    # Granite crashing on one study case in run b must not hide the other
+    # model's measurements, and must not count as a flip either: the pair
+    # is removed from a and b alike, and the removal is reported.
+    a = _report_two_models({"x / m1": True, "x / m2": True, "y / m1": False, "y / m2": True})
+    b = _report_two_models({"x / m1": True, "x / m2": True, "y / m1": True, "y / m2": True})
+    b["results"][3]["infrastructure_error"] = True  # y / m2 never ran in b
+    result = compare(a, b, exclude_infrastructure_errors=True)
+    assert result["excluded"] == ["y / m2"]
+    assert result["flipped_to_pass"] == ["y / m1"]
+    assert result["flipped_to_fail"] == []
+    assert result["stable"] == 2
+    # 3 pairs compared, one of them flipped to pass.
+    assert result["pass_rate_delta"] == round(1 / 3, 4)
+
+
+def test_excluding_infrastructure_errors_still_refuses_a_run_that_measured_nothing():
+    # The strict rule stays for the case it was written for: if every pair is
+    # an infrastructure error there is nothing to compare, and "0 unchanged"
+    # would read as a clean result.
+    a = _report({"x": True})
+    b = _report({"x": True})
+    b["results"][0]["infrastructure_error"] = True
+    with pytest.raises(ValueError, match="no comparable"):
+        compare(a, b, exclude_infrastructure_errors=True)
+
+
+def test_the_default_still_rejects_an_inconclusive_run():
+    # Opt-in only: the gate's own comparison keeps refusing a report with
+    # infrastructure errors unless the caller says otherwise.
+    a = _report({"x": True, "y": True})
+    b = _report({"x": True, "y": True})
+    b["results"][1]["infrastructure_error"] = True
+    with pytest.raises(ValueError, match="inconclusive"):
+        compare(a, b)
+    assert compare(a, b, exclude_infrastructure_errors=True)["excluded"] == ["y / m"]
+
+
+def test_without_exclusions_the_result_carries_an_empty_excluded_list():
+    report = _report({"a": True})
+    assert compare(report, report)["excluded"] == []

--- a/tests/eval/test_evaluate_library_api.py
+++ b/tests/eval/test_evaluate_library_api.py
@@ -308,6 +308,89 @@ def test_write_report_true_writes_the_expected_json(monkeypatch, tmp_path):
     assert payload["run"]["num_cases"] == 1
 
 
+# PARTIAL ARTIFACT (issue #219)
+#
+# _RecordSink's own behavior (append/extend write JSONL, sort doesn't touch
+# the file, a None path is a no-op) is covered in test_partial_artifact.py,
+# which stays in the dependency-free fast gate. What belongs here instead is
+# evaluate()'s wiring around it: the partial path it computes before
+# run_all_cases starts, and the cleanup once a report is actually written --
+# both need the real evaluate() control flow, which is why these two live
+# next to this file's other evaluate()-level tests rather than there.
+
+
+def _capture_run_all_cases_writing_to_sink(monkeypatch, records, *, then_raise=False):
+    """Replace run_all_cases with a double that writes through the same
+    _RecordSink real run_all_cases would use, so these tests exercise
+    evaluate()'s partial_sink plumbing (not just a stub that ignores it).
+    """
+
+    def _fake(rag, cases, retrieve_dev, retrieve_blind, evidence_dev, evidence_blind,
+              models, *, partial_sink=None, **_stacks):
+        sink = run_eval._RecordSink(partial_sink)
+        sink.extend(records)
+        if then_raise:
+            raise RuntimeError("simulated crash mid-run")
+        return list(sink)
+
+    monkeypatch.setattr(run_eval, "run_all_cases", _fake)
+
+
+def test_a_run_that_dies_mid_generation_leaves_its_records_in_a_partial_file(monkeypatch, tmp_path):
+    monkeypatch.setattr(run_eval, "RESULTS_DIR", tmp_path)
+    _capture_ensure_indexed(monkeypatch, [])
+    # Two records: enough that the whole file is no longer a single JSON
+    # value (json.loads would happily parse one object plus a trailing
+    # newline), which is the point of the assertion below.
+    records = [
+        {"id": _DEV_CASE_ID, "paper": "p", "case_type": "factual_number", "lang": "en",
+         "model": "m", "passed": True, "reason": "stub", "elapsed_seconds": 1.0},
+        {"id": _DEV_CASE_ID, "paper": "p", "case_type": "factual_number", "lang": "en",
+         "model": "m2", "passed": False, "reason": "stub", "elapsed_seconds": 2.0},
+    ]
+    _capture_run_all_cases_writing_to_sink(monkeypatch, records, then_raise=True)
+
+    with pytest.raises(RuntimeError, match="simulated crash mid-run"):
+        evaluate(models=["m"], case_ids=[_DEV_CASE_ID], write_report=True)
+
+    files = list(tmp_path.iterdir())
+    assert len(files) == 1
+    partial = files[0]
+    # Distinguishable from a completed report by construction, not just by
+    # convention: the closure criterion is that nothing can grade this as if
+    # it were the whole set, and a reader that tries what
+    # tools/diagnostics/model_history_row.py and compare_runs.py do --
+    # json.loads the whole file -- gets a parse error, not a plausible-looking
+    # but incomplete artifact.
+    assert partial.suffixes == [".partial", ".jsonl"]
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(partial.read_text(encoding="utf-8"))
+    written = [json.loads(line) for line in partial.read_text(encoding="utf-8").splitlines()]
+    assert written == records
+
+
+def test_a_completed_run_removes_its_partial_file(monkeypatch, tmp_path):
+    monkeypatch.setattr(run_eval, "RESULTS_DIR", tmp_path)
+    _capture_ensure_indexed(monkeypatch, [])
+    records = [
+        {"id": _DEV_CASE_ID, "paper": "p", "case_type": "factual_number", "lang": "en",
+         "model": "m", "passed": True, "reason": "stub", "elapsed_seconds": 1.0},
+    ]
+    _capture_run_all_cases_writing_to_sink(monkeypatch, records)
+
+    result = evaluate(models=["m"], case_ids=[_DEV_CASE_ID], write_report=True)
+
+    # Exactly the final report -- the partial sidecar this run actually wrote
+    # to (unlike test_write_report_true_writes_the_expected_json's stub,
+    # which never touches partial_sink at all) is gone, or a completed run
+    # would leave two files that both look authoritative for the same run.
+    files = list(tmp_path.iterdir())
+    assert len(files) == 1
+    assert files[0] == Path(result["report_path"])
+    payload = json.loads(files[0].read_text(encoding="utf-8"))
+    assert payload["results"] == records
+
+
 def test_write_report_includes_the_conditions_block(monkeypatch, tmp_path):
     """Issue #222: the artifact must record what produced its pass rate, not
     only the pass rate itself."""
@@ -321,10 +404,11 @@ def test_write_report_includes_the_conditions_block(monkeypatch, tmp_path):
     conditions = payload["conditions"]
     assert set(conditions) == {
         "config", "versions", "hardware", "git_commit", "gold_sha256",
-        "sampling", "seed", "keep_alive_seconds",
+        "sampling", "seed", "keep_alive_seconds", "generation_budget_seconds",
     }
     assert conditions["seed"] is None
     assert conditions["keep_alive_seconds"] == int(run_eval._EVAL_GENERATION_KEEP_ALIVE_SECONDS)
+    assert conditions["generation_budget_seconds"] == run_eval.GENERATION_BUDGET_SECONDS
     assert len(conditions["gold_sha256"]) == 64
     # "run" and "summary"/"results" are untouched by the new sibling key --
     # the two existing readers never look past them.

--- a/tests/eval/test_evaluate_library_api.py
+++ b/tests/eval/test_evaluate_library_api.py
@@ -107,6 +107,12 @@ def _stub_pipeline(monkeypatch):
     monkeypatch.setattr(run_eval, "preflight_ollama", lambda *_a, **_kw: None)
     monkeypatch.setattr(run_eval, "stage_blind_papers", lambda cases: {})
     monkeypatch.setattr(run_eval, "verify_all_papers_indexed", lambda *_a, **_kw: None)
+    # write_report=True now also builds the "conditions" block (issue #222),
+    # which otherwise makes a real HTTP call to Ollama and a real nvidia-smi
+    # subprocess call -- neither belongs in a test that doubles the rest of
+    # the pipeline.
+    monkeypatch.setattr(run_eval, "_ollama_server_version", lambda: None)
+    monkeypatch.setattr(run_eval, "_gpu_info", lambda: {"name": None, "vram_total_mib": None})
     previous_roles = rag.chat_pdfs.get_model_roles()
     previous_flags = rag.chat_pdfs.get_pipeline_flags()
     yield
@@ -300,6 +306,79 @@ def test_write_report_true_writes_the_expected_json(monkeypatch, tmp_path):
     assert result["report_path"] == str(files[0])
     payload = json.loads(files[0].read_text(encoding="utf-8"))
     assert payload["run"]["num_cases"] == 1
+
+
+def test_write_report_includes_the_conditions_block(monkeypatch, tmp_path):
+    """Issue #222: the artifact must record what produced its pass rate, not
+    only the pass rate itself."""
+    monkeypatch.setattr(run_eval, "RESULTS_DIR", tmp_path)
+    _capture_ensure_indexed(monkeypatch, [])
+    _capture_run_all_cases(monkeypatch, [])
+
+    result = evaluate(models=["m"], case_ids=[_DEV_CASE_ID], write_report=True)
+
+    payload = json.loads(Path(result["report_path"]).read_text(encoding="utf-8"))
+    conditions = payload["conditions"]
+    assert set(conditions) == {
+        "config", "versions", "hardware", "git_commit", "gold_sha256",
+        "sampling", "seed", "keep_alive_seconds",
+    }
+    assert conditions["seed"] is None
+    assert conditions["keep_alive_seconds"] == int(run_eval._EVAL_GENERATION_KEEP_ALIVE_SECONDS)
+    assert len(conditions["gold_sha256"]) == 64
+    # "run" and "summary"/"results" are untouched by the new sibling key --
+    # the two existing readers never look past them.
+    assert payload["run"]["num_cases"] == 1
+    assert "results" in payload and "summary" in payload
+
+
+def test_conditions_config_is_the_run_s_own_config_not_a_rebuilt_default(monkeypatch, tmp_path):
+    """The block must reuse evaluate()'s own config_effective (already
+    exercised by test_config_overrides_reach_the_appconfig_and_ensure_indexed
+    above), not rebuild a fresh AppConfig -- a second source is exactly the
+    drift issue #222 exists to end."""
+    monkeypatch.setattr(run_eval, "RESULTS_DIR", tmp_path)
+    _capture_ensure_indexed(monkeypatch, [])
+    _capture_run_all_cases(monkeypatch, [])
+    overrides = {"retrieval.top_k_final": 3}
+
+    result = evaluate(
+        models=["m"], case_ids=[_DEV_CASE_ID], config_overrides=overrides, write_report=True
+    )
+
+    payload = json.loads(Path(result["report_path"]).read_text(encoding="utf-8"))
+    assert payload["conditions"]["config"] == result["config"]
+    assert payload["conditions"]["config"]["dev"]["retrieval"]["top_k_final"] == 3
+
+
+def test_conditions_sampling_matches_wiring_s_own_constants(monkeypatch, tmp_path):
+    """Pins the literal values, not just object equality with wiring.py's
+    constants -- a future edit to those constants must show up here, since
+    changing them silently changes what every later run measures (the exact
+    failure mode issue #222 names for the sampling parameters)."""
+    from rag.engine.wiring import (
+        QUERY_DECOMPOSER_SAMPLING_OPTIONS,
+        RAG_SAMPLING_OPTIONS,
+        RECOMP_SAMPLING_OPTIONS,
+    )
+
+    monkeypatch.setattr(run_eval, "RESULTS_DIR", tmp_path)
+    _capture_ensure_indexed(monkeypatch, [])
+    _capture_run_all_cases(monkeypatch, [])
+
+    result = evaluate(models=["m"], case_ids=[_DEV_CASE_ID], write_report=True)
+
+    payload = json.loads(Path(result["report_path"]).read_text(encoding="utf-8"))
+    sampling = payload["conditions"]["sampling"]
+    assert sampling == {
+        "rag": RAG_SAMPLING_OPTIONS,
+        "chat": QUERY_DECOMPOSER_SAMPLING_OPTIONS,
+        "recomp": RECOMP_SAMPLING_OPTIONS,
+    }
+    assert sampling["rag"]["temperature"] == 0.15
+    assert sampling["rag"]["repeat_last_n"] == 64
+    assert sampling["recomp"]["num_predict"] == 1500
+    assert sampling["chat"]["num_predict"] == 400
 
 
 def test_update_baseline_false_leaves_the_baseline_file_byte_identical(monkeypatch, tmp_path):

--- a/tests/eval/test_generation_time_budget.py
+++ b/tests/eval/test_generation_time_budget.py
@@ -1,0 +1,160 @@
+"""Tests for the eval runner's per-generation wall-clock budget (issue #229).
+
+Measured on a real campaign (2026-09-11): the rag generator runs with
+num_predict -1 and nothing else bounded a single case, so one uncooperative
+generation held the run -- and the GPU -- for up to 45 minutes. This budget
+caps a single generation (one model x one case call) instead.
+
+``_run_with_budget`` and ``run_factual_case`` need nothing from ``rag`` at
+import time -- ``run_factual_case`` takes its ``rag`` module as a plain
+argument, so a fake stands in for it here -- which keeps this file collected
+in the dependency-free fast CI gate (tests/conftest.py's heuristic only skips
+a file that imports ``rag`` itself). ``run_study_case``'s equivalent
+coverage lives in test_run_study_case.py instead, because that function
+imports rag.engine.wiring internally and needs the real engine installed.
+"""
+
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import pytest  # noqa: E402
+
+import run_eval  # noqa: E402
+from run_eval import (  # noqa: E402
+    GenerationBudgetExceeded,
+    _run_with_budget,
+    run_factual_case,
+)
+
+
+# _run_with_budget
+
+
+def test_returns_the_result_when_fn_finishes_in_time():
+    assert _run_with_budget(lambda: 42, budget_seconds=5) == 42
+
+
+def test_raises_generation_budget_exceeded_when_fn_overruns():
+    with pytest.raises(GenerationBudgetExceeded):
+        _run_with_budget(lambda: time.sleep(1), budget_seconds=0.05)
+
+
+def test_reraises_fns_own_exception_when_it_fails_within_budget():
+    def _boom():
+        raise ValueError("simulated model failure")
+
+    with pytest.raises(ValueError, match="simulated model failure"):
+        _run_with_budget(_boom, budget_seconds=5)
+
+
+def test_an_overrun_does_not_block_the_caller_past_the_budget():
+    """The abandoned thread is not joined again -- the whole point is that
+    the caller gets its budget back, not the wall-clock time fn actually
+    used."""
+    start = time.perf_counter()
+    with pytest.raises(GenerationBudgetExceeded):
+        _run_with_budget(lambda: time.sleep(2), budget_seconds=0.05)
+    assert time.perf_counter() - start < 1.0
+
+
+# run_factual_case
+
+
+class _FakeRagBudgetExceeded:
+    """generar_respuesta_silenciosa that never returns in time."""
+
+    def set_model_roles_runtime(self, roles):
+        pass
+
+    def generar_respuesta_silenciosa(self, question, fragments, stats=None):
+        time.sleep(1)
+        raise AssertionError("must have been abandoned by the budget")
+
+
+class _FakeRagInfrastructureError:
+    """generar_respuesta_silenciosa that fails fast, not by overrunning."""
+
+    def set_model_roles_runtime(self, roles):
+        pass
+
+    def generar_respuesta_silenciosa(self, question, fragments, stats=None):
+        raise ConnectionError("simulated Ollama unreachable")
+
+
+def _fragment():
+    return {"doc": "text", "metadata": {"source": "p.pdf", "page": 1}}
+
+
+def _case():
+    return {
+        "id": "c1", "paper": "p", "case_type": "factual_number", "lang": "en",
+        "question": "how many?",
+    }
+
+
+def test_a_generation_that_overruns_the_budget_is_marked_budget_exceeded(monkeypatch):
+    monkeypatch.setattr(run_eval, "GENERATION_BUDGET_SECONDS", 0.05)
+
+    records = run_factual_case(
+        _FakeRagBudgetExceeded(), _case(), [_fragment()], ["m"], retrieval_elapsed=0.0
+    )
+
+    assert len(records) == 1
+    record = records[0]
+    assert record["budget_exceeded"] is True
+    assert record["passed"] is False
+    assert "infrastructure_error" not in record
+
+
+def test_a_budget_exceeded_record_is_never_also_an_infrastructure_error(monkeypatch):
+    """The distinction is the point of the issue: infrastructure_error makes
+    the whole run inconclusive against the baseline, budget_exceeded must
+    not."""
+    monkeypatch.setattr(run_eval, "GENERATION_BUDGET_SECONDS", 0.05)
+
+    records = run_factual_case(
+        _FakeRagBudgetExceeded(), _case(), [_fragment()], ["m"], retrieval_elapsed=0.0
+    )
+
+    assert records[0].get("infrastructure_error") is not True
+
+
+def test_a_real_failure_within_budget_is_still_an_infrastructure_error(monkeypatch):
+    """Regression guard for the other direction: a fast failure (dead
+    Ollama) must not start being misreported as budget_exceeded just because
+    the budget machinery now wraps the call."""
+    monkeypatch.setattr(run_eval, "GENERATION_BUDGET_SECONDS", 5)
+
+    records = run_factual_case(
+        _FakeRagInfrastructureError(), _case(), [_fragment()], ["m"], retrieval_elapsed=0.0
+    )
+
+    assert len(records) == 1
+    record = records[0]
+    assert record["infrastructure_error"] is True
+    assert "budget_exceeded" not in record
+
+
+def test_a_generation_within_budget_passes_through_untouched(monkeypatch):
+    """A budget generous enough for a normal answer must not change the
+    non-budget-exceeded outcome (point 5 of the verification plan: the
+    budget must not break the healthy case)."""
+    monkeypatch.setattr(run_eval, "GENERATION_BUDGET_SECONDS", 5)
+
+    class _FakeRagFast:
+        def set_model_roles_runtime(self, roles):
+            pass
+
+        def generar_respuesta_silenciosa(self, question, fragments, stats=None):
+            return "42"
+
+    records = run_factual_case(
+        _FakeRagFast(), _case(), [_fragment()], ["m"], retrieval_elapsed=0.0
+    )
+
+    assert len(records) == 1
+    assert "budget_exceeded" not in records[0]
+    assert "infrastructure_error" not in records[0]

--- a/tests/eval/test_partial_artifact.py
+++ b/tests/eval/test_partial_artifact.py
@@ -1,0 +1,168 @@
+"""Tests for the eval runner's incremental partial artifact (issue #219).
+
+Before this, every record lived only in memory until evaluate()'s single
+``report_path.write_text(...)`` at the very end -- the last full run took 64
+minutes for 156 cases and one model, so a crash, an OOM or a ^C partway
+through a multi-hour sweep left tests/eval/runs/ empty, measurements and
+all. _RecordSink streams each record to a JSONL sidecar as it lands, so a
+killed run still leaves its already-computed records on disk, in a form
+readable independently of the final report.
+
+Pure: no ``rag`` import, no GPU, no Ollama, no network -- _RecordSink is a
+plain list subclass and this exercises run_all_cases's phase 1 (retrieval)
+with the same fakes test_phase1_one_corpus_at_a_time.py uses, so this file
+stays collected in the dependency-free fast CI gate. evaluate()-level
+coverage (a run that dies mid-generation, and cleanup on a completed run)
+lives in test_evaluate_library_api.py instead, next to evaluate()'s other
+tests, which already need the real engine installed.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import pytest  # noqa: E402
+
+import run_eval  # noqa: E402
+from run_eval import _RecordSink  # noqa: E402
+
+
+# _RecordSink
+
+
+def test_a_sink_with_no_path_behaves_like_a_plain_list():
+    sink = _RecordSink(None)
+    sink.append({"id": "a"})
+    sink.extend([{"id": "b"}, {"id": "c"}])
+    assert list(sink) == [{"id": "a"}, {"id": "b"}, {"id": "c"}]
+
+
+def test_append_writes_one_readable_json_line(tmp_path):
+    path = tmp_path / "run.partial.jsonl"
+    sink = _RecordSink(path)
+
+    sink.append({"id": "a", "passed": True})
+
+    lines = path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    assert json.loads(lines[0]) == {"id": "a", "passed": True}
+
+
+def test_extend_writes_one_line_per_record(tmp_path):
+    path = tmp_path / "run.partial.jsonl"
+    sink = _RecordSink(path)
+
+    sink.extend([{"id": "a"}, {"id": "b"}])
+
+    lines = path.read_text(encoding="utf-8").splitlines()
+    assert [json.loads(line) for line in lines] == [{"id": "a"}, {"id": "b"}]
+
+
+def test_append_and_extend_both_land_in_the_same_file_in_order(tmp_path):
+    path = tmp_path / "run.partial.jsonl"
+    sink = _RecordSink(path)
+
+    sink.append({"id": "a"})
+    sink.extend([{"id": "b"}, {"id": "c"}])
+    sink.append({"id": "d"})
+
+    lines = path.read_text(encoding="utf-8").splitlines()
+    assert [json.loads(line)["id"] for line in lines] == ["a", "b", "c", "d"]
+
+
+def test_the_sink_still_carries_every_record_in_memory_too(tmp_path):
+    """Nothing downstream of run_all_cases (build_summary, the final report's
+    "results" list) may lose records just because a sink path was given."""
+    path = tmp_path / "run.partial.jsonl"
+    sink = _RecordSink(path)
+
+    sink.append({"id": "a"})
+    sink.extend([{"id": "b"}])
+
+    assert list(sink) == [{"id": "a"}, {"id": "b"}]
+
+
+def test_sort_reorders_the_in_memory_list_without_touching_the_file(tmp_path):
+    """_restore_case_order sorts run_all_cases's records in place -- the file
+    is an append log of production order, which is fine to leave as-is."""
+    path = tmp_path / "run.partial.jsonl"
+    sink = _RecordSink(path)
+    sink.extend([{"id": "b"}, {"id": "a"}])
+
+    sink.sort(key=lambda r: r["id"])
+
+    assert list(sink) == [{"id": "a"}, {"id": "b"}]
+    lines = path.read_text(encoding="utf-8").splitlines()
+    assert [json.loads(line)["id"] for line in lines] == ["b", "a"]
+
+
+# run_all_cases + partial_sink (phase 1 only -- retrieval-only case types
+# need no Ollama, matching test_phase1_one_corpus_at_a_time.py's fakes)
+
+
+class _FakeResult:
+    fragments = ()
+
+
+class _FakeRetrieve:
+    def run(self, question):
+        return _FakeResult()
+
+
+class _FakeEvidence:
+    def select_evidence(self, fragments):
+        return [], {}
+
+
+def _case(case_id):
+    return {
+        "id": case_id, "paper": "p", "case_type": "figure_retrieval", "lang": "en",
+        "source": "corpus", "question": case_id,
+    }
+
+
+@pytest.fixture(autouse=True)
+def _no_gpu_release(monkeypatch):
+    monkeypatch.setattr(run_eval, "_release_gpu_models", lambda *_a, **_kw: None)
+    monkeypatch.setattr(run_eval, "_release_ollama_models", lambda *_a, **_kw: None)
+    monkeypatch.setattr(
+        run_eval,
+        "run_retrieval_case",
+        lambda case, retrieved, elapsed: {
+            "id": case["id"], "paper": case["paper"], "case_type": case["case_type"],
+            "lang": case["lang"], "model": None, "passed": True, "reason": "fake",
+            "elapsed_seconds": round(elapsed, 2),
+        },
+    )
+
+
+def test_run_all_cases_streams_every_record_to_the_partial_sink(tmp_path):
+    sink_path = tmp_path / "run.partial.jsonl"
+    cases = [_case("c1"), _case("c2"), _case("c3")]
+
+    records = run_eval.run_all_cases(
+        None, cases, _FakeRetrieve(), None, _FakeEvidence(), None,
+        models=[], partial_sink=sink_path,
+    )
+
+    assert len(records) == 3
+    lines = sink_path.read_text(encoding="utf-8").splitlines()
+    written = [json.loads(line) for line in lines]
+    assert {r["id"] for r in written} == {"c1", "c2", "c3"}
+    # Every record run_all_cases returned is on disk too -- a reader does not
+    # need the process to still be alive to see them.
+    assert sorted(written, key=lambda r: r["id"]) == sorted(records, key=lambda r: r["id"])
+
+
+def test_run_all_cases_with_no_sink_writes_nothing_to_disk(tmp_path):
+    """partial_sink defaults to None -- every caller that predates issue
+    #219, and every test that stubs run_all_cases out entirely, keeps
+    behaving exactly as before."""
+    records = run_eval.run_all_cases(
+        None, [_case("c1")], _FakeRetrieve(), None, _FakeEvidence(), None, models=[],
+    )
+
+    assert len(records) == 1
+    assert list(tmp_path.iterdir()) == []

--- a/tests/eval/test_phase2_model_major.py
+++ b/tests/eval/test_phase2_model_major.py
@@ -1,0 +1,206 @@
+"""Phase 2 loads each generator once per sweep, not once per case (issue #220).
+
+Phase 2 used to loop cases on the outside and models on the inside --
+``run_factual_case``'s ``for model in models: rag.set_model_roles_runtime(...)``
+ran on every generation call, so an N-model sweep set the "rag" role
+N x len(pending) times. On an 8 GB card that held one generator at a time,
+each switch was a real unload + reload (issue #229's sibling measurement:
+2.3 s for a 4.9 GB model, 7.9 s for a 10 GB one). ``run_all_cases`` now loops
+model-major: fix the role once per model, then run every pending case under
+it -- N switches total, not N x len(pending).
+
+Phase 1 made this exact change for this exact reason (issue #123) and
+``_restore_case_order`` puts its records back into the caller's case order
+afterwards so the artefact stays comparable. These tests check the phase 2
+equivalent: that the role is set N times (not N x M), and that
+``_restore_generation_order`` regroups the model-major output back into the
+same case order *and* the same per-case model order the previous case-major
+loop produced -- built from ``git log``'s issue #220 diff, not assumed.
+
+These tests use fakes -- the point is call counts and record order, exactly
+like ``test_phase1_one_corpus_at_a_time.py`` does for phase 1.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import pytest  # noqa: E402
+
+import run_eval  # noqa: E402
+
+
+class _FakeRag:
+    """Records every role assignment and generation call; answers a fixed
+    literal so grading is deterministic without Ollama."""
+
+    def __init__(self, log):
+        self._log = log
+
+    def set_model_roles_runtime(self, overrides):
+        self._log.append(("set_role", overrides["rag"]))
+        return {"rag": overrides["rag"]}
+
+    def generar_respuesta_silenciosa(self, question, fragments, stats=None):
+        self._log.append(("generate", question))
+        return "42"
+
+
+def _factual_case(case_id):
+    """A minimal factual_number case: source "corpus" so phase 1 routes it
+    through the (faked) dev-corpus retrieval, accepted_answers matching
+    _FakeRag's canned answer so every generation call grades a clean pass."""
+    return {
+        "id": case_id,
+        "paper": f"paper-{case_id}",
+        "case_type": "factual_number",
+        "lang": "en",
+        "source": "corpus",
+        "question": f"question for {case_id}",
+        "accepted_answers": ["42"],
+    }
+
+
+def _fake_retrieval(cases, retrieve, evidence, records, pending, store=None):
+    """Stand-in for ``_run_retrieval_for_corpus``: every case retrieves the
+    same one fragment and lands in ``pending``, in the order given.
+
+    Phase 1's own ordering and Fragment-conversion machinery is exercised by
+    test_phase1_one_corpus_at_a_time.py already; these tests are about phase
+    2's loop shape, so phase 1 is faked down to "every case has fragments".
+    """
+    for case in cases:
+        pending.append({
+            "case": case,
+            "fragments": [{"content": "frag", "source": case["paper"]}],
+            "elapsed": 0.0,
+        })
+
+
+@pytest.fixture
+def harness(monkeypatch):
+    """A fake rag double, phase 1 replaced by ``_fake_retrieval``, and a
+    frozen clock so elapsed_seconds/generation_seconds are reproducible
+    (needed for the full-record equality check in the order test below)."""
+    monkeypatch.setattr(run_eval, "_run_retrieval_for_corpus", _fake_retrieval)
+    monkeypatch.setattr(run_eval, "_release_gpu_models", lambda *_a, **_kw: None)
+    monkeypatch.setattr(run_eval, "_release_ollama_models", lambda *_a, **_kw: None)
+    monkeypatch.setattr(run_eval.time, "perf_counter", lambda: 0.0)
+    log = []
+    rag = _FakeRag(log)
+    return log, rag
+
+
+def test_role_is_set_once_per_model_not_once_per_case(harness):
+    """(a) N models x M cases must set the "rag" role N times, not N x M.
+
+    This is the closure criterion itself: with the previous case-major loop
+    (case outer, model inner -- ``run_factual_case`` calling
+    ``rag.set_model_roles_runtime`` once per (case, model) pair), 3 models x
+    4 cases would set the role 12 times. Model-major sets it 3 times, once
+    per model, regardless of how many cases follow.
+    """
+    log, rag = harness
+    cases = [_factual_case(f"c{i}") for i in range(4)]
+    models = ["model-a", "model-b", "model-c"]
+
+    run_eval.run_all_cases(rag, cases, object(), None, None, None, models)
+
+    role_sets = [model for kind, model in log if kind == "set_role"]
+    assert role_sets == models, (
+        f"expected exactly one set_model_roles_runtime call per model, in "
+        f"order, got {role_sets}"
+    )
+
+
+def test_generation_calls_are_grouped_by_model(harness):
+    """The property the role count is a proxy for: every pending case for a
+    model must run before the next model's role switch, not interleaved."""
+    log, rag = harness
+    cases = [_factual_case(f"c{i}") for i in range(3)]
+    models = ["model-a", "model-b"]
+
+    run_eval.run_all_cases(rag, cases, object(), None, None, None, models)
+
+    kinds = [kind for kind, _value in log]
+    assert kinds == [
+        "set_role", "generate", "generate", "generate",
+        "set_role", "generate", "generate", "generate",
+    ]
+
+
+def test_records_match_the_previous_case_major_loop_order(harness):
+    """(b) Execution order changed (model-major); the artefact's record set
+    and order must not.
+
+    The reference below reconstructs the *previous* case-major loop --
+    ``for item in pending: for model in models: rag.set_model_roles_runtime
+    (...); <per-model body>`` -- reading straight off the #220 diff: the old
+    ``run_all_cases`` called ``run_factual_case(rag, item["case"],
+    item["fragments"], models, item["elapsed"])`` per pending item, and
+    ``run_factual_case`` itself looped ``for model in models:
+    rag.set_model_roles_runtime(...)`` then ran the per-model body now
+    extracted, unchanged, into ``_run_factual_case_for_model`` (still true
+    today: ``run_factual_case`` is kept case-major on purpose for
+    run_probe_lang.py/run_probe_domain.py, so this is not a description of
+    dead code). The reference is executed for real against the same fakes,
+    not hand-typed, and compared record-for-record -- including
+    elapsed_seconds/generation_seconds, made reproducible by the harness's
+    frozen clock -- with what the new model-major run_all_cases returns.
+    """
+    log, rag = harness
+    cases = [_factual_case(f"c{i}") for i in range(3)]
+    models = ["model-a", "model-b"]
+    pending = [
+        {"case": c, "fragments": [{"content": "frag", "source": c["paper"]}], "elapsed": 0.0}
+        for c in cases
+    ]
+
+    expected = []
+    for item in pending:
+        for model in models:
+            rag.set_model_roles_runtime({"rag": model})
+            expected.append(
+                run_eval._run_factual_case_for_model(
+                    rag, item["case"], item["fragments"], model, item["elapsed"]
+                )
+            )
+    log.clear()  # the reference run above must not leak into the real assertion
+
+    actual = run_eval.run_all_cases(rag, cases, object(), None, None, None, models)
+
+    assert [(r["id"], r["model"]) for r in actual] == [
+        (r["id"], r["model"]) for r in expected
+    ]
+    assert actual == expected
+
+
+def test_model_major_records_still_stream_to_the_partial_sink_once_each(harness, tmp_path):
+    """Issue #219's guarantee survives the reorder: every phase 2 record is
+    on disk the moment it exists (so the file is in model-major execution
+    order), each exactly once (the in-memory regroup must not go through
+    the sink's append/extend), while the returned list is in case order."""
+    log, rag = harness
+    cases = [_factual_case(f"c{i}") for i in range(3)]
+    models = ["model-a", "model-b"]
+    sink_path = tmp_path / "run.partial.jsonl"
+
+    returned = run_eval.run_all_cases(
+        rag, cases, object(), None, None, None, models, partial_sink=sink_path,
+    )
+
+    on_disk = [json.loads(line) for line in sink_path.read_text().splitlines()]
+    assert [(r["id"], r["model"]) for r in on_disk] == [
+        ("c0", "model-a"), ("c1", "model-a"), ("c2", "model-a"),
+        ("c0", "model-b"), ("c1", "model-b"), ("c2", "model-b"),
+    ]
+    assert [(r["id"], r["model"]) for r in returned] == [
+        ("c0", "model-a"), ("c0", "model-b"),
+        ("c1", "model-a"), ("c1", "model-b"),
+        ("c2", "model-a"), ("c2", "model-b"),
+    ]
+    assert sorted(on_disk, key=lambda r: (r["id"], r["model"])) == sorted(
+        returned, key=lambda r: (r["id"], r["model"])
+    )

--- a/tests/eval/test_run_conditions.py
+++ b/tests/eval/test_run_conditions.py
@@ -187,13 +187,14 @@ def test_run_conditions_has_every_field_the_issue_asks_for(_quiet_conditions):
 
     assert set(conditions) == {
         "config", "versions", "hardware", "git_commit", "gold_sha256",
-        "sampling", "seed", "keep_alive_seconds",
+        "sampling", "seed", "keep_alive_seconds", "generation_budget_seconds",
     }
     assert set(conditions["versions"]) == {
         "mineru", "sentence_transformers", "torch", "transformers", "faiss", "ollama_server",
     }
     assert conditions["seed"] is None
     assert conditions["keep_alive_seconds"] == int(run_eval._EVAL_GENERATION_KEEP_ALIVE_SECONDS)
+    assert conditions["generation_budget_seconds"] == run_eval.GENERATION_BUDGET_SECONDS
     assert len(conditions["gold_sha256"]) == 64
     assert conditions["sampling"] == sampling
 

--- a/tests/eval/test_run_conditions.py
+++ b/tests/eval/test_run_conditions.py
@@ -1,0 +1,244 @@
+"""The run artifact's conditions block (issue #222) -- what decided a pass
+rate, kept apart from what it decided.
+
+No ``rag`` or ``monkeygrab.adapters`` import here: every helper under test
+takes what it needs as an argument or reaches it through
+``importlib.metadata``/``subprocess``, never the engine. That keeps this file
+collected (not silently skipped by ``tests/conftest.py``) in the
+dependency-free fast gate, the same way test_summary_split.py and
+test_preflight_model_tags.py are.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import pytest  # noqa: E402
+
+import run_eval  # noqa: E402
+from monkeygrab.config.app_config import AppConfig  # noqa: E402
+
+
+# _package_version
+
+
+def test_an_installed_package_reports_a_version_string():
+    # pytest itself is guaranteed installed -- this is the test runner.
+    version = run_eval._package_version("pytest")
+    assert isinstance(version, str) and version
+
+
+def test_a_missing_package_reports_none():
+    assert run_eval._package_version("definitely-not-a-real-package-222") is None
+
+
+# _gpu_info
+
+
+def test_gpu_info_degrades_to_none_when_torch_absent_and_nvidia_smi_missing(monkeypatch):
+    monkeypatch.delitem(sys.modules, "torch", raising=False)
+
+    def _raise(*_a, **_kw):
+        raise FileNotFoundError("nvidia-smi not found")
+
+    monkeypatch.setattr("subprocess.run", _raise)
+
+    assert run_eval._gpu_info() == {"name": None, "vram_total_mib": None}
+
+
+def test_gpu_info_parses_nvidia_smi_when_torch_is_not_loaded(monkeypatch):
+    monkeypatch.delitem(sys.modules, "torch", raising=False)
+
+    class _Result:
+        stdout = "NVIDIA GeForce RTX 4090, 24564\n"
+
+    monkeypatch.setattr("subprocess.run", lambda *_a, **_kw: _Result())
+
+    assert run_eval._gpu_info() == {"name": "NVIDIA GeForce RTX 4090", "vram_total_mib": 24564}
+
+
+def test_gpu_info_prefers_an_already_imported_torch_over_nvidia_smi(monkeypatch):
+    class _Props:
+        name = "NVIDIA A100"
+        total_memory = 42 * 2**20  # bytes -> 42 MiB, chosen to be checkable exactly
+
+    class _Cuda:
+        @staticmethod
+        def is_available():
+            return True
+
+        @staticmethod
+        def get_device_properties(_index):
+            return _Props()
+
+    class _FakeTorch:
+        cuda = _Cuda()
+
+    monkeypatch.setitem(sys.modules, "torch", _FakeTorch())
+
+    def _fail_if_called(*_a, **_kw):
+        raise AssertionError("nvidia-smi must not run when torch already answered")
+
+    monkeypatch.setattr("subprocess.run", _fail_if_called)
+
+    assert run_eval._gpu_info() == {"name": "NVIDIA A100", "vram_total_mib": 42}
+
+
+def test_gpu_info_is_none_when_torch_is_loaded_but_reports_no_cuda(monkeypatch):
+    class _Cuda:
+        @staticmethod
+        def is_available():
+            return False
+
+    class _FakeTorch:
+        cuda = _Cuda()
+
+    monkeypatch.setitem(sys.modules, "torch", _FakeTorch())
+
+    assert run_eval._gpu_info() == {"name": None, "vram_total_mib": None}
+
+
+# _git_info
+
+
+def test_git_info_reports_a_clean_tree(monkeypatch):
+    def _fake_run(args, **_kw):
+        class _Result:
+            stdout = "abc1234\n" if "rev-parse" in args else ""
+
+        return _Result()
+
+    monkeypatch.setattr("subprocess.run", _fake_run)
+
+    assert run_eval._git_info() == {"hash": "abc1234", "dirty": False}
+
+
+def test_git_info_reports_a_dirty_tree(monkeypatch):
+    def _fake_run(args, **_kw):
+        class _Result:
+            stdout = "abc1234\n" if "rev-parse" in args else " M rag/chat_pdfs.py\n"
+
+        return _Result()
+
+    monkeypatch.setattr("subprocess.run", _fake_run)
+
+    assert run_eval._git_info() == {"hash": "abc1234", "dirty": True}
+
+
+def test_git_info_degrades_to_none_when_git_is_unavailable(monkeypatch):
+    def _raise(*_a, **_kw):
+        raise FileNotFoundError("git not found")
+
+    monkeypatch.setattr("subprocess.run", _raise)
+
+    assert run_eval._git_info() == {"hash": None, "dirty": None}
+
+
+def test_git_info_keeps_the_commit_when_only_the_dirty_check_fails(monkeypatch):
+    """A shallow clone or a git version missing --porcelain must not lose the
+    commit hash it already had -- two separate calls, two separate failures."""
+    calls = {"n": 0}
+
+    def _fake_run(args, **_kw):
+        calls["n"] += 1
+        if "rev-parse" in args:
+            class _Result:
+                stdout = "abc1234\n"
+            return _Result()
+        raise RuntimeError("status failed")
+
+    monkeypatch.setattr("subprocess.run", _fake_run)
+
+    assert run_eval._git_info() == {"hash": "abc1234", "dirty": None}
+
+
+# _gold_cases_sha256
+
+
+def test_gold_cases_sha256_matches_a_direct_hash():
+    import hashlib
+
+    expected = hashlib.sha256(run_eval.GOLD_FILE.read_bytes()).hexdigest()
+    assert run_eval._gold_cases_sha256() == expected
+
+
+def test_gold_cases_sha256_degrades_to_none_when_unreadable(monkeypatch, tmp_path):
+    monkeypatch.setattr(run_eval, "GOLD_FILE", tmp_path / "missing.jsonl")
+    assert run_eval._gold_cases_sha256() is None
+
+
+# _run_conditions
+
+
+@pytest.fixture
+def _quiet_conditions(monkeypatch):
+    """Stub every host-dependent lookup so _run_conditions never touches the
+    network or a GPU -- only the pure pieces (versions, gold hash) run for
+    real."""
+    monkeypatch.setattr(run_eval, "_ollama_server_version", lambda: None)
+    monkeypatch.setattr(run_eval, "_gpu_info", lambda: {"name": None, "vram_total_mib": None})
+    monkeypatch.setattr(run_eval, "_git_info", lambda: {"hash": None, "dirty": None})
+
+
+def test_run_conditions_has_every_field_the_issue_asks_for(_quiet_conditions):
+    sampling = {"rag": {"temperature": 0.15}, "chat": {}, "recomp": {}}
+    conditions = run_eval._run_conditions({"dev": None, "blind": None}, sampling)
+
+    assert set(conditions) == {
+        "config", "versions", "hardware", "git_commit", "gold_sha256",
+        "sampling", "seed", "keep_alive_seconds",
+    }
+    assert set(conditions["versions"]) == {
+        "mineru", "sentence_transformers", "torch", "transformers", "faiss", "ollama_server",
+    }
+    assert conditions["seed"] is None
+    assert conditions["keep_alive_seconds"] == int(run_eval._EVAL_GENERATION_KEEP_ALIVE_SECONDS)
+    assert len(conditions["gold_sha256"]) == 64
+    assert conditions["sampling"] == sampling
+
+
+def test_run_conditions_reuses_the_config_it_is_given_not_a_fresh_default(_quiet_conditions):
+    # A marker that no real AppConfig.from_env() would ever produce -- if
+    # _run_conditions started rebuilding its own config instead of embedding
+    # the one evaluate() already built, this value would not survive.
+    marker_config = {"dev": {"marker": "distinctive-test-value"}, "blind": None}
+
+    conditions = run_eval._run_conditions(marker_config, sampling={})
+
+    assert conditions["config"] is marker_config
+    assert conditions["config"] != {"dev": None, "blind": None}
+
+
+def test_run_conditions_config_is_not_bare_appconfig_defaults(_quiet_conditions):
+    """Guard against a regression where the block is built from a fresh
+    ``AppConfig()`` instead of the run's actual, possibly-overridden one."""
+    import dataclasses
+
+    real_config = {"dev": dataclasses.asdict(AppConfig().with_overrides(**{"retrieval.top_k_final": 3}))}
+    bare_defaults = {"dev": dataclasses.asdict(AppConfig())}
+
+    conditions = run_eval._run_conditions(real_config, sampling={})
+
+    assert conditions["config"] != bare_defaults
+    assert conditions["config"]["dev"]["retrieval"]["top_k_final"] == 3
+
+
+def test_run_conditions_survives_every_sub_lookup_failing(monkeypatch):
+    """Package lookups, the Ollama version, the GPU and git can all fail
+    independently -- none of it may stop the artifact from being written."""
+    monkeypatch.setattr(run_eval, "_package_version", lambda _dist: None)
+    monkeypatch.setattr(run_eval, "_ollama_server_version", lambda: None)
+    monkeypatch.setattr(run_eval, "_gpu_info", lambda: {"name": None, "vram_total_mib": None})
+    monkeypatch.setattr(run_eval, "_git_info", lambda: {"hash": None, "dirty": None})
+    monkeypatch.setattr(run_eval, "_gold_cases_sha256", lambda: None)
+
+    conditions = run_eval._run_conditions({"dev": None, "blind": None}, sampling={})
+
+    assert conditions["versions"] == {
+        "mineru": None, "sentence_transformers": None, "torch": None,
+        "transformers": None, "faiss": None, "ollama_server": None,
+    }
+    assert conditions["hardware"] == {"name": None, "vram_total_mib": None}
+    assert conditions["git_commit"] == {"hash": None, "dirty": None}
+    assert conditions["gold_sha256"] is None

--- a/tests/eval/test_run_study_case.py
+++ b/tests/eval/test_run_study_case.py
@@ -1,0 +1,130 @@
+"""Tests for run_study_case: the generation budget (issue #229) and the
+missing elapsed-time print the issue's own follow-up comment asked for.
+
+Measured on the campaign that filed #229: of 289 generations, the 34
+study_* ones cost ~90 minutes between them (one, ricci-study-summary-es,
+took 26 minutes alone) and none of them printed how long they took --
+only the factual lines did, as "(6.8s)". That made the cost invisible
+exactly where it was concentrated. Both are fixed here: a study generation
+is now bounded by the same GENERATION_BUDGET_SECONDS as a factual one, and
+every study_* console line -- BUDGET, FAIL (malformed), ERROR
+(infrastructure) and PASS/FAIL (graded) -- now reports elapsed time the
+same way the factual path does.
+
+run_study_case imports rag.engine.wiring and monkeygrab.application.study
+internally, which pulls in the real engine (Ollama client, torch via
+sentence-transformers). The ``import rag.chat_pdfs`` below is what lets
+tests/conftest.py's heuristic skip this file in the dependency-free fast
+CI gate -- see test_evaluate_library_api.py's module docstring for the
+same pattern. Study.summarize is monkeypatched directly in every test, so
+no GPU, Ollama server or network access is needed to run these.
+"""
+
+import re
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import rag.chat_pdfs  # noqa: E402,F401  (see module docstring)
+import run_eval  # noqa: E402
+from monkeygrab.application.study import (  # noqa: E402
+    DocumentSummary,
+    MalformedSummaryError,
+    Study,
+    SummarySection,
+)
+
+
+def _case():
+    return {
+        "id": "study-1", "paper": "p", "case_type": "study_summary", "lang": "en",
+    }
+
+
+def _fragments():
+    return [{"doc": "text", "metadata": {"source": "p.pdf", "page": 1}}]
+
+
+_ELAPSED_PATTERN = re.compile(r"\(\d+\.\d+s\)")
+
+
+def test_a_study_generation_that_overruns_the_budget_is_budget_exceeded(monkeypatch, capsys):
+    monkeypatch.setattr(run_eval, "GENERATION_BUDGET_SECONDS", 0.05)
+
+    def _slow_summarize(self, fragments, config, *, language=None):
+        time.sleep(1)
+        raise AssertionError("must have been abandoned by the budget")
+
+    monkeypatch.setattr(Study, "summarize", _slow_summarize)
+
+    records = run_eval.run_study_case(_case(), _fragments(), ["m"], retrieval_elapsed=0.0)
+
+    assert len(records) == 1
+    assert records[0]["budget_exceeded"] is True
+    assert records[0]["passed"] is False
+    assert "infrastructure_error" not in records[0]
+    out = capsys.readouterr().out
+    assert "[BUDGET]" in out
+    assert _ELAPSED_PATTERN.search(out), f"no elapsed time printed for the BUDGET line: {out!r}"
+
+
+def test_a_malformed_artifact_is_a_fail_not_budget_exceeded_and_prints_elapsed(monkeypatch, capsys):
+    monkeypatch.setattr(run_eval, "GENERATION_BUDGET_SECONDS", 5)
+
+    def _bad_summarize(self, fragments, config, *, language=None):
+        raise MalformedSummaryError("not a list")
+
+    monkeypatch.setattr(Study, "summarize", _bad_summarize)
+
+    records = run_eval.run_study_case(_case(), _fragments(), ["m"], retrieval_elapsed=0.0)
+
+    assert len(records) == 1
+    assert records[0]["passed"] is False
+    assert "budget_exceeded" not in records[0]
+    assert "infrastructure_error" not in records[0]
+    out = capsys.readouterr().out
+    assert "[FAIL]" in out
+    assert _ELAPSED_PATTERN.search(out), f"no elapsed time printed for the FAIL line: {out!r}"
+
+
+def test_a_generation_failure_is_an_infrastructure_error_and_prints_elapsed(monkeypatch, capsys):
+    monkeypatch.setattr(run_eval, "GENERATION_BUDGET_SECONDS", 5)
+
+    def _dead_ollama(self, fragments, config, *, language=None):
+        raise RuntimeError("simulated Ollama unreachable")
+
+    monkeypatch.setattr(Study, "summarize", _dead_ollama)
+
+    records = run_eval.run_study_case(_case(), _fragments(), ["m"], retrieval_elapsed=0.0)
+
+    assert len(records) == 1
+    assert records[0]["infrastructure_error"] is True
+    assert "budget_exceeded" not in records[0]
+    out = capsys.readouterr().out
+    assert "[ERROR]" in out
+    assert _ELAPSED_PATTERN.search(out), f"no elapsed time printed for the ERROR line: {out!r}"
+
+
+def test_a_graded_result_within_budget_prints_elapsed(monkeypatch, capsys):
+    monkeypatch.setattr(run_eval, "GENERATION_BUDGET_SECONDS", 5)
+
+    def _fast_summarize(self, fragments, config, *, language=None):
+        sections = tuple(
+            SummarySection(heading=f"H{i}", body=f"body {i}", source_pages=(1,))
+            for i in range(3)
+        )
+        return DocumentSummary(sections=sections, source_document="p.pdf")
+
+    monkeypatch.setattr(Study, "summarize", _fast_summarize)
+
+    records = run_eval.run_study_case(_case(), _fragments(), ["m"], retrieval_elapsed=0.0)
+
+    assert len(records) == 1
+    assert records[0]["passed"] is True
+    assert "budget_exceeded" not in records[0]
+    assert "infrastructure_error" not in records[0]
+    out = capsys.readouterr().out
+    assert "[PASS]" in out
+    assert _ELAPSED_PATTERN.search(out), f"no elapsed time printed for the PASS line: {out!r}"

--- a/tests/test_web_chat_stream_timeout.py
+++ b/tests/test_web_chat_stream_timeout.py
@@ -1,0 +1,82 @@
+"""_chat_stream must not block forever on a wedged Ollama server (issue #237).
+
+_chat_stream is CHAT mode's own streaming path: it calls ollama_client_for
+directly instead of going through OllamaChatModel, so #232's fix to that
+adapter (passing request_timeout into the cached client) never reached it.
+Before this fix the call carried no timeout at all -- httpx's own "no
+timeout" -- so a stalled server left the SSE generator, and the Flask worker
+thread serving it, blocked indefinitely.
+
+Doubles a real, unresponsive TCP server rather than monkeypatching the ollama
+client: the deadline lives inside ollama.Client -> httpx.Client, which a
+Python-level stub would bypass entirely (same approach as
+tests/unit/adapters/test_ollama_chat.py's own timeout regression test).
+"""
+
+import socket
+import sys
+import threading
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import pytest
+
+from monkeygrab.adapters.chat import ollama_chat as ollama_chat_module
+from rag.web import app as web_app  # noqa: E402
+
+
+@pytest.fixture
+def _silent_server():
+    """Bind a loopback socket that accepts a connection and never replies."""
+    request_timeout = 0.5
+
+    server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server.bind(("127.0.0.1", 0))
+    server.listen(1)
+    port = server.getsockname()[1]
+    stop = threading.Event()
+
+    def _accept_and_stay_silent():
+        try:
+            conn, _ = server.accept()
+        except OSError:
+            return  # server closed during teardown before a connection arrived
+        stop.wait(request_timeout + 5)  # hold the connection open, reply never sent
+        conn.close()
+
+    thread = threading.Thread(target=_accept_and_stay_silent, daemon=True)
+    thread.start()
+
+    yield f"http://127.0.0.1:{port}", request_timeout
+
+    stop.set()
+    server.close()
+    thread.join(timeout=2)
+
+
+def test_chat_stream_raises_within_its_deadline_against_a_server_that_never_answers(
+    monkeypatch, _silent_server
+):
+    base_url, request_timeout = _silent_server
+    monkeypatch.setattr(web_app, "OLLAMA_BASE_URL", base_url)
+    monkeypatch.setattr(web_app.rag_engine, "OLLAMA_REQUEST_TIMEOUT", request_timeout)
+
+    # A distinct (base_url, timeout) cache key means this test builds its own
+    # real client; clearing avoids leaking it into later tests.
+    ollama_chat_module.ollama_client_for.cache_clear()
+    try:
+        start = time.monotonic()
+        with pytest.raises(Exception):  # noqa: B017 -- exact type is ollama/httpx's, not ours to pin
+            list(web_app._chat_stream("hola"))
+        elapsed = time.monotonic() - start
+    finally:
+        ollama_chat_module.ollama_client_for.cache_clear()
+
+    # Bounded by request_timeout, not by the server (which never answers) or
+    # by the suite's own patience -- and not near-instant either, which would
+    # mean the raise came from something other than the deadline expiring.
+    assert request_timeout <= elapsed < 5.0

--- a/tests/test_web_settings_releases_reranker.py
+++ b/tests/test_web_settings_releases_reranker.py
@@ -1,0 +1,72 @@
+"""Turning the reranker off via /api/settings must release its VRAM (#239).
+
+CrossEncoderReranker.release() existed to give back its CUDA weights once
+reranking is done, but nothing called it: rag/engine/wiring.py cached the
+reranker as a singleton with no reset path, so once loaded its weights sat
+resident for the rest of the process's life -- including after a user
+explicitly turns reranking off, at which point nothing will use them again
+until it is turned back on. This is the one call site wired for the fix (see
+rag/engine/wiring.py's release_reranker and rag_chat_model docstrings for why
+the per-query retrieval path itself is deliberately left alone).
+
+Doubles the engine entirely: what is under test is which lifecycle call the
+web layer makes on this one settings transition, not reranking itself.
+"""
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from rag.web import app as web_app  # noqa: E402
+
+
+class _FakeStore:
+    def get_page(self, *_a, **_kw):
+        return []
+
+
+def _wire_common(monkeypatch):
+    released = []
+    monkeypatch.setattr(web_app.rag_engine, "release_reranker", lambda: released.append(1))
+    monkeypatch.setattr(web_app.rag_engine, "guardar_ajustes_persistidos", lambda: None)
+    monkeypatch.setattr(web_app.rag_engine, "index_fingerprint_mismatch", lambda coll: False)
+    monkeypatch.setattr(web_app, "_get_collection", lambda: _FakeStore())
+    monkeypatch.setattr(web_app.rag_engine, "RERANKER_AVAILABLE", True)
+    monkeypatch.setattr(web_app.rag_engine, "USAR_RERANKER", True)
+    return released
+
+
+def test_turning_the_reranker_off_releases_its_vram(monkeypatch):
+    released = _wire_common(monkeypatch)
+
+    with web_app.app.test_client() as client:
+        resp = client.post("/api/settings", json={"reranker": False})
+
+    assert resp.status_code == 200
+    assert resp.get_json()["settings"]["reranker"] is False
+    assert released == [1]
+
+
+def test_turning_the_reranker_on_does_not_release_anything(monkeypatch):
+    released = _wire_common(monkeypatch)
+    web_app.rag_engine.USAR_RERANKER = False
+
+    with web_app.app.test_client() as client:
+        resp = client.post("/api/settings", json={"reranker": True})
+
+    assert resp.status_code == 200
+    assert resp.get_json()["settings"]["reranker"] is True
+    assert released == []
+
+
+def test_leaving_other_flags_alone_does_not_touch_the_reranker(monkeypatch):
+    released = _wire_common(monkeypatch)
+
+    with web_app.app.test_client() as client:
+        resp = client.post("/api/settings", json={"expandContext": False})
+
+    assert resp.status_code == 200
+    assert released == []

--- a/tests/unit/adapters/test_bm25_index_concurrency.py
+++ b/tests/unit/adapters/test_bm25_index_concurrency.py
@@ -1,0 +1,145 @@
+"""Bm25LexicalIndex._ensure_index() has no lock against a concurrent corpus
+mutation (#238).
+
+rag/engine/wiring.py's lexical_index() caches one Bm25LexicalIndex per
+(store, k1, b) and hands it to every concurrent Flask request thread
+(threaded=True). Before this fix, a rebuild was three unsynchronized writes
+(entries, then bm25, then cache_key): a thread scheduled out mid-rebuild --
+a slow BM25Okapi() call, or plain GIL contention under load -- could resume
+and publish its own snapshot, read *before* a concurrent delete_source(),
+*after* a second thread's rebuild (triggered by that same delete) had
+already published a fresher one. The slower write landed last and won for
+all three fields at once, silently reverting the index to cite content the
+caller had just deleted.
+
+Reproduced deterministically -- no sleep, no luck -- with the same trick the
+issue itself used: delay only the FIRST BM25Okapi() construction behind a
+threading.Event, standing in for a thread being scheduled out mid-rebuild,
+while a second, concurrent search (triggered by the delete landing in that
+same window) races ahead and rebuilds correctly.
+
+Inspects Bm25LexicalIndex._index directly rather than only asserting on a
+further search() call: the cache_key mismatch this bug leaves behind is
+exactly what makes the *next* search() call self-heal by rebuilding again,
+which would silently mask the regression this test exists to catch. The
+same "inspect the shared cache's own state, not just its public return
+value" approach tests/unit/test_wiring_cache_concurrency.py already uses for
+wiring's caches.
+"""
+
+import sys
+import threading
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from rank_bm25 import BM25Okapi as RealBM25Okapi
+
+from monkeygrab.adapters.lexical import bm25_index as module
+from monkeygrab.adapters.lexical.bm25_index import Bm25LexicalIndex
+from monkeygrab.config.retrieval import RetrievalConfig
+from monkeygrab.domain.chunk_metadata import ChunkMetadata
+from monkeygrab.domain.fragment import Fragment
+
+
+def _fragment(text, source, chunk=0):
+    return Fragment(doc=text, metadata=ChunkMetadata(source=source, page=0, chunk=chunk))
+
+
+class _MutableStore:
+    """VectorStore double whose corpus can be mutated between calls --
+    standing in for a real FAISS store racing a concurrent delete_source()."""
+
+    def __init__(self, fragments):
+        self._fragments = list(fragments)
+
+    def count(self):
+        return len(self._fragments)
+
+    def get_page(self, limit, offset):
+        return list(self._fragments)
+
+    def delete_source(self, source):
+        self._fragments = [f for f in self._fragments if f.metadata.source != source]
+
+
+def test_a_slower_rebuild_never_overwrites_a_fresher_one_racing_a_delete(monkeypatch):
+    config = RetrievalConfig()
+    store = _MutableStore(
+        [
+            _fragment(
+                "confidential quarterly salary figures for the finance team",
+                "doc0.pdf",
+            ),
+            _fragment("unrelated public marketing copy", "public.pdf", chunk=1),
+            _fragment("another unrelated public paragraph", "public.pdf", chunk=2),
+        ]
+    )
+    index = Bm25LexicalIndex(store, config)
+
+    entered_slow_build = threading.Event()
+    release_slow_build = threading.Event()
+    call_count = {"n": 0}
+
+    def _delayed_bm25okapi(corpus_tokens, k1, b):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            # Thread A: signal it has already read the pre-delete corpus and
+            # is now inside the slow constructor -- the exact window issue
+            # #238 shows a concurrent delete landing in.
+            entered_slow_build.set()
+            assert release_slow_build.wait(timeout=5), "test deadlocked: never released"
+        return RealBM25Okapi(corpus_tokens, k1=k1, b=b)
+
+    monkeypatch.setattr(module, "BM25Okapi", _delayed_bm25okapi)
+
+    slow_results = []
+    thread_a = threading.Thread(
+        target=lambda: slow_results.append(index.search("confidential", top_n=5))
+    )
+    thread_a.start()
+    assert entered_slow_build.wait(timeout=5), "thread A never reached the slow constructor"
+
+    # The delete that races thread A's in-flight rebuild.
+    store.delete_source("doc0.pdf")
+
+    # Thread B: a second, concurrent request triggered by that same delete.
+    # Against the unlocked adapter it races ahead and rebuilds immediately;
+    # against the locked one it blocks until thread A releases the rebuild
+    # lock below -- either way it must end up rebuilding from the post-delete
+    # corpus (call_count reaches 2 without ever waiting on
+    # release_slow_build, since only the first call delays), so it is not
+    # joined with an expectation of either timing here.
+    fast_results = []
+    thread_b = threading.Thread(
+        target=lambda: fast_results.append(index.search("confidential", top_n=5))
+    )
+    thread_b.start()
+
+    # Let thread A's stale build finish and attempt to publish.
+    release_slow_build.set()
+    thread_a.join(timeout=5)
+    assert not thread_a.is_alive(), "thread A hung instead of publishing"
+    thread_b.join(timeout=5)
+    assert not thread_b.is_alive(), "thread B hung instead of publishing"
+
+    # Thread B's own rebuild read the corpus after the delete, so its own
+    # result must already be correct regardless of the race below.
+    assert fast_results[0] == []
+
+    # The decisive check: once both requests have settled, the SHARED index
+    # must still reflect thread B's fresher rebuild, not thread A's stale
+    # one publishing last in wall-clock time. Checked directly on the cache
+    # rather than via one more search() call: a mismatched cache_key left
+    # behind by the bug would make that next call rebuild again and quietly
+    # self-heal, hiding exactly the regression under test.
+    cache_key, entries, _bm25 = index._index
+    assert cache_key == (2, config.bm25_k1, config.bm25_b), (
+        f"stale rebuild overwrote the fresher one: cache_key={cache_key}"
+    )
+    assert all(f.metadata.source != "doc0.pdf" for f in entries), (
+        "the shared index still cites the deleted document after both "
+        f"requests settled: {[f.metadata.source for f in entries]}"
+    )

--- a/tests/unit/adapters/test_cross_encoder_reranker.py
+++ b/tests/unit/adapters/test_cross_encoder_reranker.py
@@ -161,5 +161,32 @@ def test_rerank_hard_fails_when_scoring_itself_raises(monkeypatch):
         CrossEncoderReranker().rerank("q", [_fragment("a")], top_k=1)
 
 
+def test_release_drops_the_model_so_the_next_rerank_reloads_it(monkeypatch):
+    """release() existed with no caller anywhere in the codebase (#239) and
+    no test either -- this pins what it must do: forget the loaded model, so
+    a later rerank() builds a fresh CrossEncoder instead of reusing the freed
+    one."""
+    _patch_crossencoder(monkeypatch)
+    _force_cpu(monkeypatch)
+
+    reranker = CrossEncoderReranker()
+    reranker.rerank("q", [_fragment("a")], top_k=1)
+    assert len(FakeCrossEncoder.instances) == 1
+
+    reranker.release()
+    reranker.rerank("q", [_fragment("a")], top_k=1)
+
+    assert len(FakeCrossEncoder.instances) == 2
+
+
+def test_release_before_any_rerank_call_does_not_load_anything(monkeypatch):
+    _patch_crossencoder(monkeypatch)
+    _force_cpu(monkeypatch)
+
+    CrossEncoderReranker().release()  # must not raise, must not load the model
+
+    assert FakeCrossEncoder.instances == []
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/unit/adapters/test_ollama_chat.py
+++ b/tests/unit/adapters/test_ollama_chat.py
@@ -1,11 +1,17 @@
 """Unit tests for monkeygrab.adapters.chat.ollama_chat.OllamaChatModel.
 
 Stubs the ollama client and requests.post entirely -- no Ollama server, no
-network -- so these run in milliseconds.
+network -- so these run in milliseconds. The one exception is the request
+timeout regression test, which talks to a real loopback socket (still no
+Ollama server, no external network) because the deadline it pins lives in
+the real ollama.Client -> httpx.Client path a Python-level stub bypasses.
 """
 
 import logging
+import socket
 import sys
+import threading
+import time
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[3]
@@ -22,15 +28,17 @@ from monkeygrab.domain.generation_chunk import GenerationChunk
 def _stub_chat(monkeypatch, calls, content="", error=None):
     """Replace the cached client factory with one recording every chat call.
 
-    Each recorded call carries the ``host`` its client was built for, so a test
-    can assert which server the adapter would have talked to.
+    Each recorded call carries the ``host`` and ``timeout`` its client was
+    built for, so a test can assert which server the adapter would have
+    talked to, and with what deadline.
     """
     class _FakeClient:
-        def __init__(self, host):
+        def __init__(self, host, timeout=None):
             self._host = host
+            self._timeout = timeout
 
         def chat(self, **kwargs):
-            calls.append({**kwargs, "host": self._host})
+            calls.append({**kwargs, "host": self._host, "client_timeout": self._timeout})
             if error is not None:
                 raise error
             return {"message": {"content": content}}
@@ -74,6 +82,19 @@ def test_generate_talks_to_the_configured_base_url(monkeypatch):
     assert calls[0]["host"] == "http://gpu-box:11434"
 
 
+def test_generate_builds_its_client_with_the_configured_request_timeout(monkeypatch):
+    """generate() used to build its client with no timeout at all (issue #232):
+    stream() applied request_timeout via requests.post, generate() dropped it
+    on the floor. The ollama client takes no per-call timeout, only one baked
+    in at construction, so this is the only place generate() can hand it over."""
+    calls = []
+    _stub_chat(monkeypatch, calls)
+
+    OllamaChatModel("m", num_ctx=100, request_timeout=42).generate("hello")
+
+    assert calls[0]["client_timeout"] == 42
+
+
 def test_generate_puts_the_system_prompt_first(monkeypatch):
     calls = []
     _stub_chat(monkeypatch, calls)
@@ -112,6 +133,64 @@ def test_generate_hard_fails_on_ollama_error(monkeypatch):
 
     with pytest.raises(RuntimeError, match="ollama down"):
         OllamaChatModel("m", num_ctx=100).generate("hello")
+
+
+def test_generate_raises_within_its_deadline_against_a_server_that_never_answers():
+    """Doubles a real, unresponsive server (not a Python-level stub) to pin
+    the issue #232 regression: generate() had no deadline of its own, so a
+    resident-but-stuck Ollama server left it blocked forever -- exactly what
+    made a 26-minute gate case (#229) impossible to bound from inside the
+    adapter. Nothing here monkeypatches ollama_client_for, so this exercises
+    the real ollama.Client -> httpx.Client path generate() actually takes.
+
+    A plain TCP listener that accepts the connection and then never writes
+    back is enough: the client's request write succeeds against the kernel's
+    receive buffer regardless of whether anything ever reads it, so the
+    adapter blocks on the response instead, which is the wait request_timeout
+    must bound.
+    """
+    request_timeout = 0.5
+
+    server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server.bind(("127.0.0.1", 0))
+    server.listen(1)
+    port = server.getsockname()[1]
+    stop = threading.Event()
+
+    def _accept_and_stay_silent():
+        try:
+            conn, _ = server.accept()
+        except OSError:
+            return  # server closed during teardown before a connection arrived
+        stop.wait(request_timeout + 5)  # hold the connection open, reply never sent
+        conn.close()
+
+    thread = threading.Thread(target=_accept_and_stay_silent, daemon=True)
+    thread.start()
+
+    # A distinct cache key per (base_url, timeout): nothing else in this
+    # module builds a real client against this port, but clearing keeps the
+    # real client this test builds from lingering in the cache afterwards.
+    module.ollama_client_for.cache_clear()
+    chat_model = OllamaChatModel(
+        "m", num_ctx=100, base_url=f"http://127.0.0.1:{port}", request_timeout=request_timeout
+    )
+
+    start = time.monotonic()
+    try:
+        with pytest.raises(RuntimeError, match="Ollama generate failed"):
+            chat_model.generate("hello")
+        elapsed = time.monotonic() - start
+    finally:
+        stop.set()
+        server.close()
+        thread.join(timeout=2)
+        module.ollama_client_for.cache_clear()
+
+    # Bounded by request_timeout, not by the server (which never answers) or
+    # by the suite's own patience -- and not near-instant either, which would
+    # mean the raise came from something other than the deadline expiring.
+    assert request_timeout <= elapsed < 5.0
 
 
 class _FakeStreamResponse:

--- a/tests/unit/test_env_example_drift.py
+++ b/tests/unit/test_env_example_drift.py
@@ -81,6 +81,10 @@ with its own reason -- never by skipping a directory or file wholesale:
   ``rag/web/desktop.py`` reads as an OS install-location fallback; the OS
   sets these, not the user via ``.env``, and MonkeyGrab defines no default
   for either.
+- ``EVAL_GENERATION_BUDGET_SECONDS`` -- overrides the eval gate's per-
+  generation wall-clock budget (``tests/eval/run_eval.py``, issue #229);
+  a gate knob for tuning a measurement run, not a product configuration
+  variable a ``.env`` deployment would ever set.
 
 Nothing today is "documented but legitimately never read" -- that is what
 ``dead`` in ``test_every_documented_env_var_is_read_by_code`` catches, and
@@ -125,6 +129,7 @@ _CODE_READS_NOT_DOCUMENTED = {
     "RUN_OLLAMA_INTEGRATION",
     "OLLAMA_GEMMA4_TEST_MODEL",
     "OLLAMA_AUX_MODEL",
+    "EVAL_GENERATION_BUDGET_SECONDS",
     "DISABLE_HMR",
     "LOCALAPPDATA",
     "XDG_DATA_HOME",

--- a/tests/unit/test_model_history_row.py
+++ b/tests/unit/test_model_history_row.py
@@ -6,6 +6,7 @@ as zero. Counting a model's unreported generation as "0 tokens" would make it
 the cheapest model in the table for the one reason that is not a measurement.
 """
 
+import json
 import sys
 from pathlib import Path
 
@@ -13,7 +14,7 @@ ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from tools.diagnostics.model_history_row import format_rows, summarise  # noqa: E402
+from tools.diagnostics.model_history_row import format_rows, main, summarise  # noqa: E402
 
 
 def _record(model, passed=True, rate=None, count=None):
@@ -91,3 +92,43 @@ class TestTheRow:
         # "not recorded *(of 0)*" states the same absence twice.
         rows = format_rows(summarise([_record("m")]), "run-1")
         assert "*(of 0)*" not in rows
+
+
+class TestReadingARealArtifact:
+    """Issue #222 adds a "conditions" block next to "run"/"summary"/"results"
+    in the artifact this tool reads -- main() only ever touches "results" and
+    "run"/"id", so an artifact carrying the new block must read exactly as it
+    did before."""
+
+    def _write_artifact(self, tmp_path):
+        payload = {
+            "run": {"timestamp": "20260101T000000Z", "stack": "s"},
+            "summary": {"overall": {"total": 2, "passed": 1, "pass_rate": 0.5}},
+            "results": [
+                _record("m", passed=True, rate=40, count=20),
+                _record("m", passed=False),
+            ],
+            "conditions": {
+                "config": {"dev": None, "blind": None},
+                "versions": {"torch": None},
+                "hardware": {"name": None, "vram_total_mib": None},
+                "git_commit": {"hash": "abc1234", "dirty": False},
+                "gold_sha256": "0" * 64,
+                "sampling": {"rag": {"temperature": 0.15}},
+                "seed": None,
+                "keep_alive_seconds": 120,
+            },
+        }
+        artifact = tmp_path / "artifact.json"
+        artifact.write_text(json.dumps(payload), encoding="utf-8")
+        return artifact
+
+    def test_main_prints_the_row_unaffected_by_the_conditions_block(self, tmp_path, capsys):
+        artifact = self._write_artifact(tmp_path)
+
+        exit_code = main([str(artifact)])
+
+        out = capsys.readouterr().out
+        assert exit_code == 0
+        assert "1 / 2" in out
+        assert "*(of 1)*" in out

--- a/tests/unit/test_persisted_settings.py
+++ b/tests/unit/test_persisted_settings.py
@@ -245,3 +245,36 @@ def test_role_env_vars_name_the_getenv_calls_that_read_them():
     }
     actual = {module_var: read_from.get(module_var) for module_var in expected}
     assert actual == expected
+
+
+# _DEFAULT_MODEL_ROLES / _DEFAULT_PIPELINE_FLAGS / _restaurar_roles_y_flags_por_defecto
+# -- issue #231: the test suite must not depend on this machine's settings.json.
+
+
+def test_default_pipeline_flags_covers_exactly_the_persisted_set():
+    """A flag missing here would come back mutated after cargar_ajustes_persistidos();
+    a flag present here but not in PERSISTED_FLAGS is dead weight. Either drift
+    should fail loudly instead of silently reopening issue #231 for that flag."""
+    assert set(rag_engine._DEFAULT_PIPELINE_FLAGS) == set(settings.PERSISTED_FLAGS)
+
+
+def test_default_model_roles_covers_every_role():
+    assert set(rag_engine._DEFAULT_MODEL_ROLES) == set(rag_engine.MODEL_ROLE_VARS)
+
+
+def test_restaurar_roles_y_flags_por_defecto_undoes_a_settings_json_style_mutation(data_dir):
+    """Simulates what cargar_ajustes_persistidos() does at rag.web.app import
+    time -- mutate every role and flag it can reach -- then asserts the
+    restore function used by tests/conftest.py's session fixture puts all of
+    them back, not just the three PIPELINE_RUNTIME_FLAGS the concrete bug
+    report named."""
+    rag_engine.set_model_roles_runtime({role: "settings-json-model" for role in rag_engine.MODEL_ROLE_VARS})
+    for flag in settings.PERSISTED_FLAGS:
+        setattr(rag_engine, flag, not getattr(rag_engine, flag))
+
+    rag_engine._restaurar_roles_y_flags_por_defecto()
+
+    assert rag_engine.get_model_roles() == rag_engine._DEFAULT_MODEL_ROLES
+    assert rag_engine.MODELO_DESC == rag_engine._inferir_descripcion_modelo(rag_engine._DEFAULT_MODEL_ROLES["rag"])
+    for flag, default in rag_engine._DEFAULT_PIPELINE_FLAGS.items():
+        assert getattr(rag_engine, flag) is default

--- a/tests/unit/test_wiring_reranker_release.py
+++ b/tests/unit/test_wiring_reranker_release.py
@@ -1,0 +1,100 @@
+"""Tests for wiring.release_reranker() (issue #239).
+
+CrossEncoderReranker.release() existed to give back its CUDA weights, but a
+repo-wide grep found zero callers: wiring.reranker() cached one instance as a
+singleton with no reset path, so once loaded its weights stayed resident for
+the rest of the process's life. release_reranker() is the exposed release
+point, mirroring release_embedder -- but unlike the embedder (whose worker
+process is gone for good and must be rebuilt), CrossEncoderReranker reloads
+its own weights lazily on the next rerank() call, so the fix drops the
+cached instance's weights without discarding the singleton itself.
+
+Doubles CrossEncoderReranker entirely: what is under test is the wiring
+cache's own behaviour, not the sentence-transformers adapter (that adapter's
+own release() is covered by
+tests/unit/adapters/test_cross_encoder_reranker.py).
+"""
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import rag.chat_pdfs  # noqa: E402,F401
+from monkeygrab.config.app_config import AppConfig  # noqa: E402
+from rag.engine import wiring  # noqa: E402
+
+
+class _FakeReranker:
+    """Stands in for CrossEncoderReranker: only the release contract matters."""
+
+    def __init__(self):
+        self.released = 0
+
+    def release(self):
+        self.released += 1
+
+
+def _reset_cache():
+    with wiring._reranker_cache_lock:
+        wiring._reranker_cache["reranker"] = None
+
+
+def _patch_class(monkeypatch):
+    built = []
+
+    def _build():
+        instance = _FakeReranker()
+        built.append(instance)
+        return instance
+
+    monkeypatch.setattr(wiring, "CrossEncoderReranker", _build)
+    return built
+
+
+def test_release_reranker_calls_release_on_the_cached_instance(monkeypatch):
+    _reset_cache()
+    built = _patch_class(monkeypatch)
+    config = AppConfig()
+
+    instance = wiring.reranker(config)
+    wiring.release_reranker()
+
+    assert built == [instance]
+    assert instance.released == 1
+
+
+def test_release_reranker_keeps_the_singleton_so_the_next_call_reuses_it(monkeypatch):
+    """Unlike release_embedder (which evicts its slot because the embedder's
+    worker process is gone for good), the reranker reloads its weights
+    lazily on the next rerank() -- so wiring.reranker() must keep returning
+    the SAME object after a release, not build a second one."""
+    _reset_cache()
+    built = _patch_class(monkeypatch)
+    config = AppConfig()
+
+    first = wiring.reranker(config)
+    wiring.release_reranker()
+    second = wiring.reranker(config)
+
+    assert first is second
+    assert len(built) == 1
+
+
+def test_release_reranker_is_a_no_op_before_anything_was_ever_built():
+    _reset_cache()
+    wiring.release_reranker()  # must not raise
+
+
+def test_release_reranker_reaches_the_cached_instance_even_called_twice(monkeypatch):
+    _reset_cache()
+    built = _patch_class(monkeypatch)
+    config = AppConfig()
+    wiring.reranker(config)
+
+    wiring.release_reranker()
+    wiring.release_reranker()
+
+    assert built[0].released == 2


### PR DESCRIPTION
## Summary

`docs/model-history.md` compared rows measured on three different gold sets
and carried five rows that had never been run. The root cause was not
sloppiness in the table but in what stood behind it: the run artifact
recorded no conditions, so nobody could tell after the fact what a row had
been measured under.

This branch fixes the causes first, then re-measures. Still in progress: the
GPU is on tranche 3 of 4, and the table will be completed before merge.

## What changed, in the order it had to happen

**Make a measurement verifiable** (#222). The artifact now carries a
`conditions` block: per-corpus config, installed versions, hardware, commit,
sha256 of the gold set, sampling parameters, `seed: null`, `keep_alive`.
`evaluate()` already computed most of it and never wrote it.

**Make a campaign possible** (#229, #219). A single generation ran 26 minutes
with `num_predict -1` and nothing bounding it, and the artifact was written
once at the end, so hours of work could vanish. Now: a 180s per-generation
budget, recorded as `budget_exceeded` (distinct from `infrastructure_error`),
and records streamed to a `.partial.jsonl` that is distinguishable from a
complete artifact by construction. The study path now reports elapsed time.

**Fix the product bug this exposed** (#232). `generate()` never applied
`request_timeout`; only `stream()` did, because the ollama client takes no
per-call timeout. The client is now cached on `(base_url, timeout)`.

**Write the standard down** (#221, #218). `tests/eval/README.md` described a
51-case, two-language, four-case-type gate. Re-anchored to the real file and
given an "Experiment standard" section: what the gate pins, what it leaves to
the environment, and why every row is n=1.

**Rebuild the table** (#218, #233). Eight generators measured on the 156-case
set under one declared set of conditions. `s/answer` is now the measured wall
time of the call -- the previous column understated the wait 36x by omitting
prompt evaluation. Superseded rows kept, grouped by the set that produced
them, labelled as not comparable.

**Stop docs from contradicting code** (#224, #225, #226, #228). The root
README said `gemma4:e4b` was retired while the code still defaults to it; the
harness docs defined the search set as 32 cases where the code returns 123;
`fast_tier.txt` said 13 and listed 16; the language-probe section said the
gate never exercises es/ca.

**Stop tests depending on the developer's machine** (#227, #230, #231).
Importing `rag.web.app` during collection applied this machine's gitignored
`settings.json` to module globals; one flag test passed only because that
file happened to agree with the defaults. The harness read `config["dev"]` on
a premise (`source: corpus` only) that #213 invalidated.

## Found and filed, not yet fixed

- #234 -- the budget-exhausting cases failed identically across every model
  in tranche 1, then not at all in tranche 2. The tranche-1 repeat
  (`20260911T230513Z`) answered most of it: 19 of the 24 were two contiguous
  windows of that run, not the models and not a shared stage; the doc now
  says so. Left open, re-scoped to the instrumentation (record start time,
  stage running when the budget hits).
- #235 -- nothing records GPU vs CPU-offload placement; `qwen3:8b` never
  reached the GPU in 24 samples and its speed column says so without saying
  why.

## Closed after the last measurement

- #220 -- phase 2 now runs model-major (`8dd3bce` integrated here with the
  budget and the partial sink kept; a new test pins that the sink still gets
  every record once, in execution order). Integrated only after the last
  tranche so no run is attributable to a runner change.
- #223 -- noise floor measured on the 156-case set: tranche 1 run twice,
  28 of 536 pairs flip on sampling alone, net -2 to +5 per model. Stated in
  "How to read", with a `Runs` column on the table.
- #240 -- `compare_runs.py` refused any run with one infrastructure error,
  which was every run with Granite in it; `--exclude-infrastructure-errors`
  drops those pairs from both sides and reports them.

## Test plan

- Every fix verified with the full `pytest` suite (1156 passed), not subsets:
  two test files with colliding basenames only surface in the full run.
- Each behavioural fix shown to fail without it: budget (2s override against
  real Ollama), partial artifact (killed run leaves records), timeout (real
  loopback socket that never answers, 0.51s), settings leak (hostile
  `settings.json`, suite green; fix reverted, the named test fails).
- `tests/characterization/` untouched throughout; `git diff --stat` on it is
  empty on every commit.
- Four tranches plus the tranche-1 repeat on the RTX 4060 8 GB:
  `20260911T032105Z`, `20260911T071629Z`, `20260911T094107Z`,
  `20260911T171038Z`, `20260911T230513Z`. About 14 GPU hours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Closes

Fixes #218
Fixes #219
Fixes #221
Fixes #222
Fixes #224
Fixes #225
Fixes #226
Fixes #227
Fixes #228
Fixes #229
Fixes #230
Fixes #231
Fixes #232
Fixes #233
Fixes #237
Fixes #238
Fixes #239
Fixes #220
Fixes #223
Fixes #240

Left open on purpose: #234 (re-scoped to instrumentation after the tranche-1
repeat), #235 (placement is recorded by hand in the table; automating it is
separate work).

