### PR TITLE
Bring the harness runbook up to the 2026-09-12 search-set measurement

### DIFF
--- a/harness/RUNBOOK.md
+++ b/harness/RUNBOOK.md
@@ -253,12 +253,12 @@ start without at least one; it is what guarantees termination.
 **Budget, and whose machine the number came from.** Quoting one GPU's timings
 as universal is how someone budgets a night for something that takes seven.
 
-| | reference GPU (2026-08-19) | RTX 4060 Laptop 8 GB (2026-09-01) |
-|---|---|---|
-| retrieval-only case | ~4.1 s | **~30 s** |
-| answered case | ~28.5 s | ~9-11 s |
-| full search-set evaluation | ~20 min | ~25 min (phase 1 dominates) |
-| fast tier (16 cases) | ~4 min for 13 of them (unmeasured for the 3 study-artifact cases, issue #226) | not measured here |
+| | reference GPU (2026-08-19) | RTX 4060 Laptop 8 GB (2026-09-01) | RTX 4060 Laptop 8 GB (2026-09-12, `20260912T003549Z`, 123 cases, `Ling-3.0-tiny`) |
+|---|---|---|---|
+| retrieval-only case | ~4.1 s | **~30 s** | ~8.3 s |
+| answered case | ~28.5 s | ~9-11 s | ~7.3 s generation, ~14.9 s with its retrieval |
+| full search-set evaluation | ~20 min | ~25 min (phase 1 dominates) | ~31 min (three runs, 31 min each) |
+| fast tier | ~4 min for 13 of the 16 then listed (issue #226) | not measured here | ~8.5 min for the 25 now listed, 3 of them one budget-exhausting `study_quiz` |
 
 The 4060 figures are from a run with `OLLAMA_KEEP_ALIVE=0` (which the warning
 above now restricts to gate runs -- a campaign measured without it answers
@@ -329,16 +329,14 @@ red test.
 State these when reporting a campaign; they are not disclaimers, they are the
 measurement's actual resolution.
 
-- **The search-set win-margin and sabotage-flip numbers are stale.** "At
-  most 5 cases" and "3 net flips" were measured on the 32-case search set
-  that existed before #213 (block B, issue #30) grew it to 123 -- see
-  `harness/README.md`'s Resolution warning section (issue #225) for the
-  full account and what re-measuring them for real needs. `harness/loop.py`
-  still hardcodes those numbers into every report's `resolution_warning`,
-  so an accepted improvement on today's corpus still reads as **a candidate
-  for confirmation, not a demonstrated result** -- that conclusion holds
-  regardless; the specific numbers behind it just don't describe today's
-  search set yet.
+- **The search-set figures were re-measured on 2026-09-12** (issue #243,
+  `harness/README.md`'s Resolution warning section): 16 available failures
+  of 123, a noise floor of 3 cases between two identical runs, and 10 net
+  flips under the known-catastrophic sabotage -- above the ~6-flip
+  threshold, so a catastrophic change is detectable now. An accepted gain
+  of 4 or 5 cases still reads as **a candidate for confirmation, not a
+  demonstrated result**; 6 or more is at the threshold. `harness/loop.py`
+  carries these numbers into every report's `resolution_warning`.
 - **Index-time knobs are still not searched, but the tier is now costed.**
   Chunking and the index-time flags force a full reindex, which no budget
   survives inside a search loop. Declaring one in `SEARCH_SPACE` is still a red
@@ -348,8 +346,8 @@ measurement's actual resolution.
   unit the patience budget is already spent in. It measures nothing itself; the
   reindex and evaluation seconds come from a real run. Whether such a candidate
   can pay off at all is still block B's question (#30) -- #213 grew the search
-  set, but the resolution warning above has not been re-measured against it,
-  so the answer still isn't in.
+  set and the resolution warning above is now measured against it, but no
+  index-time candidate has been run through it, so the answer still isn't in.
 - **Stage 1 is a single-field sweep from a fixed reference**, not a
   compounding hill climb. Two accepted single-field changes cannot combine
   within a run.


### PR DESCRIPTION
## Summary

`harness/RUNBOOK.md` still priced the fast tier at 16 cases and told a campaign reporter the resolution figures were stale. After #252 both are measured: the budget table gains the 2026-09-12 column (from `20260912T003549Z`'s own per-case timings) and section 7 states the numbers.

## Test plan

Docs only. Figures recomputed from the artifact: retrieval-only median 8.3 s, answered median 7.3 s generation / 14.9 s with retrieval, 31 min per run, 25 fast-tier ids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)