### PR TITLE
Measure the harness's noise floor and resolution on the 123-case search set, and re-derive the fast tier from it

### DIFF
--- a/harness/README.md
+++ b/harness/README.md
@@ -180,19 +180,22 @@ fake evaluator that raises on a declared key makes startup fail loudly
   search-set subset) -- never from a proposer, which can only emit config
   overrides. Proven, not assumed: `harness/tests/test_evaluator.py` asserts
   the blind set is disjoint from both the search set and the fast tier.
-- **Fast tier** (16 fixed ids, `fast_tier.txt`) -- regression filter only, it
-  **never declares an improvement**. 13 of the 16 (8 answered + 5
-  retrieval-only) cost ~4 min at current measured rates (8 × ~28.5 s + 5 ×
-  ~4.1 s); the remaining three are study-artifact cases (issue #140) with
-  no per-case timing measured yet, so they are not priced into that total
-  (issue #226 -- see the file's own header for the full accounting). The
-  ~13 min comparison against a full search-set run this bullet used to make
-  is gone: that run measured the pre-#213 32-case search set, not today's
-  123, and nobody has re-timed a full run since. Its job is rejecting a bad
-  candidate before it can contaminate the ratchet, not the minutes it
-  happens to save. Includes all 5 of today's known search-set failures
-  (three figure-retrieval failures cost ~4 s each, nearly free to include,
-  and give the regression filter real signal on the retrieval side).
+- **Fast tier** (25 fixed ids, `fast_tier.txt`) -- regression filter only, it
+  **never declares an improvement**. Re-derived on 2026-09-12 from the
+  search-set reference run by one rule (issue #247): every case that run
+  failed (16), plus the first passing case in `gold_cases.jsonl` order for
+  every `case_type` and every `source` the failures left uncovered (9). It
+  spans all seven case types and all three stores, and
+  `harness/tests/test_evaluator.py` asserts both, so the next corpus
+  expansion cannot strand a store here again as #213 did. Cost, from that
+  run's own per-case timings: about 8.5 min, of which 3 are one
+  `study_quiz` that exhausts the generation budget (kept: the deadline
+  #249 added bounds it, and the quiz path shows up here first). Its job is
+  rejecting a bad candidate before it can contaminate the ratchet, not the
+  minutes it happens to save against a ~31 min full search-set run. The
+  failures are here so the filter has signal on both sides: a candidate
+  that fixes one shows a gain the tier does not act on, a candidate that
+  breaks a passing one is rejected before the ratchet sees it.
 
 ## Objective, constraint, noise floor
 
@@ -209,16 +212,14 @@ defaults should be one is issue #242.
 **Objective:** `objective_adjusted` = passing cases on the search set, minus
 cases listed in `unreachable_cases.txt` (excluded from both numerator and
 denominator, not just discounted). `unreachable_cases.txt` starts **empty**
-and stays that way as of 2026-08-12: the `reason` field of all five of
-today's search-set failures was read against the reference gate run and
-none is the generator failing to answer over a figure it saw — three are
-`figure_retrieval` cases (never call the generator) that fail because
-retrieval surfaced text where an image chunk was wanted, exactly what fusion
-weights/`top_k_final`/the reranker threshold move; the other two are a
-number present in the abstract that did not survive into the generated
-answer. All five are inside stage 1's action space. See the file's header
-for the full citation. `objective_raw` (unreachable cases included) is
-tracked alongside so the exclusion mechanism is auditable before it is ever
+and stays that way as of 2026-09-12: the reference run on the current
+123-case search set (`20260912T003549Z`, 107/123) fails 16 cases -- 11
+`factual_number`, 2 `factual_concept`, 2 `figure_retrieval`, 1 `study_quiz`
+that exhausted the generation budget -- and every one of them is a
+retrieval or generation outcome the declared search space can move, not a
+case no configuration could reach. Their ids are the first block of
+`fast_tier.txt`. `objective_raw` (unreachable cases included) is tracked
+alongside so the exclusion mechanism is auditable before it is ever
 needed — today `raw == adjusted`.
 
 **Constraint, per bucket, not blended.** Answered cases (`factual_number`/
@@ -260,54 +261,58 @@ counts toward `--patience`) and raises `evaluator.InconclusiveEvaluationError`
 before the loop even starts if the **reference** measurement itself carries
 one — no ratchet baseline can be trusted in that case.
 
-**Noise floor: 0 cases.** Measured 2026-07-29 (design doc, criterion 1
-note): two runs of the same configuration and code, same index, zero flips
-across 51 gold cases. Independently re-verified in this PR restricted to
-the 32-case search set: still 0 flips. A delta of 0 is not an improvement
-(`loop.NOISE_FLOOR_CASES`).
+**Noise floor: 3 cases.** Measured 2026-09-12 on the search set this loop
+evaluates and with the generator it runs (`Ling-3.0-tiny`): two
+`evaluate()` calls of the identical configuration, `conditions` equal field
+for field, `20260912T003549Z` (107/123) and `20260912T013552Z` (104/123);
+`compare_runs.py` over the pair: 0 flipped to PASS, 3 flipped to FAIL, 120
+unchanged. A candidate three cases up on the ratchet is rejected as
+`rejected_no_gain` (`loop.NOISE_FLOOR_CASES`); four is the smallest
+accepted gain. This replaces the 2026-07-29 figure of zero flips, which was
+measured on the 51-case set that preceded #213 and re-verified on the
+32-case search set of the time; the current 156-case set flips on sampling
+alone (`docs/model-history.md`, "How to read", item 1), and so does this
+subset of it (issue #243).
 
 ## Resolution warning
 
-Stale in exactly the way `evaluator.search_set_case_ids()`'s own docstring
-warns about (issue #225): every number below was measured against the
-32-case search set that existed before #213 (the corpus expansion, block B
-of issue #30) grew it to 123 (see Sets above), and nobody has re-run either
-measurement against the current set.
+Measured 2026-09-12 on the current 123-case search set, with the same three
+runs as the noise floor above (issue #243), replacing figures that had been
+measured on the 32-case set that preceded #213:
 
-The **~6 net flips** the design doc (§3) sets as the threshold for a paired
-difference not attributable to chance is a fixed methodological constant,
-not derived from search-set size, so it does not by itself need
-re-measuring. What does: **"the search set can win at most 5 cases" (27/32
-pass on the 2026-08-19 reference run)** is a capacity claim that scales with
-the search set's size, and **"3 net flips under `RAG_TOP_K_FINAL=1`"**
-(criterion 2's known-catastrophic sabotage, versus 7 on the old 51-case
-gate) is a paired comparison that only means something re-run on the cases
-it is meant to describe. Both are hardcoded in `harness/loop.py`'s
-`RESOLUTION_WARNING` dict (`SEARCH_SET_AVAILABLE_FAILURES`,
-`SEARCH_SET_NET_FLIPS_UNDER_KNOWN_SABOTAGE`) and attached verbatim, via
-`message`, to every real campaign's `resolution_warning` -- so a report run
-today still describes a search set a quarter the size of the one the code
-actually evaluates against.
+- **Available failures: 16 of 123** (`20260912T003549Z`, 107/123). The old
+  figure was "at most 5" on 27/32.
+- **Net flips under the known-catastrophic sabotage: 10.** The criterion-2
+  sabotage, `retrieval.top_k_final=1` passed through `evaluate()`'s
+  `config_overrides` (`20260912T010521Z`, 97/123), flipped 2 cases to PASS
+  and 12 to FAIL against the first reference, 4 and 11 against the second.
+  The old figure was 3 net on the 32-case set.
+- **Demonstrability threshold: ~6 net flips**, the design doc's (§3) fixed
+  methodological constant, unchanged.
 
-Recomputing them for real needs two things nobody has measured yet, not an
-estimate: a reference evaluation over all 123 search-set cases (to count
-today's failures) and a paired comparison against a `RAG_TOP_K_FINAL=1`
-candidate over the same 123 (to count net flips). Until one of those runs
-exists, the honest statement is that the search set has roughly quadrupled
-since these figures were produced, and whether that changes the resolution
-picture for better or worse is not yet known -- not that it is still "5
-cases" and "3 net flips" today.
+So the resolution picture has changed for the better: a catastrophic
+single-field change now clears the threshold and is detectable on the
+search set. What the set still cannot do is demonstrate a *small*
+improvement. With a noise floor of 3, an accepted candidate is at least 4
+cases up on the ratchet, and 4 or 5 is above the floor but below the
+threshold -- a candidate for confirmation, not a demonstrated result. All
+of this is in `harness/loop.py`'s `RESOLUTION_WARNING` dict
+(`SEARCH_SET_AVAILABLE_FAILURES`, `SEARCH_SET_NET_FLIPS_UNDER_KNOWN_SABOTAGE`,
+`noise_floor_cases`) and attached verbatim, via `message`, to every real
+campaign's report.
 
 > [!NOTE]
-> All of the numbers above come from four local, gitignored artifacts
-> (`tests/eval/runs/20260729T020233Z_...json`, `...040824Z...`,
-> `...081129Z...json`, `...20260812T194812Z...json`) — `tests/eval/runs/` is
-> in `.gitignore`, so they are not reproducible from a fresh clone. They are
-> cited, not shipped. The three 2026-07-29 runs predate issue #27's
-> keep-alive fix and are cited for their PASS/FAIL evidence (noise floor,
-> sabotage flips, resolution limit), which the fix did not touch
-> (`compare_runs.py` against the healthy 2026-07-29 run reports 51 cases
-> unchanged); the 2026-08-12 run is cited for current timing.
+> The three 2026-09-12 artifacts (`tests/eval/runs/20260912T003549Z_...json`,
+> `...010521Z...`, `...013552Z...`), like every run artifact, are local and
+> gitignored -- cited, not shipped. They were produced by calling
+> `run_eval.evaluate()` exactly as `evaluator.real_evaluate()` does
+> (`models=run_eval.DEFAULT_MODELS`, `search_space.expand_overrides`,
+> `update_baseline=False`) with `write_report=True`, on `main` at `ee56ea9`,
+> 31 minutes each, no infrastructure errors, one budget exhaustion each.
+> The 2026-07-29 and 2026-08-12 runs the previous version of this section
+> cited (`20260729T020233Z`, `...040824Z`, `...081129Z`,
+> `20260812T194812Z`) remain the source of the per-bucket latency medians
+> above; nothing here retracts them, they simply described a smaller set.
 
 ## Proposers
 

--- a/harness/fast_tier.txt
+++ b/harness/fast_tier.txt
@@ -1,81 +1,57 @@
 # Fast tier -- regression filter only (never declares an improvement).
-# Fixed, versioned subset of the search set: 16 cases spanning every
-# case_type, drawn from 6 of the search set's 41 papers -- all of them
-# English documents of the `corpus` source, chosen before #213 added the
-# `corpus_es`/`corpus_ca` stores. Those two stores have no fast-tier case,
-# so a regression confined to them passes this filter (issue #247).
+# Fixed, versioned subset of the search set: 25 cases, re-derived on
+# 2026-09-12 from the search-set reference run
+# tests/eval/runs/20260912T003549Z_mineru-jina_clip-faiss.json (Ling-3.0-tiny,
+# 107/123, issue #243) by one rule, so it can be re-derived again the same
+# way after the next corpus change (issue #247):
+#
+#   every case that run failed (16), plus the first passing case in
+#   gold_cases.jsonl order for every case_type and every source that the
+#   failures alone did not cover (9).
+#
+# Spans every case_type (7) and every source (corpus, corpus_es, corpus_ca)
+# of the search set; harness/tests/test_evaluator.py asserts both, so the
+# next corpus expansion cannot strand a store here again as #213 did.
 #
 # Its job is not to save minutes -- it is to reject a bad candidate without
-# contaminating the ratchet, before paying for the full search set. Earlier
-# revisions of this file justified the tier by an evaluation-time budget
-# (the design's original ~2.8 h/candidate estimate); that budget was wrong
-# by a factor of ~6 (issue #27's keep-alive fix removed a per-case cold
-# model load the original figure baked in -- measured 2026-08-12,
-# tests/eval/runs/20260812T194812Z_mineru-jina_clip-faiss.json, local and
-# gitignored) and the saving this tier buys is correspondingly smaller than
-# assumed. The tier stays regardless: its function (a regression filter the
-# ratchet needs) does not depend on how many minutes it happens to save.
+# contaminating the ratchet, before paying for the full search set. Cost,
+# from that run's own per-case elapsed_seconds (retrieval plus generation):
+# ~330 s for the 24 cases that finished, plus one study_quiz
+# (gw-study-quiz-ca) that exhausted the 180 s generation budget -- about
+# 8.5 min against ~31 min for the whole search set. The budget case stays:
+# the deadline that #249 added bounds it, and a candidate that fixes or
+# breaks the quiz path shows up here first.
 #
-# Sizing arithmetic, recomputed against the 2026-08-12 measurement's bucket
-# medians (answered 28.5 s, retrieval-only 4.1 s -- both down from the
-# 2026-07-29 reference's 201.1 s/198.4 s and 3.9 s/4.5 s respectively; only
-# the answered bucket moved, since retrieval-only cases never call the
-# generator the keep-alive fix affects):
-#   8 answered cases  x ~28.5s = ~228s
-#   5 retrieval-only  x ~4.1s  =  ~21s
-#   total ~249s ~= 4 min for these 13 cases -- still worth running first,
-#   just not for the reason originally assumed. The three study-artifact
-#   cases below (issue #140) are not priced into that total: no per-case
-#   timing exists for study_summary/study_outline/study_quiz, so say that
-#   instead of guessing -- the tier's real cost is ~249s plus an unmeasured
-#   amount for three full-document generations (see the note below).
-#   The ~13 min full-search-set comparison this line used to make is gone
-#   for the same reason harness/README.md's Sets section was rewritten
-#   (issue #225): it measured a 32-case search set that #213 grew to 123
-#   cases, and nobody has re-timed a full run since.
-#
-# Includes all 5 of the search-set failures known on 2026-08-12, when the
-# search set had 32 cases (dpo-pipeline-figure-es, higgs-diphoton-figure,
-# planck-contours-figure, planck-sigma8-es, planck-h0-tension); which cases
-# fail on today's 123 is issue #243's measurement, and this list has not
-# been re-derived from it -- the three figure failures cost ~4s each, so including
-# them is nearly free and gives the regression filter real signal on the
-# retrieval side; the two answered failures satisfy "at least two of five"
-# before the figures are even counted.
+# The failing cases are here so the filter has signal on both sides: a
+# candidate that fixes one shows a gain the tier does not act on, a candidate
+# that breaks a passing one is rejected before the ratchet sees it. The
+# three figure failures cost ~9 s each and are the retrieval-side signal.
 
-# -- answered (8): factual_number / factual_concept --
-planck-sigma8-es
-planck-h0-tension
-att-n-layers
-dpo-acronym
-gw-snr
-gw-site
-higgs-significance
-ricci-hamilton-intro
-
-# -- retrieval-only (5): figure_retrieval / table_retrieval --
-att-bleu-table
-dpo-pipeline-figure-es
+# -- failed in the reference run (16) --
 higgs-diphoton-figure
 planck-contours-figure
-gw-strain-figure
+planck-h0-tension
+gw-study-quiz-ca
+adam-beta2
+adam-stepsize
+supernovae-lab
+photosynthesis-chloroplasts
+antarctica-ice-thickness
+antarctica-freshwater
+fotosintesis-carbono
+machupicchu-restaurado
+acueducto-altura
+mediterrania-grecs
+basquet-naixement
+catala-llengua-habitual
 
-# -- study artifacts (3): study_summary / study_outline / study_quiz --
-#
-# Present because the tier's own rule is to span every case_type in the search
-# set (harness/tests/test_evaluator.py), and issue #140 added three. They are
-# not free: each one is a full generation over a whole document, so this tier
-# costs three more answered-bucket cases than it did.
-#
-# Worth it for the same reason the failing figure cases are here. Only one knob
-# in SEARCH_SPACE reaches them at all -- flags.usar_optimizacion_contexto, the
-# one that decides what text the generator sees -- and it reaches them harder
-# than it reaches an answered case, because a Study artifact reads a whole
-# document rather than a top-k. A candidate that degrades context assembly
-# shows up here first.
-#
-# One paper, all three types: they share its chunks, so the document is loaded
-# once for the three.
-att-study-summary
+# -- passing coverage: one per case_type / source not covered above (9) --
+att-bleu-ende
+att-bleu-table
+att-arch-figure
+dpo-acronym
 att-study-outline
+att-study-summary
 att-study-quiz
+pitagoras-pruebas
+gaudi-montserrat

--- a/harness/loop.py
+++ b/harness/loop.py
@@ -17,13 +17,16 @@ full numbers and why they cannot be re-derived from a fresh clone):
    for fewer/cheaper generator calls without the constraint noticing.
    ``_latency_breach`` checks each bucket against its own reference median
    independently.
-2. **``resolution_warning`` in the final report.** The search set (32
-   ``source: corpus`` cases) can win at most 5 cases today, and moved only 3
-   net flips under the most destructive single-field change anyone has
-   measured (``RAG_TOP_K_FINAL=1``) -- both below the ~6-flip threshold
-   design doc section 3 sets for a paired difference not attributable to
-   chance. Every report says so, so an accepted improvement reads as a
-   candidate for confirmation, not a demonstrated result.
+2. **``resolution_warning`` in the final report.** The search set (123
+   non-arXiv cases since #213) can win at most 16 cases today, resampling
+   moves 3 of them, and the most destructive single-field change anyone has
+   measured (``retrieval.top_k_final=1``) moves 10 net -- above the ~6-flip
+   threshold design doc section 3 sets for a paired difference not
+   attributable to chance, so a catastrophic change is now detectable
+   (measured 2026-09-12, issue #243). A gain of four or five cases clears
+   the noise floor but not that threshold. Every report says so, so an
+   accepted improvement of that size reads as a candidate for confirmation,
+   not a demonstrated result.
 3. **A ``rejected_regression`` verdict also fires at the search-set stage**
    when the retrieval-only bucket loses cases net against the reference
    (paired by id), even if the blended ``objective_adjusted`` still went up.
@@ -106,44 +109,68 @@ from harness import search_space
 
 # NOISE FLOOR
 
-# Measured 2026-07-29 (docs/design/2026-07-28-loop-automejorable.md,
-# criterion 1 note): two runs of the same configuration and code, same index
-# (both recorded a cache hit), zero flips across all 51 gold cases --
-# tests/eval/runs/20260729T020233Z_mineru-jina_clip-faiss.json and
-# tests/eval/runs/20260729T040824Z_mineru-jina_clip-faiss.json (both local,
-# gitignored, so not reproducible from a fresh clone -- see harness/README.md).
-# Independently re-verified in this PR restricted to just the 32-case search
-# set this harness actually uses: still 0 flips. A delta of zero cases is not
-# an improvement. If tests/eval/grade.py's scoring rules ever change, this
-# floor must be remeasured -- it is specific to that grader, not a law of the
+# Measured 2026-09-12 on the search set this harness actually evaluates
+# (the 123 non-arXiv cases, evaluator.search_set_case_ids()) with the
+# generator it actually runs (run_eval.DEFAULT_MODELS, Ling-3.0-tiny): two
+# evaluate() calls of the identical configuration, identical `conditions`
+# block field for field, 31 min each --
+# tests/eval/runs/20260912T003549Z_mineru-jina_clip-faiss.json (107/123) and
+# tests/eval/runs/20260912T013552Z_mineru-jina_clip-faiss.json (104/123), both
+# local and gitignored (see harness/README.md). compare_runs.py over the
+# pair: 0 flipped to PASS, 3 flipped to FAIL, 120 unchanged. Three cases is
+# what resampling the same configuration moves, so a candidate three up on
+# the reference has shown nothing (issue #243).
+#
+# This replaces the 2026-07-29 figure of zero flips, measured on the 51-case
+# gold set that preceded #213 and re-verified then on the 32-case search set;
+# the 156-case set flips on sampling alone (docs/model-history.md, "How to
+# read", item 1) and so does this subset of it. If tests/eval/grade.py's
+# scoring rules or the gold set change, this floor must be remeasured -- it
+# is specific to that grader, that set and that generator, not a law of the
 # pipeline.
-NOISE_FLOOR_CASES = 0
+NOISE_FLOOR_CASES = 3
 
 # The latency constraint's multiplier (design doc section 5).
 LATENCY_CEILING_MULTIPLIER = 1.20
 
 # RESOLUTION LIMIT (see module docstring point 2)
 
-SEARCH_SET_AVAILABLE_FAILURES = 5
+# Both from the same 2026-09-12 runs as the noise floor. Available failures:
+# the first reference run failed 16 of 123 (11 factual_number, 2
+# factual_concept, 2 figure_retrieval, 1 study_quiz that exhausted the 180 s
+# budget). Sensitivity: the criterion-2 sabotage, retrieval.top_k_final=1
+# through evaluate()'s config_overrides
+# (tests/eval/runs/20260912T010521Z_mineru-jina_clip-faiss.json, 97/123),
+# flipped 2 to PASS and 12 to FAIL against that reference -- 10 net -- and
+# 4 to PASS, 11 to FAIL against the second reference. Against the 32-case
+# set the same sabotage moved 3 net flips; on today's set it clears the
+# ~6-flip demonstrability threshold, so the set can now show a catastrophic
+# single-field change. What it still cannot do is show a *small* one: a
+# gain of four or five cases clears the noise floor but not the threshold.
+SEARCH_SET_AVAILABLE_FAILURES = 16
 DEMONSTRABILITY_FLIP_THRESHOLD = 6
-SEARCH_SET_NET_FLIPS_UNDER_KNOWN_SABOTAGE = 3
+SEARCH_SET_NET_FLIPS_UNDER_KNOWN_SABOTAGE = 10
 SEARCH_SET_SABOTAGE_DESCRIPTION = (
-    "RAG_TOP_K_FINAL=1 (single fragment retrieved; criterion 2, 2026-07-29)"
+    "retrieval.top_k_final=1 (single fragment retrieved; criterion 2, 2026-09-12, "
+    "run 20260912T010521Z against reference 20260912T003549Z)"
 )
 
 RESOLUTION_WARNING: Dict[str, Any] = {
     "available_search_set_failures": SEARCH_SET_AVAILABLE_FAILURES,
     "demonstrability_flip_threshold": DEMONSTRABILITY_FLIP_THRESHOLD,
     "net_flips_under_known_sabotage": SEARCH_SET_NET_FLIPS_UNDER_KNOWN_SABOTAGE,
+    "noise_floor_cases": NOISE_FLOOR_CASES,
     "sabotage_description": SEARCH_SET_SABOTAGE_DESCRIPTION,
     "message": (
-        "The search set can win at most 5 cases and moved only 3 net flips under "
-        "a known-catastrophic single-field sabotage, below the ~6-flip threshold "
-        "design doc section 3 sets for a demonstrable paired difference. An "
-        "accepted improvement on today's corpus is a candidate for confirmation, "
-        "not a demonstrated result -- see "
-        "docs/design/2026-07-28-loop-automejorable.md section 3 and issue #30 "
-        "(block B, the corpus expansion this harness is sized against)."
+        "The search set can win at most 16 cases (2026-09-12 reference, 107/123). "
+        "Resampling the same configuration moves 3 of them, so an accepted "
+        "improvement is at least 4 cases up on the ratchet; the ~6-flip threshold "
+        "design doc section 3 sets for a demonstrable paired difference is what a "
+        "known-catastrophic single-field sabotage (retrieval.top_k_final=1) now "
+        "clears at 10 net flips. An accepted gain of 4 or 5 cases is therefore a "
+        "candidate for confirmation, not a demonstrated result; 6 or more is at "
+        "the threshold -- see docs/design/2026-07-28-loop-automejorable.md "
+        "section 3 and issue #243."
     ),
 }
 

--- a/harness/tests/test_evaluator.py
+++ b/harness/tests/test_evaluator.py
@@ -83,6 +83,16 @@ def test_fast_tier_covers_every_case_type_in_the_search_set():
     assert fast_case_types == search_case_types
 
 
+def test_fast_tier_covers_every_source_in_the_search_set():
+    # Issue #247: the tier chosen before #213 covered six English documents
+    # of one store, so a regression confined to the es/ca stores passed it
+    # untouched. Case-type coverage alone let that happen for weeks.
+    source_by_id = {c["id"]: c["source"] for c in ev._gold_cases()}
+    search_sources = {source_by_id[i] for i in ev.search_set_case_ids()}
+    fast_sources = {source_by_id[i] for i in ev.load_fast_tier()}
+    assert fast_sources == search_sources
+
+
 def test_fast_tier_has_no_duplicate_ids():
     fast = ev.load_fast_tier()
     assert len(fast) == len(set(fast))

--- a/harness/tests/test_loop.py
+++ b/harness/tests/test_loop.py
@@ -255,16 +255,54 @@ def test_fast_tier_regression_is_rejected_before_paying_for_the_full_set(tmp_pat
     assert full_eval_calls["count"] == 1
 
 
-def test_a_real_improvement_is_accepted_and_moves_the_ratchet(tmp_path):
+def test_a_gain_equal_to_the_noise_floor_is_rejected_as_no_gain(tmp_path):
+    """The floor is measured, not decorative: two runs of the same
+    configuration on the search set flipped three cases (#243), so a
+    candidate three cases up on the reference has shown nothing."""
     search_ids = ("a", "b", "c", "d", "e", "f", "g", "h")
     fast_ids = ("a",)
+    recovered = ("f", "g", "h")
+    assert len(recovered) == loop.NOISE_FLOOR_CASES
 
     def evaluate(overrides, case_ids):
         better = overrides.get("retrieval.top_k_final") == 12
-        # Reference passes 6/8; the improved candidate passes all 8 -- a
-        # clear gain, well past the noise floor of 0.
         records = [
-            _rec(cid, "factual_number", better or cid not in ("g", "h"), 200.0) for cid in case_ids
+            _rec(cid, "factual_number", better or cid not in recovered, 200.0) for cid in case_ids
+        ]
+        return ev.EvaluationResult(records=tuple(records), effective_config=dict(overrides))
+
+    report = loop.run_loop(
+        reference=AppConfig(),
+        evaluate=evaluate,
+        proposer=_FixedProposer({"retrieval.top_k_final": 12}),
+        search_set_ids=search_ids,
+        fast_tier_ids=fast_ids,
+        unreachable_ids=(),
+        max_iterations=1,
+        patience=None,
+        ledger_dir=tmp_path,
+        verify_reachability=False,
+    )
+
+    entry = report["iterations"][0]
+    assert entry["verdict"] == "rejected_no_gain"
+    assert "noise floor (3)" in entry["reason"]
+    assert report["ratchet"] == 5
+
+
+def test_a_real_improvement_is_accepted_and_moves_the_ratchet(tmp_path):
+    search_ids = ("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l")
+    fast_ids = ("a",)
+    recovered = ("g", "h", "i", "j", "k", "l")
+    # Reference passes 6/12; the improved candidate passes all 12 -- a gain of
+    # six, past the measured noise floor of three (loop.NOISE_FLOOR_CASES) and
+    # at the design doc's ~6-flip demonstrability threshold.
+    assert len(recovered) > loop.NOISE_FLOOR_CASES
+
+    def evaluate(overrides, case_ids):
+        better = overrides.get("retrieval.top_k_final") == 12
+        records = [
+            _rec(cid, "factual_number", better or cid not in recovered, 200.0) for cid in case_ids
         ]
         return ev.EvaluationResult(records=tuple(records), effective_config=dict(overrides))
 
@@ -284,7 +322,7 @@ def test_a_real_improvement_is_accepted_and_moves_the_ratchet(tmp_path):
 
     entry = report["iterations"][0]
     assert entry["verdict"] == "accepted"
-    assert report["ratchet"] == 8
+    assert report["ratchet"] == 12
     assert report["best_iteration"] == entry["iteration"]
 
 
@@ -305,7 +343,11 @@ def test_resolution_warning_is_always_present_in_the_report(tmp_path):
         verify_reachability=False,
     )
     assert report["resolution_warning"] == loop.RESOLUTION_WARNING
-    assert report["resolution_warning"]["available_search_set_failures"] == 5
+    # The measured figures of 2026-09-12 (#243), so a re-measurement that
+    # forgets this dict shows up here rather than in a stale report.
+    assert report["resolution_warning"]["available_search_set_failures"] == 16
+    assert report["resolution_warning"]["net_flips_under_known_sabotage"] == 10
+    assert report["resolution_warning"]["noise_floor_cases"] == loop.NOISE_FLOOR_CASES == 3
     assert report["resolution_warning"]["demonstrability_flip_threshold"] == 6
 
 
@@ -553,13 +595,15 @@ def test_recovery_candidate_reaches_the_search_set_when_reference_is_degraded(tm
     because the sabotage lucked into it; the healthy high-water state in the
     ledger fails it. Recovery pairing must let a candidate that restores
     health through to acceptance instead of rejecting it at the fast tier."""
-    search_ids = ("lucky", "a", "b", "c", "d")
+    search_ids = ("lucky", "a", "b", "c", "d", "e", "f")
     fast_ids = ("lucky",)
-    # High water (healthy): fails 'lucky', passes everything else -> 4.
+    # High water (healthy): fails 'lucky', passes everything else -> 6. The
+    # degraded reference passes only 'lucky' -> 1, so restoring health is a
+    # gain of five over the ratchet, past the noise floor of three.
     _seed_entry(
         tmp_path,
         1,
-        4,
+        6,
         [
             {
                 "id": "lucky",
@@ -569,7 +613,7 @@ def test_recovery_candidate_reaches_the_search_set_when_reference_is_degraded(tm
             },
             *[
                 {"id": cid, "case_type": "factual_number", "passed": True, "elapsed_seconds": 200.0}
-                for cid in ("a", "b", "c", "d")
+                for cid in ("a", "b", "c", "d", "e", "f")
             ],
         ],
     )
@@ -601,10 +645,10 @@ def test_recovery_candidate_reaches_the_search_set_when_reference_is_degraded(tm
 
     assert report["recovery_mode"]["active"] is True
     assert report["recovery_mode"]["baseline_iteration"] == 1
-    assert report["recovery_mode"]["baseline_objective_adjusted"] == 4
+    assert report["recovery_mode"]["baseline_objective_adjusted"] == 6
     entry = report["iterations"][0]
     assert entry["evaluated_case_set"] == "search_set"  # got past the fast tier
-    assert entry["verdict"] == "accepted"  # restored health: 4 > ratchet 1
+    assert entry["verdict"] == "accepted"  # restored health: 6 > ratchet 1 + floor 3
     assert entry["regression_baseline_iteration"] == 1
 
 

--- a/tests/eval/README.md
+++ b/tests/eval/README.md
@@ -310,15 +310,17 @@ existed simply lack them; a reader must treat a missing key as "not recorded", n
 
 ## Measuring the noise floor and the gate's sensitivity
 
-The runs cited below are historical, measured 2026-07-29 against a 51-case gold set: six
-English papers as the dev set, three arXiv papers (ResNet, BERT, ViT) as the blind set, `lang`
-limited to `en`/`es`, and four `case_type` values -- not the 156-case, three-language,
-four-source set `gold_cases.jsonl` holds today (see Corpus above). The fractions below
+The first runs cited below are historical, measured 2026-07-29 against a 51-case gold set:
+six English papers as the dev set, three arXiv papers (ResNet, BERT, ViT) as the blind set,
+`lang` limited to `en`/`es`, and four `case_type` values -- not the 156-case, three-language,
+four-source set `gold_cases.jsonl` holds today (see Corpus above). The fractions there
 (`44/51`, `39/51`, `40/51`) belong to that older, smaller set and do not rescale to a
-denominator of 156; nobody has re-run this measurement against the current file. The procedure
--- run twice, diff with `compare_runs.py` -- is unchanged and is exactly what a fresh
-measurement should still follow; only the numbers already on record here are frozen at the set
-they were measured on.
+denominator of 156. Both measurements have since been repeated on the current set -- the
+noise floor on all 156 cases with four generators (2026-09-11, below) and the noise floor
+and the sensitivity on the 123-case search set with the gate's default generator (2026-09-12,
+`harness/README.md`, "Resolution warning"). The procedure -- run twice, diff with
+`compare_runs.py` -- is unchanged; the older numbers stay on record for the set they were
+measured on.
 
 Both need a GPU machine with Ollama running — the fast CI gate cannot run
 them. `compare_runs.py` itself is pure and is covered by the fast gate.


### PR DESCRIPTION
## Summary

Closes the last two open issues from the campaign's review pass. Every number `harness/loop.py` reasoned with came from the 32-case search set that preceded #213. Three `evaluate()` calls on 2026-09-12, made exactly as `evaluator.real_evaluate()` makes them (generator `Ling-3.0-tiny`, the 123-case search set, `main` at `ee56ea9`, 31 min each, no infrastructure errors):

| run | overrides | result |
|---|---|---|
| `20260912T003549Z` | none | 107/123 |
| `20260912T010521Z` | `retrieval.top_k_final=1` | 97/123 |
| `20260912T013552Z` | none | 104/123 |

- **Noise floor 3** (`compare_runs.py` over the two references: 0 up, 3 down, 120 unchanged). `NOISE_FLOOR_CASES = 3`; a gain of three is `rejected_no_gain`, pinned by a new test; the two fixtures that assumed zero now gain by six and five.
- **Resolution**: 16 available failures; the sabotage moves 10 net flips against the first reference (7 against the second), above the ~6-flip threshold, so a catastrophic change is detectable; 4 or 5 cases still is not a demonstrated result. `RESOLUTION_WARNING` and both READMEs say so with the artifacts cited.
- **Fast tier** (#247): re-derived by one stated rule from the reference run -- every failure (16) plus the first passing case per `case_type` and per `source` left uncovered (9) -- 25 ids spanning all seven case types and all three stores; `test_evaluator.py` asserts source coverage.

## Test plan

- `ruff check .` clean; full `pytest`: 1213 passed, 2 skipped.
- The measurement itself ran on the code after #250/#251: one budget exhaustion per run, none cascading -- the #249 window did not recur.

## Closes

Fixes #243
Fixes #247

🤖 Generated with [Claude Code](https://claude.com/claude-code)