### PR TITLE
Record when, where and in which stage each evaluation record ran, and make the row tool produce the table's row

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,7 +137,7 @@ user had picked it (issue #79). Jina CLIP v2 and BGE Reranker v2 M3 are fixed.
 
 Other env vars: `DOCS_FOLDER` (default `rag/docs/en/`), `MONKEYGRAB_DATA_DIR` (writable root for `vector_db`/history/debug; defaults to the package dir in dev, `%LOCALAPPDATA%/MonkeyGrab` in the packaged app), `OLLAMA_BASE_URL` (default `http://localhost:11434`, falling back to Ollama's own `OLLAMA_HOST`).
 
-The Ollama endpoint has exactly one reader, `monkeygrab.config.env.read_env_ollama_base_url`, feeding `AppConfig.models.ollama.base_url` and `rag.chat_pdfs.OLLAMA_BASE_URL`. Every generation call, both `/chat` modes and the reachability check (web control panel) resolve through it. Do not re-read the variable at a call site: a second resolution is how a health check once ended up reporting a server the pipeline never talked to.
+The Ollama endpoint has exactly one reader, `monkeygrab.config.env.read_env_ollama_base_url`, feeding `AppConfig.models.ollama.base_url` and `rag.chat_pdfs.OLLAMA_BASE_URL`. Every generation call, both `/chat` modes, the reachability check (web control panel) and the evaluation gate's own preflight, keep-alive release and version lookup (`tests/eval/run_eval.py`, issue #244) resolve through it. Do not re-read the variable at a call site, and do not hardcode `localhost` either: a second resolution is how a health check once ended up reporting a server the pipeline never talked to.
 
 Desktop app: `rag/web/desktop.py` is the pywebview entry point frozen by PyInstaller (`packaging/MonkeyGrab.spec`, `packaging/build_exe.py`) into `MonkeyGrab.exe`. Built-in corpora ship in the bundle; Ollama is an external prerequisite. See [`packaging/README.md`](packaging/README.md).
 

--- a/docs/model-history.md
+++ b/docs/model-history.md
@@ -40,7 +40,10 @@ turns this log into a ranking, which it is not.
 3. **Placement is part of the measurement.** Two models do not fit in 7.6 GiB
    alongside the auxiliary, so Ollama may load one into system RAM instead,
    silently. Where that was observed the row says so, and its speed columns
-   describe the degraded regime (issue #235).
+   describe the degraded regime (issue #235). The rows above were annotated
+   from `ollama ps` samples taken by hand every 20 s; artifacts written after
+   #235 carry `vram_fraction` on every generation record, and
+   `tools/diagnostics/model_history_row.py` fills the column from it.
 4. **The budget column is mostly not a model property, and it counts
    against the model anyway.** A generation is capped at 180 s (issue #229)
    and an exhausted budget is scored as a failure of the row's model. The

--- a/harness/README.md
+++ b/harness/README.md
@@ -196,6 +196,16 @@ fake evaluator that raises on a declared key makes startup fail loudly
 
 ## Objective, constraint, noise floor
 
+**Which generator.** Every evaluation the loop runs -- the reference, each
+candidate, a replay -- generates with `run_eval.DEFAULT_MODELS`
+(`evaluator.real_evaluate` passes it), which is `Ling-3.0-tiny` unless
+`OLLAMA_RAG_MODEL` is set. That is the gate's default, not the product's
+(`gemma4:e4b`); the loop therefore searches for a retrieval configuration
+that helps the faster model the 0.82 floor was calibrated with, and a
+configuration it accepts has not been shown to help the shipped one. Export
+`OLLAMA_RAG_MODEL` to search for the product instead. Whether the two
+defaults should be one is issue #242.
+
 **Objective:** `objective_adjusted` = passing cases on the search set, minus
 cases listed in `unreachable_cases.txt` (excluded from both numerator and
 denominator, not just discounted). `unreachable_cases.txt` starts **empty**
@@ -363,14 +373,17 @@ python -m harness.cli --dry-run --max-iterations 3
 python -m harness.cli --proposer llm --max-iterations 8 --patience 3
 
 # Real campaign pinned to be comparable with prior ledger history -- e.g. a
-# criterion-5 recovery run against a sabotaged reference (--set is
-# repeatable; unknown keys abort at launch; pins reach EVERY measured
+# criterion-5 recovery run against a sabotaged reference. --set is
+# repeatable, unknown keys abort at launch, and pins reach EVERY measured
 # evaluation, the reference's included -- not just the harness's bookkeeping
-# config):
-RAG_TOP_K_FINAL=1 python -m harness.cli \
+# config. The generator is not a --set key: evaluate() refuses models.rag
+# (and models.recomp) as overrides because generation switches that role
+# from its own `models` argument. Pin it through the environment run_eval.py
+# reads -- OLLAMA_RAG_MODEL sets run_eval.DEFAULT_MODELS, OLLAMA_AUX_MODEL
+# the chat/contextual/recomp roles (issue #245):
+OLLAMA_RAG_MODEL=gemma4:e4b OLLAMA_AUX_MODEL=gemma4:e2b python -m harness.cli \
     --ledger-dir tests/eval/runs/harness-loop \
-    --set models.rag=gemma4:e4b --set models.chat=gemma4:e2b \
-    --set models.contextual=gemma4:e2b --set models.recomp=gemma4:e2b
+    --set retrieval.top_k_final=1
 
 # Criterion 7: reconstruct one ledger iteration and re-run its exact
 # overrides and case ids. Exit 0 iff the pass/fail vector matches.

--- a/rag/engine/generation.py
+++ b/rag/engine/generation.py
@@ -214,10 +214,21 @@ def generar_respuesta_silenciosa(
             that most needs to compare generators -- could measure seconds per
             case but not tokens per second.
 
+            Also carries ``stage`` while the call is in flight: ``"context"``
+            during message preparation (RECOMP synthesis on the auxiliary
+            model, when that flag is on) and ``"generator"`` once the model
+            under test is streaming. The gate bounds this whole call with one
+            wall-clock budget, and without the marker a cut could not say
+            which of the two it cut (issue #234).
+
     Returns:
         Complete response text.
     """
+    if stats is not None:
+        stats["stage"] = "context"
     mensaje_usuario = cfg._preparar_mensaje_usuario_rag(pregunta, fragmentos)
+    if stats is not None:
+        stats["stage"] = "generator"
     return cfg._generar_respuesta_stream(mensaje_usuario, stats=stats)
 
 

--- a/tests/eval/README.md
+++ b/tests/eval/README.md
@@ -172,7 +172,16 @@ something is missing:
    nearest 0.01) *after* the gate check, and only if that is higher than the
    current value -- the baseline never moves down automatically. It also
    refuses more than one `--models` entry: the file holds one number,
-   calibrated on the default generator.
+   calibrated on the gate's default generator.
+
+   That default is `run_eval.DEFAULT_MODELS` -- `Ling-3.0-tiny` unless `OLLAMA_RAG_MODEL`
+   says otherwise -- and it is **not** the product's default (`gemma4:e4b`). The gate and the
+   configuration harness (`harness/evaluator.real_evaluate`, which passes `DEFAULT_MODELS`)
+   measure the faster model the 0.82 floor was set with, at 7.5 s per answer against 11.8 s
+   for the shipped one; a no-argument `python tests/eval/run_eval.py` is therefore a statement
+   about the pipeline under `Ling-3.0-tiny`, not about what a user runs. Pass
+   `--models gemma4:e4b` (or export `OLLAMA_RAG_MODEL`) to measure the product; whether the
+   two defaults should be made the same is issue #242.
 
 Infrastructure failures leave the run inconclusive. Only an unfiltered gold-set
 run (`case_ids is None`, the CLI) is compared against the baseline. A subset
@@ -245,6 +254,18 @@ commit, a sha256 of `gold_cases.jsonl`, the sampling options per role, `seed: nu
 after the fact instead of merely asserted -- read it with `tools/diagnostics/model_history_row.py`
 before trusting a row. Anything measured before this was added has no such record; treat
 pre-#222 rows as rows of undocumented conditions, not as rows comparable to a later one.
+
+Each record also says when and where it ran. `started_at` (UTC, to the second) is on every
+record, so a window of a run in which every generation slowed down is visible in the artifact
+instead of having to be counted off record positions (issue #234: nineteen budget exhaustions
+in one run were two such windows). A `budget_exceeded` record carries `stage_at_budget` --
+`context` (RECOMP synthesis on the auxiliary model, when on) or `generator` for a factual
+case, `setup` or `generator` for a study case -- read off the marker
+`generar_respuesta_silenciosa` sets in its `stats` dict as it goes. Every generation record
+carries `vram_fraction`, the share of the model's bytes Ollama reports resident in VRAM
+(`/api/ps`) right after the call: `1.0` is fully on the GPU, less is CPU offload, and the key is
+absent when Ollama could not be asked (issue #235). Artifacts written before these fields
+existed simply lack them; a reader must treat a missing key as "not recorded", never as zero.
 
 ### Adding a row to `docs/model-history.md`
 

--- a/tests/eval/run_eval.py
+++ b/tests/eval/run_eval.py
@@ -61,6 +61,7 @@ if str(EVAL_DIR) not in sys.path:
 os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
 
 import grade  # noqa: E402  (tests/eval sibling module)
+from monkeygrab.config.env import read_env_ollama_base_url  # noqa: E402
 
 GOLD_FILE = EVAL_DIR / "gold_cases.jsonl"
 BASELINE_FILE = EVAL_DIR / "baseline_min_pass_rate.txt"
@@ -99,7 +100,11 @@ EXTRA_DEV_CORPORA = {
     "corpus_ca": (REPO_ROOT / "rag" / "docs" / "ca", EVAL_DIR / "dev_docs_ca", "dev set (ca)"),
 }
 
-OLLAMA_BASE_URL = "http://localhost:11434"
+# The same resolution the pipeline under test uses (AGENTS.md section 3):
+# the preflight, the keep-alive release and the version lookup must talk to
+# the server that actually generates, or a health check passes against one
+# server while the measurement runs on another (issue #244).
+OLLAMA_BASE_URL = read_env_ollama_base_url()
 
 # The baseline was calibrated with this model. Other models can be measured
 DEFAULT_MODELS = [
@@ -653,6 +658,50 @@ def _decoding_metrics(stats: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
+def _utc_now_iso() -> str:
+    """Wall-clock start of a record, so a window in a run is visible.
+
+    Issue #234: nineteen budget exhaustions turned out to be two contiguous
+    windows of one run, and the only way to see that was to count record
+    positions by hand. Seconds are enough; the artifact's own timestamp gives
+    the date.
+    """
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _placement(model: str) -> Dict[str, Any]:
+    """Where ``model`` is resident right now, as the share of its bytes in VRAM.
+
+    Issue #235: on an 8 GB card Ollama silently loads a model that does not
+    fit next to the auxiliary into system RAM, and a record's speed columns
+    then describe that regime with nothing saying so. Read right after the
+    generation call, while keep-alive still holds the weights, from the same
+    ``/api/ps`` a human would check by hand.
+
+    Best-effort like ``_ollama_server_version``: the record already holds a
+    real pass/fail, so a failed lookup returns ``{}`` rather than costing it.
+    The key is absent rather than null for the same reason ``_decoding_metrics``
+    omits its keys -- an absent value cannot be averaged by accident.
+
+    Returns:
+        ``{"vram_fraction": f}`` with ``f`` in ``[0, 1]`` (1.0 is fully on the
+        GPU), or ``{}`` when Ollama is unreachable or no longer lists the model.
+    """
+    try:
+        # Lazy and inside the try: the fast CI gate installs no `requests`,
+        # and a diagnostic must degrade to "not recorded" there, not fail.
+        import requests
+
+        response = requests.get(f"{OLLAMA_BASE_URL}/api/ps", timeout=5)
+        response.raise_for_status()
+        for entry in response.json().get("models", []):
+            if model in (entry.get("name"), entry.get("model")) and entry.get("size"):
+                return {"vram_fraction": round(entry.get("size_vram", 0) / entry["size"], 3)}
+    except Exception:  # noqa: BLE001 - best-effort, see docstring
+        pass
+    return {}
+
+
 # GENERATION BUDGET (issue #229)
 
 
@@ -784,18 +833,26 @@ def _run_study_case_for_model(
 
     malformed = (MalformedSummaryError, MalformedOutlineError, MalformedQuizError)
 
+    started_at = _utc_now_iso()
     t0 = time.perf_counter()
+    # Which stage the budget cut, if it cuts (issue #234). Study has no shared
+    # stage -- no decomposition, no RECOMP -- so this can only ever say the
+    # generator, which is itself the finding when a case exhausts the budget
+    # in every model.
+    progress: Dict[str, str] = {}
 
     def _generate() -> Dict[str, Any]:
         # Bound as one call for the budget below (issue #229) -- config
         # and fragment conversion are local and instant, only
         # study.summarize/outline/quiz talks to Ollama, but wrapping the
         # setup too keeps this a single opaque unit like run_factual_case's.
+        progress["stage"] = "setup"
         config = wiring.app_config_from_runtime().with_overrides(
             **{"models.rag": model}
         )
         domain_fragments = [wiring.fragment_from_dict(f) for f in fragments]
         study = Study(wiring.rag_chat_model(config))
+        progress["stage"] = "generator"
         lang_label = case.get("language")
         if not lang_label:
             lang = case.get("lang")
@@ -833,8 +890,11 @@ def _run_study_case_for_model(
             "id": case["id"], "paper": case["paper"], "case_type": case["case_type"],
             "lang": case["lang"], "model": model, "passed": False,
             "budget_exceeded": True,
+            "stage_at_budget": progress.get("stage", "unknown"),
             "reason": str(exc),
             "elapsed_seconds": round(elapsed, 2),
+            "started_at": started_at,
+            **_placement(model),
         }
         print(f"  [BUDGET] {case['id']} / {model} ({elapsed:.1f}s) -- {exc}", flush=True)
         return record
@@ -845,6 +905,8 @@ def _run_study_case_for_model(
             "lang": case["lang"], "model": model, "passed": False,
             "reason": f"malformed artifact -- {type(exc).__name__}: {str(exc)[:120]}",
             "elapsed_seconds": round(elapsed, 2),
+            "started_at": started_at,
+            **_placement(model),
         }
         print(
             f"  [FAIL] {case['id']} / {model} ({elapsed:.1f}s) -- malformed artifact",
@@ -859,6 +921,7 @@ def _run_study_case_for_model(
             "infrastructure_error": True,
             "reason": f"study failed -- {type(exc).__name__}: {exc}",
             "elapsed_seconds": round(elapsed, 2),
+            "started_at": started_at,
         }
         print(
             f"  [ERROR] {case['id']} / {model} ({elapsed:.1f}s): {type(exc).__name__}: {exc}",
@@ -873,6 +936,8 @@ def _run_study_case_for_model(
         "lang": case["lang"], "model": model, "passed": result["pass"],
         "reason": result["reason"],
         "elapsed_seconds": round(elapsed, 2),
+        "started_at": started_at,
+        **_placement(model),
     }
     status = "PASS" if result["pass"] else "FAIL"
     print(
@@ -943,9 +1008,14 @@ def _run_factual_case_for_model(
             "passed": False,
             "reason": "no fragments retrieved",
             "elapsed_seconds": round(retrieval_elapsed, 2),
+            "started_at": _utc_now_iso(),
         }
 
+    started_at = _utc_now_iso()
     t0 = time.perf_counter()
+    # generar_respuesta_silenciosa marks "context" (RECOMP, when on) and
+    # "generator" in here as it goes, so a budget cut can say which one it
+    # cut (issue #234) instead of leaving it to be guessed from the case.
     gen_stats: Dict[str, Any] = {}
     try:
         answer = _run_with_budget(
@@ -964,8 +1034,11 @@ def _run_factual_case_for_model(
             "model": model,
             "passed": False,
             "budget_exceeded": True,
+            "stage_at_budget": gen_stats.get("stage", "unknown"),
             "reason": str(exc),
             "elapsed_seconds": round(retrieval_elapsed + gen_elapsed, 2),
+            "started_at": started_at,
+            **_placement(model),
         }
         print(f"  [BUDGET] {case['id']} / {model} ({gen_elapsed:.1f}s) -- {exc}", flush=True)
         return record
@@ -985,6 +1058,7 @@ def _run_factual_case_for_model(
             "infrastructure_error": True,
             "reason": f"{type(exc).__name__}: {exc}",
             "elapsed_seconds": round(retrieval_elapsed + gen_elapsed, 2),
+            "started_at": started_at,
         }
         print(f"  [ERROR] {case['id']} / {model} -- {type(exc).__name__}: {exc}", flush=True)
         return record
@@ -1004,7 +1078,9 @@ def _run_factual_case_for_model(
         # on this corpus retrieval dominates it -- comparing generators by
         # that number mostly compares how busy the card was.
         "generation_seconds": round(gen_elapsed, 2),
+        "started_at": started_at,
         **_decoding_metrics(gen_stats),
+        **_placement(model),
     }
     if not result["pass"]:
         record["answer"] = answer
@@ -1332,6 +1408,7 @@ def _run_retrieval_for_corpus(cases, retrieve, evidence, records, pending, store
     is open, and still land in ``pending`` because generation is phase 2's job.
     """
     for case in cases:
+        started_at = _utc_now_iso()
         t0 = time.perf_counter()
         if case["case_type"] in _STUDY_CASE_TYPES:
             if store is None:
@@ -1341,6 +1418,7 @@ def _run_retrieval_for_corpus(cases, retrieve, evidence, records, pending, store
                     "infrastructure_error": True,
                     "reason": "study case needs the vector store and none was provided",
                     "elapsed_seconds": 0.0,
+                    "started_at": started_at,
                 })
                 continue
             fragments = document_chunks(store, f"{case['paper']}.pdf")
@@ -1352,6 +1430,7 @@ def _run_retrieval_for_corpus(cases, retrieve, evidence, records, pending, store
                     "infrastructure_error": True,
                     "reason": f"no stored chunks for {case['paper']}.pdf",
                     "elapsed_seconds": round(elapsed, 2),
+                    "started_at": started_at,
                 })
                 print(f"  [ERROR] {case['id']} -- no chunks for {case['paper']}.pdf", flush=True)
                 continue
@@ -1379,6 +1458,7 @@ def _run_retrieval_for_corpus(cases, retrieve, evidence, records, pending, store
                     "infrastructure_error": True,
                     "reason": f"retrieval failed -- {type(exc).__name__}: {exc}",
                     "elapsed_seconds": round(time.perf_counter() - t0, 2),
+                    "started_at": started_at,
                 }
             )
             print(f"  [ERROR] {case['id']} -- retrieval: {type(exc).__name__}: {exc}", flush=True)
@@ -1394,7 +1474,7 @@ def _run_retrieval_for_corpus(cases, retrieve, evidence, records, pending, store
         # "retrieved" and quietly inflate the figure and table scores -- the
         # two the multimodal stack exists to move.
         if case["case_type"] in _RETRIEVAL_ONLY_CASE_TYPES:
-            record = run_retrieval_case(case, retrieved, elapsed)
+            record = {**run_retrieval_case(case, retrieved, elapsed), "started_at": started_at}
             records.append(record)
             status = "PASS" if record["passed"] else "FAIL"
             print(f"  [{status}] {case['id']} ({elapsed:.1f}s) -- {record['reason']}", flush=True)

--- a/tests/eval/test_record_instrumentation.py
+++ b/tests/eval/test_record_instrumentation.py
@@ -1,0 +1,218 @@
+"""Tests for what a generation record says about *when* and *where* it ran.
+
+Issue #234's repeat showed 19 budget exhaustions that were two contiguous
+windows of one run, not the models -- and the only way to see that was to
+count record positions by hand, because a record carried no clock. Issue
+#235 showed a model measured entirely from system RAM with nothing in the
+artifact saying so. Three fields close that gap: ``started_at`` on every
+record, ``stage_at_budget`` on a budget-exhausted one, and ``vram_fraction``
+on every generation record.
+
+No GPU or Ollama server: the rag module is a double and ``/api/ps`` is a
+planted ``requests`` module, the same way test_generation_keep_alive.py
+satisfies run_eval.py's lazy ``import requests`` in the fast CI gate.
+"""
+
+import importlib
+import sys
+import time
+import types
+from datetime import datetime
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import pytest  # noqa: E402
+
+import run_eval  # noqa: E402
+
+
+def _case():
+    return {
+        "id": "c1", "paper": "p", "case_type": "factual_number", "lang": "en",
+        "question": "how many?", "accepted_answers": ["42"],
+    }
+
+
+def _fragment():
+    return {"doc": "text", "metadata": {"source": "p.pdf", "page": 1}}
+
+
+class _FakeRag:
+    """Answers "42" and reports what the real silent path reports: token
+    counts, plus the stage marker generar_respuesta_silenciosa now sets."""
+
+    def set_model_roles_runtime(self, roles):
+        pass
+
+    def generar_respuesta_silenciosa(self, question, fragments, stats=None):
+        if stats is not None:
+            stats["stage"] = "context"
+            stats["stage"] = "generator"
+            stats.update({"eval_count": 4, "eval_duration": 40_000_000})
+        return "42"
+
+
+class _FakeRagStuckInContext(_FakeRag):
+    """Marks the context stage and never comes back -- RECOMP hanging."""
+
+    def generar_respuesta_silenciosa(self, question, fragments, stats=None):
+        if stats is not None:
+            stats["stage"] = "context"
+        time.sleep(1)
+        raise AssertionError("must have been abandoned by the budget")
+
+
+@pytest.fixture
+def no_placement(monkeypatch):
+    """Keep placement out of tests that are about the other fields."""
+    monkeypatch.setattr(run_eval, "_placement", lambda model: {})
+
+
+def _is_utc_iso(value):
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    return parsed.tzinfo is not None and parsed.utcoffset().total_seconds() == 0
+
+
+# started_at (issue #234)
+
+
+def test_a_generation_record_carries_its_utc_start_time(no_placement):
+    record = run_eval._run_factual_case_for_model(_FakeRag(), _case(), [_fragment()], "m", 0.0)
+    assert _is_utc_iso(record["started_at"])
+
+
+def test_a_budget_exhausted_record_carries_its_start_time_too(monkeypatch, no_placement):
+    monkeypatch.setattr(run_eval, "GENERATION_BUDGET_SECONDS", 0.05)
+    record = run_eval._run_factual_case_for_model(
+        _FakeRagStuckInContext(), _case(), [_fragment()], "m", 0.0
+    )
+    assert record["budget_exceeded"] is True
+    assert _is_utc_iso(record["started_at"])
+
+
+def test_a_retrieval_record_carries_its_start_time(monkeypatch):
+    class _Retrieve:
+        def run(self, question):
+            raise RuntimeError("simulated retrieval failure")
+
+    records, pending = [], []
+    case = {**_case(), "source": "corpus"}
+    run_eval._run_retrieval_for_corpus([case], _Retrieve(), None, records, pending)
+    assert records[0]["infrastructure_error"] is True
+    assert _is_utc_iso(records[0]["started_at"])
+
+
+# stage_at_budget (issue #234)
+
+
+def test_a_budget_exhausted_factual_record_names_the_stage_that_was_running(monkeypatch, no_placement):
+    monkeypatch.setattr(run_eval, "GENERATION_BUDGET_SECONDS", 0.05)
+    record = run_eval._run_factual_case_for_model(
+        _FakeRagStuckInContext(), _case(), [_fragment()], "m", 0.0
+    )
+    assert record["stage_at_budget"] == "context"
+
+
+def test_a_record_that_finished_within_budget_has_no_stage_field(no_placement):
+    record = run_eval._run_factual_case_for_model(_FakeRag(), _case(), [_fragment()], "m", 0.0)
+    assert "stage_at_budget" not in record
+
+
+def test_a_budget_exhausted_record_says_unknown_when_nothing_marked_a_stage(monkeypatch, no_placement):
+    class _Silent(_FakeRag):
+        def generar_respuesta_silenciosa(self, question, fragments, stats=None):
+            time.sleep(1)
+
+    monkeypatch.setattr(run_eval, "GENERATION_BUDGET_SECONDS", 0.05)
+    record = run_eval._run_factual_case_for_model(_Silent(), _case(), [_fragment()], "m", 0.0)
+    assert record["stage_at_budget"] == "unknown"
+
+
+# vram_fraction (issue #235)
+
+
+class _Response:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self._payload
+
+
+@pytest.fixture
+def ps(monkeypatch):
+    """Plant a ``requests`` whose GET answers /api/ps with what the test sets."""
+    state = {"payload": {"models": []}, "urls": []}
+
+    def _get(url, timeout=None):
+        state["urls"].append(url)
+        if isinstance(state["payload"], Exception):
+            raise state["payload"]
+        return _Response(state["payload"])
+
+    fake = types.ModuleType("requests")
+    fake.get = _get
+    monkeypatch.setitem(sys.modules, "requests", fake)
+    return state
+
+
+def test_placement_is_the_vram_share_ollama_reports_for_that_model(ps):
+    ps["payload"] = {"models": [
+        {"name": "other", "model": "other", "size": 100, "size_vram": 100},
+        {"name": "m", "model": "m", "size": 1000, "size_vram": 640},
+    ]}
+    assert run_eval._placement("m") == {"vram_fraction": 0.64}
+    assert ps["urls"] == [f"{run_eval.OLLAMA_BASE_URL}/api/ps"]
+
+
+def test_placement_is_absent_when_ollama_no_longer_lists_the_model(ps):
+    ps["payload"] = {"models": [{"name": "other", "model": "other", "size": 1, "size_vram": 1}]}
+    assert run_eval._placement("m") == {}
+
+
+def test_placement_is_absent_rather_than_fatal_when_ps_fails(ps):
+    # Best-effort like the version lookup: a diagnostic must not cost the
+    # run a record that already holds a real pass/fail.
+    ps["payload"] = ConnectionError("simulated")
+    assert run_eval._placement("m") == {}
+
+
+def test_placement_lands_on_a_passing_generation_record(monkeypatch):
+    monkeypatch.setattr(run_eval, "_placement", lambda model: {"vram_fraction": 1.0})
+    record = run_eval._run_factual_case_for_model(_FakeRag(), _case(), [_fragment()], "m", 0.0)
+    assert record["vram_fraction"] == 1.0
+
+
+def test_placement_lands_on_a_budget_exhausted_record(monkeypatch):
+    # The model is still loaded when the budget hits -- and where it was
+    # loaded is exactly what #235 wants next to a slow record.
+    monkeypatch.setattr(run_eval, "GENERATION_BUDGET_SECONDS", 0.05)
+    monkeypatch.setattr(run_eval, "_placement", lambda model: {"vram_fraction": 0.3})
+    record = run_eval._run_factual_case_for_model(
+        _FakeRagStuckInContext(), _case(), [_fragment()], "m", 0.0
+    )
+    assert record["vram_fraction"] == 0.3
+
+
+def test_placement_is_read_for_the_model_under_test(monkeypatch):
+    seen = []
+    monkeypatch.setattr(run_eval, "_placement", lambda model: seen.append(model) or {})
+    run_eval._run_factual_case_for_model(_FakeRag(), _case(), [_fragment()], "the-model", 0.0)
+    assert seen == ["the-model"]
+
+
+# OLLAMA_BASE_URL (issue #244)
+
+
+def test_the_gates_own_endpoint_follows_ollama_base_url(monkeypatch):
+    monkeypatch.setenv("OLLAMA_BASE_URL", "http://eval-host.test:9999/")
+    try:
+        importlib.reload(run_eval)
+        assert run_eval.OLLAMA_BASE_URL == "http://eval-host.test:9999"
+    finally:
+        monkeypatch.delenv("OLLAMA_BASE_URL")
+        importlib.reload(run_eval)

--- a/tests/test_generation_stage_marks.py
+++ b/tests/test_generation_stage_marks.py
@@ -1,0 +1,54 @@
+"""The silent generation path says which stage it is in, through ``stats``.
+
+Issue #234: a budget-exhausted evaluation record could not say whether the
+context stage (RECOMP synthesis on the auxiliary model, when the flag is on)
+or the generator itself was running when the cap hit. ``run_eval.py`` bounds
+``generar_respuesta_silenciosa`` as one opaque call and reads the marker off
+the same ``stats`` dict Ollama's counters land in.
+
+Lives here rather than under tests/unit because it imports the engine
+(``rag.engine.generation`` pulls in wiring and the runtime globals), which
+the dependency-free CI job cannot load.
+"""
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import rag.chat_pdfs  # noqa: E402,F401  (the facade must load before its engine modules)
+from rag.engine import generation  # noqa: E402
+
+
+def test_the_silent_path_marks_context_then_generator(monkeypatch):
+    seen = []
+    stats = {}
+
+    def _prepare(pregunta, fragmentos):
+        seen.append(("context", stats.get("stage")))
+        return "user message"
+
+    def _stream(mensaje_usuario, on_token=None, stats=None):
+        seen.append(("generator", stats.get("stage")))
+        stats.update({"eval_count": 1, "eval_duration": 1})
+        return "answer"
+
+    monkeypatch.setattr(generation.cfg, "_preparar_mensaje_usuario_rag", _prepare)
+    monkeypatch.setattr(generation.cfg, "_generar_respuesta_stream", _stream)
+
+    assert generation.generar_respuesta_silenciosa("q", [], stats=stats) == "answer"
+    # Each stage sees its own marker already set when it starts, so a cap
+    # that hits mid-stage reads the stage that was running.
+    assert seen == [("context", "context"), ("generator", "generator")]
+    # Ollama's counters land on top of the marker, not instead of it.
+    assert stats == {"stage": "generator", "eval_count": 1, "eval_duration": 1}
+
+
+def test_the_silent_path_still_works_with_no_stats_dict(monkeypatch):
+    monkeypatch.setattr(generation.cfg, "_preparar_mensaje_usuario_rag", lambda q, f: "m")
+    monkeypatch.setattr(
+        generation.cfg, "_generar_respuesta_stream", lambda m, on_token=None, stats=None: "a"
+    )
+    assert generation.generar_respuesta_silenciosa("q", []) == "a"

--- a/tests/unit/test_model_history_row.py
+++ b/tests/unit/test_model_history_row.py
@@ -1,9 +1,12 @@
-"""The three numbers a model-history row reports, and what it refuses to say.
+"""What a model-history row reports, and what it refuses to say.
 
-Issue #146. The interesting behaviour here is not the arithmetic, it is what
-happens to records that carry no token statistics: they are skipped, never read
-as zero. Counting a model's unreported generation as "0 tokens" would make it
-the cheapest model in the table for the one reason that is not a measurement.
+Issue #146, corrected by #241. `seconds_per_answer` must be the wall time of
+the generation call (`generation_seconds`), not tokens divided by the decode
+rate -- the old formula understated a measured 7.89 s wait as 0.22 s. The
+other running theme is what happens to a record that carries no statistics,
+no wall time, or no VRAM sample: it is skipped, never read as zero. Counting
+an absence as zero would make the unmeasured case look like the cheapest or
+fastest one in the table, which is not a measurement.
 """
 
 import json
@@ -17,81 +20,184 @@ if str(ROOT) not in sys.path:
 from tools.diagnostics.model_history_row import format_rows, main, summarise  # noqa: E402
 
 
-def _record(model, passed=True, rate=None, count=None):
+def _record(
+    model,
+    passed=True,
+    rate=None,
+    count=None,
+    generation_seconds=None,
+    eval_duration_s=None,
+    budget_exceeded=False,
+    infrastructure_error=False,
+    vram_fraction=None,
+):
     record = {"model": model, "passed": passed}
     if rate is not None:
         record["tokens_per_second"] = rate
     if count is not None:
         record["eval_count"] = count
+    if generation_seconds is not None:
+        record["generation_seconds"] = generation_seconds
+    if eval_duration_s is not None:
+        record["eval_duration_s"] = eval_duration_s
+    if budget_exceeded:
+        record["budget_exceeded"] = True
+    if infrastructure_error:
+        record["infrastructure_error"] = True
+    if vram_fraction is not None:
+        record["vram_fraction"] = vram_fraction
     return record
 
 
-class TestTheThreeNumbers:
-    def test_latency_is_the_tokens_divided_by_the_rate(self):
-        # The whole point of #146: 96 tokens at 38.2 tok/s is 2.51 s, and the
-        # table only ever showed the 38.2.
-        summary = summarise([_record("m", rate=38.2, count=96)])["m"]
-        assert summary["tokens_per_answer"] == 96
-        assert round(summary["seconds_per_answer"], 2) == 2.51
-
-    def test_a_faster_decoder_can_be_the_slower_model(self):
-        summary = summarise(
-            [_record("reasoner", rate=38.2, count=96), _record("terse", rate=43.5, count=5)]
+class TestTheWait:
+    def test_seconds_per_answer_is_the_wall_time_not_tokens_over_rate(self):
+        # The point of #241: count/rate is 22/100 = 0.22 s, which is exactly
+        # what the old formula would have reported and exactly the decode
+        # time below it -- neither is the 7.89 s the user actually waited.
+        record = _record(
+            "m", rate=100.0, count=22, generation_seconds=7.89, eval_duration_s=0.22
         )
-        assert summary["reasoner"]["tokens_per_second"] < summary["terse"]["tokens_per_second"]
-        assert summary["reasoner"]["seconds_per_answer"] > summary["terse"]["seconds_per_answer"]
+        summary = summarise([record])[0]["m"]
+        assert summary["seconds_per_answer"] == 7.89
+        assert summary["decode_seconds_per_answer"] == 0.22
+
+    def test_a_record_with_tokens_but_no_wall_time_skips_only_the_wait(self):
+        summary = summarise([_record("m", rate=40, count=10)])[0]["m"]
+        assert summary["tokens_per_answer"] == 10
+        assert summary["measured"] == 1
+        assert summary["measured_wall"] == 0
+        assert summary["seconds_per_answer"] is None
 
     def test_the_median_is_used_so_one_runaway_does_not_move_the_row(self):
         records = [_record("m", rate=40, count=10) for _ in range(4)]
         records.append(_record("m", rate=40, count=4000))
-        assert summarise(records)["m"]["tokens_per_answer"] == 10
+        assert summarise(records)[0]["m"]["tokens_per_answer"] == 10
 
 
 class TestWhatItRefusesToCount:
     def test_records_without_statistics_are_skipped_not_read_as_zero(self):
-        summary = summarise([_record("m", rate=40, count=20), _record("m")])["m"]
+        summary = summarise([_record("m", rate=40, count=20), _record("m")])[0]["m"]
         assert summary["tokens_per_answer"] == 20
         assert summary["answered"] == 2
         assert summary["measured"] == 1
 
     def test_a_model_that_reported_nothing_yields_no_figures(self):
-        summary = summarise([_record("m"), _record("m")])["m"]
+        summary = summarise([_record("m"), _record("m")])[0]["m"]
         assert summary["measured"] == 0
         assert summary["tokens_per_answer"] is None
         assert summary["seconds_per_answer"] is None
 
     def test_a_rate_without_a_count_gives_no_latency(self):
         # Half a pair cannot produce the number this tool exists to report.
-        summary = summarise([_record("m", rate=40)])["m"]
+        summary = summarise([_record("m", rate=40)])[0]["m"]
         assert summary["measured"] == 0
 
-    def test_records_with_no_model_are_ignored(self):
-        assert summarise([{"passed": True}]) == {}
+    def test_records_with_no_model_are_tallied_as_shared_not_per_model(self):
+        per_model, shared = summarise([{"passed": True}])
+        assert per_model == {}
+        assert shared == {"passed": 1, "total": 1}
+
+
+class TestBudgetAndInfra:
+    def test_budget_and_infra_are_counted_independently(self):
+        records = [
+            _record("m", budget_exceeded=True),
+            _record("m", infrastructure_error=True),
+            _record("m"),
+        ]
+        summary = summarise(records)[0]["m"]
+        assert summary["answered"] == 3
+        assert summary["budget"] == 1
+        assert summary["infra"] == 1
+
+
+class TestRetrievalOnlyIsSharedNotPerModel:
+    def test_shared_cases_are_counted_once_and_never_into_a_models_answered(self):
+        records = [
+            _record(None, passed=True),
+            _record(None, passed=False),
+            _record("m", passed=True),
+        ]
+        per_model, shared = summarise(records)
+        assert shared == {"passed": 1, "total": 2}
+        assert per_model["m"]["answered"] == 1
+        assert per_model["m"]["passed"] == 1
+
+
+class TestPlacement:
+    def test_no_sample_is_not_recorded(self):
+        assert summarise([_record("m")])[0]["m"]["placement"] == "not recorded"
+
+    def test_every_sample_fully_on_gpu(self):
+        records = [_record("m", vram_fraction=1.0), _record("m", vram_fraction=1.0)]
+        assert summarise(records)[0]["m"]["placement"] == "GPU"
+
+    def test_every_sample_fully_on_cpu(self):
+        assert summarise([_record("m", vram_fraction=0.0)])[0]["m"]["placement"] == "CPU"
+
+    def test_mixed_samples_report_the_cpu_share_of_the_median_and_that_it_varies(self):
+        records = [_record("m", vram_fraction=1.0), _record("m", vram_fraction=0.0)]
+        assert summarise(records)[0]["m"]["placement"] == "~50% CPU (varies)"
+
+    def test_identical_partial_samples_report_the_share_without_varies(self):
+        records = [_record("m", vram_fraction=0.5), _record("m", vram_fraction=0.5)]
+        assert summarise(records)[0]["m"]["placement"] == "~50% CPU"
 
 
 class TestTheRow:
     def test_an_unmeasured_column_says_so_rather_than_showing_a_number(self):
-        rows = format_rows(summarise([_record("m")]), "run-1")
+        rows = format_rows(*summarise([_record("m")]), "run-1")
         assert "not recorded" in rows
-        assert "0" not in rows.split("|")[4]
 
     def test_a_partial_denominator_is_shown(self):
-        # Three medians over 1 of 2 records deserve less trust than over 23,
-        # and the row has to say which it is.
-        rows = format_rows(summarise([_record("m", rate=40, count=20), _record("m")]), "run-1")
+        # A median over 1 of 2 records deserves less trust than over 23, and
+        # the row has to say which it is.
+        rows = format_rows(
+            *summarise([_record("m", rate=40, count=20), _record("m")]), "run-1"
+        )
         assert "*(of 1)*" in rows
+
+    def test_a_model_with_nothing_measured_does_not_say_of_zero(self):
+        # "not recorded *(of 0)*" states the same absence twice.
+        rows = format_rows(*summarise([_record("m")]), "run-1")
+        assert "*(of 0)*" not in rows
 
     def test_pass_counts_use_every_answered_case_not_only_measured_ones(self):
         rows = format_rows(
-            summarise([_record("m", passed=True, rate=40, count=20), _record("m", passed=False)]),
+            *summarise(
+                [_record("m", passed=True, rate=40, count=20), _record("m", passed=False)]
+            ),
             "run-1",
         )
         assert "1 / 2" in rows
 
-    def test_a_model_with_nothing_measured_does_not_say_of_zero(self):
-        # "not recorded *(of 0)*" states the same absence twice.
-        rows = format_rows(summarise([_record("m")]), "run-1")
-        assert "*(of 0)*" not in rows
+    def test_header_and_a_full_row_cell_for_cell(self):
+        records = [
+            _record(
+                "m",
+                passed=True,
+                rate=40.0,
+                count=20,
+                generation_seconds=8.0,
+                eval_duration_s=0.5,
+                vram_fraction=1.0,
+            ),
+            _record("m", passed=False),
+            _record(None, passed=True),
+            _record(None, passed=False),
+        ]
+        rows = format_rows(*summarise(records), "run-42").splitlines()
+
+        assert rows[0] == (
+            "| Model | Answered | Overall | tokens/s | tokens/answer | s/answer | "
+            "decode s/answer | Budget hit | Infra | Placement | Run |"
+        )
+        # answered: 1/2 passed; overall folds in the 2 shared cases (1 passed):
+        # 2/4. tokens/answer and s/answer are each measured on 1 of 2 records.
+        assert rows[2] == (
+            "| `m` | 1 / 2 (50.0%) | 2 / 4 (50.0%) | 40.0 | 20 *(of 1)* | "
+            "8.00 *(of 1)* | 0.50 | 0 | 0 | GPU | `run-42` |"
+        )
 
 
 class TestReadingARealArtifact:
@@ -132,3 +238,5 @@ class TestReadingARealArtifact:
         assert exit_code == 0
         assert "1 / 2" in out
         assert "*(of 1)*" in out
+        # The Run cell is the timestamp the table cites, not the file's stem.
+        assert "`20260101T000000Z`" in out

--- a/tools/diagnostics/model_history_row.py
+++ b/tools/diagnostics/model_history_row.py
@@ -1,28 +1,31 @@
 """Turn a gate run artifact into the `docs/model-history.md` row for each model.
 
-Issue #146. The history table had one speed column, tokens/s, and that column
-ranks models in the wrong order.
-
-Latency per answer is tokens divided by rate, and a model that reasons inline
-spends tokens the flag was supposed to suppress. Measured 2026-09-01 on one
-representative prompt with `think: false`, `num_predict: 96`: `qwen3:30b-a3b`
-used 96 tokens at 38.2 tok/s (2.51 s) where `qwen3-coder-30b` used 5 at 43.5
-(0.11 s). Fourteen per cent apart on the column the table shows, twenty-three
-times apart on the wait the user actually sits through.
-
-So this reports three numbers per model, and the third is the one to read:
-
-    tokens/s          how fast it decodes
-    tokens/answer     how much it decides to say
-    s/answer          the product of the two -- the wait
+Issue #146, corrected by #241. `s/answer` is the wall time of the generation
+call (`generation_seconds`), not tokens divided by the decode rate: issue
+#233 measured that the old formula understated the wait by a factor of 36 --
+0.22 s against a measured 7.89 s -- because dividing tokens by rate omits
+prompt evaluation, which dominates when the prompt is retrieved context.
+Decode time is still reported, but under its own name
+(`decode_seconds_per_answer`, from `eval_duration_s`) so it cannot be
+mistaken for the wait again.
 
 Aggregation is the median, not the mean: one truncated or one runaway
 generation should not move the figure that goes in a durable table.
 
-Records missing the counts are skipped rather than read as zero, matching
-`run_eval.record_generation_stats`, which omits the keys entirely when Ollama
-reports none. Counting those as zero would drag tokens/answer toward "cheap"
-for a reason that is not real.
+Records missing a field are skipped rather than read as zero, matching
+`run_eval._decoding_metrics`, which omits its keys entirely when Ollama
+reports nothing (and matching every record written before a field existed,
+such as `vram_fraction`). Counting an absence as zero would drag a median
+toward "cheap" or "instant" for a reason that is not a measurement.
+
+Retrieval-only cases (`model` is `None`) are shared by every model in the
+run -- the gate runs them once, not once per model -- so they are tallied
+once here too and handed back separately, letting a caller add them into
+each row's `Overall` without counting the same 20 cases once per model.
+
+Columns match the current table in `docs/model-history.md` ("Generators on
+the current gold set"): Answered, Overall, tokens/s, tokens/answer,
+s/answer, decode s/answer, Budget hit, Infra, Placement, Run.
 
 Usage:
     python tools/diagnostics/model_history_row.py tests/eval/runs/<artifact>.json
@@ -35,79 +38,189 @@ import json
 import statistics
 import sys
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 
 def _median(values: List[float]) -> Optional[float]:
     return statistics.median(values) if values else None
 
 
-def summarise(results: List[Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
-    """Per-model figures for the history table.
+def _placement(vram_fractions: List[float]) -> str:
+    """Describe where a model's weights sat in memory, from `vram_fraction` samples.
 
     Args:
-        results: The artifact's ``results`` list, one record per case per model.
+        vram_fractions: One sample per record that reported it, each the
+            share of the model's bytes resident in VRAM right after that
+            call (1.0 fully on the GPU, 0.0 fully in system RAM).
 
     Returns:
-        Model name -> figures. ``answered`` counts the records that reached a
-        generator at all; ``measured`` counts the subset that also carried
-        token statistics, and the two differ whenever a model reported none.
-        Both are reported because a median over three records deserves less
-        trust than one over twenty-three, and hiding the denominator is how a
-        table stops saying that.
+        "not recorded" with no samples (the artifact predates the field);
+        "GPU" / "CPU" when every sample agrees; otherwise the CPU share of
+        the median sample, with " (varies)" appended when samples disagree.
+    """
+    if not vram_fractions:
+        return "not recorded"
+    if all(v == 1.0 for v in vram_fractions):
+        return "GPU"
+    if all(v == 0.0 for v in vram_fractions):
+        return "CPU"
+    median = statistics.median(vram_fractions)
+    label = f"~{round(100 * (1 - median))}% CPU"
+    if min(vram_fractions) != max(vram_fractions):
+        label += " (varies)"
+    return label
+
+
+def summarise(
+    results: List[Dict[str, Any]],
+) -> Tuple[Dict[str, Dict[str, Any]], Dict[str, int]]:
+    """Per-model figures for the history table, plus the shared retrieval-only tally.
+
+    Args:
+        results: The artifact's ``results`` list -- one record per case per
+            model, plus the retrieval-only cases where ``model`` is falsy.
+
+    Returns:
+        ``(per_model, shared)``.
+
+        ``per_model`` maps model name to a dict of: ``answered``/``passed``/
+        ``budget``/``infra`` (counts); ``tokens_per_second``/
+        ``tokens_per_answer`` (medians of ``tokens_per_second``/``eval_count``
+        over records carrying both -- pairing them keeps the two medians
+        describing the same generations); ``seconds_per_answer`` (median of
+        ``generation_seconds``, the wait); ``decode_seconds_per_answer``
+        (median of ``eval_duration_s``, decode time only); ``measured`` (how
+        many records had both token fields) and ``measured_wall`` (how many
+        had ``generation_seconds``) -- reported so a median over three
+        records is not trusted like one over twenty-three; ``placement``,
+        ``vram_fraction_min`` and ``vram_fraction_median`` (``None`` when no
+        record carries ``vram_fraction``).
+
+        ``shared`` is ``{"passed": int, "total": int}`` for the
+        retrieval-only cases. They are identical for every model in one run,
+        so folding them into each model's counts would count the same cases
+        once per model instead of once; kept separate, a caller computes
+        ``overall = (passed + shared["passed"]) / (answered +
+        shared["total"])``.
     """
     per_model: Dict[str, Dict[str, Any]] = {}
+    shared_total = 0
+    shared_passed = 0
     for record in results:
         model = record.get("model")
         if not model:
+            shared_total += 1
+            if record.get("passed"):
+                shared_passed += 1
             continue
+
         entry = per_model.setdefault(
             model,
-            {"answered": 0, "passed": 0, "rates": [], "counts": [], "seconds": []},
+            {
+                "answered": 0,
+                "passed": 0,
+                "budget": 0,
+                "infra": 0,
+                "rates": [],
+                "counts": [],
+                "gen_seconds": [],
+                "decode_seconds": [],
+                "vram": [],
+            },
         )
         entry["answered"] += 1
         if record.get("passed"):
             entry["passed"] += 1
+        if record.get("budget_exceeded"):
+            entry["budget"] += 1
+        if record.get("infrastructure_error"):
+            entry["infra"] += 1
+
         rate, count = record.get("tokens_per_second"), record.get("eval_count")
-        # Both or neither: a rate without a count cannot give a latency, and
-        # pairing them per record keeps the three medians describing the same
-        # generations rather than three different subsets.
+        # Both or neither: a rate without a count cannot give tokens/answer,
+        # and pairing them per record keeps the two medians describing the
+        # same generations rather than two different subsets.
         if rate and count:
             entry["rates"].append(float(rate))
             entry["counts"].append(int(count))
-            entry["seconds"].append(float(count) / float(rate))
+
+        gen_seconds = record.get("generation_seconds")
+        if gen_seconds is not None:
+            entry["gen_seconds"].append(float(gen_seconds))
+
+        decode_seconds = record.get("eval_duration_s")
+        if decode_seconds is not None:
+            entry["decode_seconds"].append(float(decode_seconds))
+
+        vram_fraction = record.get("vram_fraction")
+        if vram_fraction is not None:
+            entry["vram"].append(float(vram_fraction))
 
     for entry in per_model.values():
         entry["measured"] = len(entry["counts"])
+        entry["measured_wall"] = len(entry["gen_seconds"])
         entry["tokens_per_second"] = _median(entry["rates"])
         entry["tokens_per_answer"] = _median([float(c) for c in entry["counts"]])
-        entry["seconds_per_answer"] = _median(entry["seconds"])
-        for key in ("rates", "counts", "seconds"):
+        entry["seconds_per_answer"] = _median(entry["gen_seconds"])
+        entry["decode_seconds_per_answer"] = _median(entry["decode_seconds"])
+        entry["vram_fraction_min"] = min(entry["vram"]) if entry["vram"] else None
+        entry["vram_fraction_median"] = _median(entry["vram"])
+        entry["placement"] = _placement(entry["vram"])
+        for key in ("rates", "counts", "gen_seconds", "decode_seconds", "vram"):
             del entry[key]
-    return per_model
+
+    return per_model, {"passed": shared_passed, "total": shared_total}
 
 
 def _cell(value: Optional[float], digits: int) -> str:
-    return "not recorded" if value is None else f"{value:.{digits}f}".rstrip("0").rstrip(".")
+    return "not recorded" if value is None else f"{value:.{digits}f}"
 
 
-def format_rows(per_model: Dict[str, Dict[str, Any]], run_id: str) -> str:
-    """Markdown rows, ready to paste under the generators table."""
+def _fraction_cell(passed: int, total: int) -> str:
+    pct = 100 * passed / total if total else 0.0
+    return f"{passed} / {total} ({pct:.1f}%)"
+
+
+def format_rows(
+    per_model: Dict[str, Dict[str, Any]], shared: Dict[str, int], run_id: str
+) -> str:
+    """Markdown rows, ready to paste under the generators table.
+
+    Args:
+        per_model: as returned by ``summarise``.
+        shared: as returned by ``summarise``; folded into each row's ``Overall``.
+        run_id: identifier printed in the ``Run`` column.
+
+    Returns:
+        The header, the separator row and one data row per model, sorted by
+        model name.
+    """
     lines = [
-        "| Model | Answered cases passed | tokens/s | tokens/answer | s/answer | Run |",
-        "|---|---|---|---|---|---|",
+        "| Model | Answered | Overall | tokens/s | tokens/answer | s/answer | "
+        "decode s/answer | Budget hit | Infra | Placement | Run |",
+        "|---|---|---|---|---|---|---|---|---|---|---|",
     ]
     for model in sorted(per_model):
         e = per_model[model]
-        # The denominator qualifies a median. With nothing measured there is no
-        # median to qualify, and "not recorded *(of 0)*" says it twice.
-        partial = 0 < e["measured"] < e["answered"]
-        suffix = f" *(of {e['measured']})*" if partial else ""
+        answered = e["answered"]
+        overall_total = answered + shared["total"]
+        overall_passed = e["passed"] + shared["passed"]
+
+        # The denominator qualifies a median. With nothing measured there is
+        # no median to qualify, and "not recorded *(of 0)*" says it twice.
+        tokens_partial = 0 < e["measured"] < answered
+        tokens_suffix = f" *(of {e['measured']})*" if tokens_partial else ""
+        wall_partial = 0 < e["measured_wall"] < answered
+        wall_suffix = f" *(of {e['measured_wall']})*" if wall_partial else ""
+
         lines.append(
-            f"| `{model}` | {e['passed']} / {e['answered']} | "
+            f"| `{model}` | {_fraction_cell(e['passed'], answered)} | "
+            f"{_fraction_cell(overall_passed, overall_total)} | "
             f"{_cell(e['tokens_per_second'], 1)} | "
-            f"{_cell(e['tokens_per_answer'], 0)}{suffix} | "
-            f"{_cell(e['seconds_per_answer'], 2)} | `{run_id}` |"
+            f"{_cell(e['tokens_per_answer'], 0)}{tokens_suffix} | "
+            f"{_cell(e['seconds_per_answer'], 2)}{wall_suffix} | "
+            f"{_cell(e['decode_seconds_per_answer'], 2)} | "
+            f"{e['budget']} | {e['infra']} | {e['placement']} | `{run_id}` |"
         )
     return "\n".join(lines)
 
@@ -119,13 +232,16 @@ def main(argv: Optional[List[str]] = None) -> int:
 
     payload = json.loads(args.artifact.read_text(encoding="utf-8"))
     results = payload.get("results") or []
-    per_model = summarise(results)
+    per_model, shared = summarise(results)
     if not per_model:
         print(f"{args.artifact}: no per-model records found", file=sys.stderr)
         return 1
 
-    run_id = (payload.get("run") or {}).get("id") or args.artifact.stem
-    print(format_rows(per_model, run_id))
+    # The table cites the run by its timestamp (`20260911T230513Z`), which is
+    # what run_eval.py writes; "id" is kept for artifacts that carried one.
+    run = payload.get("run") or {}
+    run_id = run.get("timestamp") or run.get("id") or args.artifact.stem
+    print(format_rows(per_model, shared, run_id))
 
     unmeasured = [m for m, e in per_model.items() if not e["measured"]]
     if unmeasured:


### PR DESCRIPTION
## Summary

Six issues surfaced by the tranche-1 repeat of the #218 campaign and the review pass after the merge of #236, all in the evaluation tooling; the pipeline is untouched.

**Every record says when and where it ran (#234, #235, #244).** `started_at` on every record, so a window of a run in which every generation slows down is visible in the artifact instead of being counted off record positions. `stage_at_budget` on a budget-exhausted record (`context` / `generator` for factual cases, read off a marker `generar_respuesta_silenciosa` now sets in its `stats` dict; `setup` / `generator` for study cases). `vram_fraction` on every generation record from `/api/ps`, so a model measured from system RAM says so. The gate's own HTTP calls resolve the endpoint through `read_env_ollama_base_url` like the pipeline does, instead of a hardcoded localhost.

**The row tool produces the row the table has (#241).** `tools/diagnostics/model_history_row.py` still computed `s/answer` as tokens divided by rate (the 36x understatement #233 closed) and printed five columns where the table has eleven. Now: wall time for the wait, decode time under its own name, budget/infra/overall/placement columns, and a fixed `_cell` that turned `90` into `9`.

**Docs say which generator is measured (#242, #245).** `run_eval.DEFAULT_MODELS` is `Ling-3.0-tiny` while the product ships `gemma4:e4b`; both READMEs now say so and how to measure the product. The harness README's campaign example pinned `models.rag` through `--set`, which `evaluate()` refuses at launch; it now pins through the environment.

## Test plan

- `ruff check .` clean; full `pytest`: 1205 passed, 2 skipped (never a subset -- colliding basenames).
- Each behavioural change has a test that fails without it: `tests/eval/test_record_instrumentation.py` (13 tests: the three fields, the endpoint following `OLLAMA_BASE_URL`), `tests/test_generation_stage_marks.py` (the marker is set before each stage starts), `tests/unit/test_model_history_row.py` (rewritten: 7.89 s wall against the old 0.22).
- `tests/characterization/` untouched (`git diff --stat main -- tests/characterization` is empty).
- The tool run against a real artifact (`20260911T230513Z`) reproduces the Ling row in `docs/model-history.md`: 117 / 136, 7.29 s/answer, placement "not recorded" (pre-#235 artifact).

## Closes

Fixes #234
Fixes #235
Fixes #241
Fixes #242
Fixes #244
Fixes #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)