### PR TITLE
Bound stream()'s read timeout by the generation deadline, so a silent server is cut too

### DIFF
--- a/src/monkeygrab/adapters/chat/ollama_chat.py
+++ b/src/monkeygrab/adapters/chat/ollama_chat.py
@@ -50,8 +50,10 @@ class GenerationDeadlineExceeded(RuntimeError):
     """A streamed generation ran past ``generation_deadline`` and was closed.
 
     A ``RuntimeError`` like every other failure this adapter raises (hard-fail
-    policy), kept distinct so a caller that set the deadline can tell "the
-    model kept going" from "the server failed".
+    policy), kept distinct so a caller of ``stream`` that set the deadline
+    can tell "the model kept going" from "the server failed". ``generate``
+    does not raise it: there the deadline is enforced by the client's own
+    read timeout, whose error surfaces as the generic ``RuntimeError``.
     """
 
 
@@ -248,10 +250,15 @@ class OllamaChatModel:
             deadline = (
                 time.monotonic() + self._generation_deadline if self._generation_deadline else None
             )
+            # The read timeout is bounded by the deadline too: the per-line
+            # check below only runs when a line arrives, so a server that
+            # goes silent mid-stream would otherwise hold the slot for the
+            # full request_timeout, which is the #249 window in another form.
+            timeout = self._request_timeout
+            if self._generation_deadline:
+                timeout = min(timeout, self._generation_deadline)
             try:
-                with requests.post(
-                    url=url, json=payload, stream=True, timeout=self._request_timeout
-                ) as resp:
+                with requests.post(url=url, json=payload, stream=True, timeout=timeout) as resp:
                     resp.raise_for_status()
                     for line in resp.iter_lines():
                         if deadline is not None and time.monotonic() > deadline:

--- a/tests/unit/adapters/test_ollama_chat.py
+++ b/tests/unit/adapters/test_ollama_chat.py
@@ -495,3 +495,21 @@ def test_generate_bounds_its_client_timeout_by_the_deadline(monkeypatch):
     OllamaChatModel("m", num_ctx=8, request_timeout=900, generation_deadline=0).generate("p")
     OllamaChatModel("m", num_ctx=8, request_timeout=5, generation_deadline=10).generate("p")
     assert [c["client_timeout"] for c in calls] == [10, 900, 5]
+
+
+def test_stream_bounds_its_read_timeout_by_the_deadline_so_a_silent_server_is_cut_too(monkeypatch):
+    """The per-line clock check cannot fire while no line arrives. A server
+    that goes silent mid-stream is bounded by requests' read timeout, so that
+    timeout must not exceed the deadline either."""
+    seen = []
+    lines = [b'{"response": "", "done": true}']
+
+    def fake_post(**kwargs):
+        seen.append(kwargs["timeout"])
+        return _FakeStreamResponse(lines)
+
+    monkeypatch.setattr(module.requests, "post", fake_post)
+    list(OllamaChatModel("m", num_ctx=8, request_timeout=900, generation_deadline=185).stream("p"))
+    list(OllamaChatModel("m", num_ctx=8, request_timeout=900, generation_deadline=0).stream("p"))
+    list(OllamaChatModel("m", num_ctx=8, request_timeout=60, generation_deadline=185).stream("p"))
+    assert seen == [185, 900, 60]


### PR DESCRIPTION
## Summary

Follow-up to #250 from a review pass over it. `stream()` checked the deadline per line, so a server that goes silent mid-stream (no lines) would have kept the slot for the full 900 s read timeout. The read timeout handed to `requests.post` is now `min(request_timeout, generation_deadline)`. The `GenerationDeadlineExceeded` docstring no longer implies `generate()` raises it.

## Test plan

- New test pins the timeout handed to `requests.post` for the three combinations (deadline below, absent, above the read timeout).
- `ruff check .` clean; full `pytest`: 1211 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)