### PR TITLE
Say where the corpus comes from, document the budget knob and the domain probe, correct the fast tier's claims

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,8 @@ rag/                      Web interface and pipeline entry points
   chat_pdfs.py              Public facade + global config (see §1 rule 7)
   engine/                    wiring, retrieval, indexing, context, generation, chunking, debug, history, settings
   web/                       Flask backend + React frontend (pnpm; frontend/dist gitignored)
-  docs/                      Corpus PDFs (es/, ca/, en/); versioned
+  docs/                      Corpus PDFs (es/, ca/, en/): identity versioned in corpus_manifest.json,
+                             binaries fetched by tools/fetch_corpus.py (see section 8)
   vector_db/                 FAISS per corpus (gitignored)
 tests/
   unit/                      domain/ports/config/application + adapters, doubled infrastructure
@@ -84,7 +85,7 @@ tests/
                              no-infra CI job; each module docstring says why it lives here
 harness/                  Configuration search harness (issue #31); not product — see harness/README.md
 packaging/                PyInstaller desktop app build (see §3)
-tools/                    Repo tooling, not product: setup_environments.py (both venvs) + diagnostics/
+tools/                    Repo tooling, not product: setup_environments.py (both venvs), fetch_corpus.py (the corpora) + diagnostics/
 assets/                   Images the READMEs embed
 docs/design/               Architecture design docs; current: 2026-07-26-monkeygrab-v2.md
 docs/README.md             Documentation standard
@@ -204,9 +205,9 @@ Items 1–5 of §6 apply here too. What differs:
 
 ## 8. Git versioning policy
 
-**Two `.gitignore` files only:** root + `rag/web/frontend/`. No scattered `.gitignore`. Version the minimum needed to reproduce the product — code, `Modelfile`, small metric JSONs, scripts, corpus PDFs — never weights or vector indices.
+**Two `.gitignore` files only:** root + `rag/web/frontend/`. No scattered `.gitignore`. Version the minimum needed to reproduce the product — code, `Modelfile`, small metric JSONs, scripts, the corpus manifest — never weights, vector indices or fetched binaries.
 
-- **`rag/docs/`** — all corpora versioned (`es/`, `ca/`, `en/`). `rag/vector_db/` fully ignored. Local scratch results under `pipeline/output/` are ignored.
+- **`rag/docs/`** — the *identity* of every corpus document is versioned in `rag/docs/corpus_manifest.json` (arXiv id, or Wikipedia title plus the revision it was verified at); the PDFs themselves are fetched by `python tools/fetch_corpus.py` and ignored (`rag/docs/*/*.pdf`, since #213). The 13 documents committed before the fetcher existed stay tracked, because an ignore rule never applies to a file git already tracks — so a fresh clone holds 6 of 17 `en`, 5 of 17 `es` and 5 of 17 `ca` documents until the fetcher runs, and the gate refuses to run on that (`papers referenced by gold cases but not indexed`). `rag/vector_db/` fully ignored. Local scratch results under `pipeline/output/` are ignored.
 - **`.claude/`** — instructions and skills are versioned (`CLAUDE.md`, `skills/`) so a clone or CI runner picks them up; everything else there, `settings.local.json` included, stays local.
 
 ---
@@ -218,6 +219,7 @@ Items 1–5 of §6 apply here too. What differs:
 ```bash
 # Setup (both interpreters; --check verifies without installing)
 python tools/setup_environments.py             # .venv + .venv-mineru, then check
+python tools/fetch_corpus.py                   # the three corpora from rag/docs/corpus_manifest.json (--check: report only)
 
 # Web
 python rag/web/app.py                          # http://localhost:5000 (ES/EN/VAL UI + corpus selector via POST /api/corpus)

--- a/harness/fast_tier.txt
+++ b/harness/fast_tier.txt
@@ -1,6 +1,9 @@
 # Fast tier -- regression filter only (never declares an improvement).
 # Fixed, versioned subset of the search set: 16 cases spanning every
-# case_type and every paper.
+# case_type, drawn from 6 of the search set's 41 papers -- all of them
+# English documents of the `corpus` source, chosen before #213 added the
+# `corpus_es`/`corpus_ca` stores. Those two stores have no fast-tier case,
+# so a regression confined to them passes this filter (issue #247).
 #
 # Its job is not to save minutes -- it is to reject a bad candidate without
 # contaminating the ratchet, before paying for the full search set. Earlier
@@ -31,9 +34,11 @@
 #   (issue #225): it measured a 32-case search set that #213 grew to 123
 #   cases, and nobody has re-timed a full run since.
 #
-# Includes all 5 of today's known search-set failures (dpo-pipeline-figure-es,
-# higgs-diphoton-figure, planck-contours-figure, planck-sigma8-es,
-# planck-h0-tension) -- the three figure failures cost ~4s each, so including
+# Includes all 5 of the search-set failures known on 2026-08-12, when the
+# search set had 32 cases (dpo-pipeline-figure-es, higgs-diphoton-figure,
+# planck-contours-figure, planck-sigma8-es, planck-h0-tension); which cases
+# fail on today's 123 is issue #243's measurement, and this list has not
+# been re-derived from it -- the three figure failures cost ~4s each, so including
 # them is nearly free and gives the regression filter real signal on the
 # retrieval side; the two answered failures satisfy "at least two of five"
 # before the figures are even counted.

--- a/tests/eval/README.md
+++ b/tests/eval/README.md
@@ -25,6 +25,9 @@ implementation that happens to live in the test tree.
 | `run_probe_lang.py` | Runs the probe against its own isolated FAISS collection. |
 | `probe_docs_lang/` | PDFs staged for the probe, copied from `rag/docs/es\|ca/`. Gitignored. |
 | `probe_runs_lang/` | Dated JSON results from each `run_probe_lang.py` run. Gitignored. |
+| `probe_cases_domain.jsonl` | Domain-axis diagnostic probe (same status as the language one — see below). |
+| `run_probe_domain.py` | Runs the domain probe against its own isolated FAISS collection. |
+| `probe_docs_domain/`, `probe_runs_domain/`, `probe_cache_domain/` | Staged PDFs, dated results and the arXiv download cache for the domain probe. Gitignored. |
 
 ## Corpus
 
@@ -32,6 +35,10 @@ Four sources, mixed deliberately (the `source` field in `gold_cases.jsonl`):
 
 - **`corpus`** -- the dev set: `rag/docs/en/`, 17 documents. Retrieved chunks and reranking
   behavior here are what the pipeline's heuristics were tuned against.
+  A fresh clone does not hold them all: since #213 the PDFs are gitignored and only their
+  identity is versioned (`rag/docs/corpus_manifest.json`), so run `python tools/fetch_corpus.py`
+  once before the gate (`--check` says what is missing). `run_eval.py` does not fetch them itself
+  and refuses to run on a partial store (`papers referenced by gold cases but not indexed`).
 - **`arxiv`** (`arxiv_id` set) -- the blind set: ML papers fetched on demand by
   `fetch_papers.py`, never used to tune anything. A judge calibrated only on the dev set can't
   tell "the pipeline retrieves well" from "the pipeline overfits these PDFs"; the blind set is
@@ -207,6 +214,12 @@ instead of re-derived from memory.
 - Generation's `keep_alive` is forced to 120 seconds for the run's duration
   (`_EVAL_GENERATION_KEEP_ALIVE_SECONDS` in `run_eval.py`), so a cold first call per model is
   not read as steady-state latency.
+- Every generation call is capped at 180 s of wall clock (`GENERATION_BUDGET_SECONDS`, issue
+  #229) and an exhausted cap is a failure of that (case, model) pair. The knob is
+  `EVAL_GENERATION_BUDGET_SECONDS`, an environment variable of the gate rather than of the
+  product, which is why `.env.example` does not list it; the value in effect is written to the
+  artifact's `conditions.generation_budget_seconds`, and two runs with different budgets are not
+  comparable rows.
 - The `chat`, `contextual` and `recomp` roles are all pinned to `AUX_MODEL` for the whole
   evaluation (`_scoped_model_roles` around the `evaluate()` call in `run_eval.py`). A
   `--models` sweep varies only the `rag` role; the query decomposer a sweep might otherwise
@@ -548,3 +561,25 @@ are not promoted into `gold_cases.jsonl`. If a later source on this axis
 comes back *viable*, its cases are written to survive promotion (per
 section 3's "los casos de la sonda se redactan para sobrevivir"): they are
 the seed of the full batch, not throwaway material.
+
+## Domain-axis probe (diagnostic, not the gate)
+
+The sibling of the probe above for the **domain axis** of the same design-doc
+section: does a corpus whose vocabulary is far from the ML/physics the
+pipeline was tuned on produce failures a loop could learn from? Three recent
+arXiv papers (two econometrics, one biomathematics), ten cases in
+`probe_cases_domain.jsonl`, staged from the `fetch_papers.py` cache into their
+own collection so the run can never write into a product or gate store:
+
+```bash
+python tests/eval/fetch_papers.py --dest tests/eval/probe_cache_domain 2608.18973v1 2608.18375v1 2608.17955v1
+python tests/eval/run_probe_domain.py                  # or --models <generator>
+```
+
+Same shape of output as `run_eval.py`, same human step afterwards. Measured
+2026-08-23 (`gemma4:e2b`, 9/10, artefact gitignored under `probe_runs_domain/`):
+no lexical collapse out of domain, the one failure a generation miss on
+retrieved evidence. The design doc records the verdict, *viable tras arreglo*,
+and why: arXiv feeds the pipeline from any field, but a source this easy does
+not give a loop enough failures to move. `test_probe_cases_domain.py` skips
+itself until the three papers are in the cache.


### PR DESCRIPTION
## Summary

Documentation-only, from a docs-versus-code audit after #246.

- `AGENTS.md` §2/§8/§9: the corpus PDFs are not versioned since #213; the manifest is, and `tools/fetch_corpus.py` fetches them. A fresh clone holds 13 of 51 documents and the gate refuses to run on that. The contract said the opposite.
- `tests/eval/README.md`: fetch step in the Corpus section; `EVAL_GENERATION_BUDGET_SECONDS` named next to the 180 s cap it sets (it was in no document); the domain-axis probe documented next to the language-axis one, with its measured verdict.
- `harness/fast_tier.txt`: the header claimed to span every paper (it spans 6 of 41, none in the es/ca stores) and listed "today's failures" from the 32-case era. Claims corrected; the coverage gap is #247.

## Test plan

- `ruff check .` clean; full `pytest` green (docs only, plus the fast-tier header the loader parses -- `harness/tests/test_evaluator.py` passes).
- Numbers recomputed from the repo: `git ls-files rag/docs | grep -c pdf` = 13; 41 search-set papers and 6 covered, from `gold_cases.jsonl` and `fast_tier.txt`; 10 domain-probe cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)