### PR TITLE
Cap the rag role at 4,096 tokens and make the gate measure the product's generator

### DIFF
--- a/.github/workflows/full-eval.yml
+++ b/.github/workflows/full-eval.yml
@@ -10,7 +10,7 @@ name: Full eval gate
 # test doubles.
 #
 # THIS GATE REQUIRES A LOCAL OLLAMA SERVER AND A CUDA GPU. The models it
-# calls (gemma4:e2b by default) and the
+# calls (gemma4:e4b by default, the product's own) and the
 # reranker CrossEncoder are not available on hosted GitHub runners, so this
 # workflow only runs on a self-hosted runner where those prerequisites are
 # already met, and it is never triggered automatically (workflow_dispatch
@@ -28,7 +28,7 @@ on:
       models:
         description: "Space-separated Ollama generator models to evaluate"
         required: false
-        default: "gemma4:e2b"
+        default: "gemma4:e4b"
       update_baseline:
         description: "Raise the pass-rate baseline if this run is green (never lowers it)"
         type: boolean

--- a/docs/model-history.md
+++ b/docs/model-history.md
@@ -68,7 +68,11 @@ turns this log into a ranking, which it is not.
 
 156 cases: 136 reach a generator, 20 are retrieval-only and shared by every
 model in a run. Three corpora of 17 documents (en/es/ca) plus the blind set.
-Budget 180 s, `AUX_MODEL` = `Ling-3.0-tiny` for every row.
+Budget 180 s, `AUX_MODEL` = `Ling-3.0-tiny` for every row. Every row was
+measured with the `rag` role's `num_predict` at -1 (unbounded); the product
+caps it at 4,096 since 2026-09-12, which changes no passing answer (the
+campaign's 99th percentile is 2,138 tokens), so later rows remain comparable
+with these.
 
 | Model | Size | Answered (of 136) | Overall (of 156) | tokens/s | tokens/answer | s/answer | Budget hit | Infra | Placement | Run | Runs |
 |---|---|---|---|---|---|---|---|---|---|---|---|

--- a/harness/README.md
+++ b/harness/README.md
@@ -201,13 +201,14 @@ fake evaluator that raises on a declared key makes startup fail loudly
 
 **Which generator.** Every evaluation the loop runs -- the reference, each
 candidate, a replay -- generates with `run_eval.DEFAULT_MODELS`
-(`evaluator.real_evaluate` passes it), which is `Ling-3.0-tiny` unless
-`OLLAMA_RAG_MODEL` is set. That is the gate's default, not the product's
-(`gemma4:e4b`); the loop therefore searches for a retrieval configuration
-that helps the faster model the 0.82 floor was calibrated with, and a
-configuration it accepts has not been shown to help the shipped one. Export
-`OLLAMA_RAG_MODEL` to search for the product instead. Whether the two
-defaults should be one is issue #242.
+(`evaluator.real_evaluate` passes it): `gemma4:e4b`, the product's own
+default, unless `OLLAMA_RAG_MODEL` is set (decided 2026-09-12, issue #242;
+it was `Ling-3.0-tiny` before). A configuration the loop accepts is
+therefore measured on the generator a user runs. The auxiliary roles stay
+pinned to `AUX_MODEL` (`Ling-3.0-tiny`) as in every gate run. The noise
+floor and resolution figures below were measured with `Ling-3.0-tiny` and
+are being re-measured with `gemma4:e4b`; until that lands, read them as the
+Ling figures they are.
 
 **Objective:** `objective_adjusted` = passing cases on the search set, minus
 cases listed in `unreachable_cases.txt` (excluded from both numerator and

--- a/rag/engine/wiring.py
+++ b/rag/engine/wiring.py
@@ -61,7 +61,14 @@ RAG_SAMPLING_OPTIONS: Dict[str, Any] = {
     "top_p": 0.9,
     "repeat_penalty": 1.15,
     "repeat_last_n": 64,
-    "num_predict": -1,
+    # Was -1 (unbounded) until 2026-09-12. Across the 3,167 answers of the
+    # model campaign the 99th percentile was 2,138 tokens and every longer
+    # one was a failing answer; one unbounded quiz call reached ~96,000
+    # tokens and held Ollama's only slot for fifteen minutes (issue #249).
+    # 4,096 truncates no real answer on record and cuts a runaway in about
+    # forty seconds on this card. Rows measured under -1 stay comparable:
+    # no passing answer came near the cap.
+    "num_predict": 4096,
 }
 
 RECOMP_SAMPLING_OPTIONS: Dict[str, Any] = {
@@ -242,8 +249,10 @@ def rag_chat_model(config: AppConfig) -> OllamaChatModel:
 
     Sampling is cold and repetition-penalised: the answer must stay inside the
     retrieved evidence, and a wandering generator is worse than a terse one.
-    ``num_predict`` is unbounded because a truncated answer to a document
-    question is indistinguishable from a wrong one.
+    ``num_predict`` is capped at 4,096 (see ``RAG_SAMPLING_OPTIONS``): a
+    truncated answer to a document question is indistinguishable from a wrong
+    one, which is why the cap sits nearly twice above the 99th percentile of
+    every answer measured rather than at a typical length.
 
     The unloader is wired in here because this model runs last, but it only
     reaches other Ollama-served roles (query decomposer, RECOMP, contextual)

--- a/tests/eval/README.md
+++ b/tests/eval/README.md
@@ -181,14 +181,15 @@ something is missing:
    refuses more than one `--models` entry: the file holds one number,
    calibrated on the gate's default generator.
 
-   That default is `run_eval.DEFAULT_MODELS` -- `Ling-3.0-tiny` unless `OLLAMA_RAG_MODEL`
-   says otherwise -- and it is **not** the product's default (`gemma4:e4b`). The gate and the
-   configuration harness (`harness/evaluator.real_evaluate`, which passes `DEFAULT_MODELS`)
-   measure the faster model the 0.82 floor was set with, at 7.5 s per answer against 11.8 s
-   for the shipped one; a no-argument `python tests/eval/run_eval.py` is therefore a statement
-   about the pipeline under `Ling-3.0-tiny`, not about what a user runs. Pass
-   `--models gemma4:e4b` (or export `OLLAMA_RAG_MODEL`) to measure the product; whether the
-   two defaults should be made the same is issue #242.
+   That default is `run_eval.DEFAULT_MODELS`: `gemma4:e4b` unless `OLLAMA_RAG_MODEL` says
+   otherwise -- the product's own default, so a no-argument `python tests/eval/run_eval.py`,
+   the `full-eval` workflow and the configuration harness (`harness/evaluator.real_evaluate`,
+   which passes `DEFAULT_MODELS`) all measure what a user runs. Decided 2026-09-12 (issue
+   #242); until then the default was `Ling-3.0-tiny`, the faster model the 0.82 floor was first
+   set with (7.5 s per answer against 11.8 s). The floor did not move with the switch:
+   `gemma4:e4b` scored 136/156 = 0.872 on `20260911T094107Z`, and the rule sets the floor at
+   the rate minus 0.05, which is 0.82 again. The auxiliary roles stay pinned to `AUX_MODEL`
+   (`Ling-3.0-tiny`) for every run, as the experiment standard below requires.
 
 Infrastructure failures leave the run inconclusive. Only an unfiltered gold-set
 run (`case_ids is None`, the CLI) is compared against the baseline. A subset
@@ -220,6 +221,11 @@ instead of re-derived from memory.
   product, which is why `.env.example` does not list it; the value in effect is written to the
   artifact's `conditions.generation_budget_seconds`, and two runs with different budgets are not
   comparable rows.
+- The `rag` role's `num_predict` is 4,096 since 2026-09-12 (it was -1, unbounded; issue #249
+  and the decision after it). Rows measured under -1 remain comparable with rows measured
+  under 4,096: across the campaign's 3,167 answers the 99th percentile was 2,138 tokens and
+  every longer answer failed anyway, so the cap changes no passing answer. The value in effect
+  is in the artifact's `conditions.sampling.rag`.
 - The adapter's own deadline, `OLLAMA_GENERATION_DEADLINE`, is set to the budget plus five
   seconds for the generation phase (issue #249). The budget only stops *waiting*; the deadline is
   what closes the request the budget walked away from, which is what makes Ollama cancel the

--- a/tests/eval/run_eval.py
+++ b/tests/eval/run_eval.py
@@ -106,12 +106,12 @@ EXTRA_DEV_CORPORA = {
 # server while the measurement runs on another (issue #244).
 OLLAMA_BASE_URL = read_env_ollama_base_url()
 
-# The baseline was calibrated with this model. Other models can be measured
-DEFAULT_MODELS = [
-    os.getenv(
-        "OLLAMA_RAG_MODEL", "hf.co/noctrex/Ling-3.0-tiny-MXFP4_MOE-GGUF:MXFP4_MOE"
-    )
-]
+# The product's own default generator (rag/chat_pdfs.py MODELO_RAG), so a
+# no-argument run states something about what ships. Until 2026-09-12 this
+# was Ling-3.0-tiny, the faster model the 0.82 floor was first set with
+# (issue #242); gemma4:e4b clears that floor at 136/156 = 0.872 on
+# 20260911T094107Z, so the floor did not move. Other models can be measured
+DEFAULT_MODELS = [os.getenv("OLLAMA_RAG_MODEL", "gemma4:e4b")]
 
 # Model used for the auxiliary Ollama roles during this run: query
 # decomposition, contextual-retrieval enrichment and RECOMP synthesis. Kept

--- a/tests/unit/test_wiring_rag_sampling_cap.py
+++ b/tests/unit/test_wiring_rag_sampling_cap.py
@@ -1,0 +1,42 @@
+"""The rag role's generation is capped in tokens, and the cap clears every
+real answer on record.
+
+Decided 2026-09-12 after issue #249: with ``num_predict = -1`` one quiz call
+produced ~96,000 tokens and held Ollama's only slot for fifteen minutes,
+and in the web chat nothing but the user stops such a generation. Across the
+3,167 answers the model campaign measured, the 99th percentile was 2,138
+tokens and the longest 8,883 -- every one of the long ones a failing
+answer. 4,096 truncates none of the real ones and cuts a runaway in about
+forty seconds on this card.
+
+Lives here rather than under tests/characterization because it pins a
+decision, not observed behaviour to be preserved as-is.
+"""
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import rag.chat_pdfs  # noqa: E402,F401
+from monkeygrab.config.app_config import AppConfig  # noqa: E402
+from rag.engine import wiring  # noqa: E402
+
+# The 99th percentile of answer length across the 2026-09-11 campaign
+# (3,167 answers; medians 27-335 tokens). The cap sits nearly twice above it
+# and far below a runaway.
+_P99_ANSWER_TOKENS = 2_138
+
+
+def test_rag_generation_is_capped_above_every_real_answer_on_record():
+    cap = wiring.RAG_SAMPLING_OPTIONS["num_predict"]
+    assert cap > 0, "an unbounded rag generation is what #249 measured at 96,000 tokens"
+    assert cap >= 1.5 * _P99_ANSWER_TOKENS
+    assert cap == 4096
+
+
+def test_the_cap_reaches_the_built_rag_model():
+    model = wiring.rag_chat_model(AppConfig())
+    assert model._options()["num_predict"] == 4096


### PR DESCRIPTION
## Summary

Two product decisions taken from the campaign's numbers (the questionnaire after #253):

- **`num_predict` 4,096 for the `rag` role** (was -1). p99 of 3,167 measured answers is 2,138 tokens, every longer one failed; the #249 runaway reached 96,000. A test pins the cap and its rationale. Rows in `docs/model-history.md` measured under -1 stay comparable; the experiment standard records why.
- **The gate, the `full-eval` workflow and the harness default to `gemma4:e4b`**, the product's generator (they measured `Ling-3.0-tiny`; the workflow even defaulted to `gemma4:e2b`). The 0.82 floor holds: 136/156 = 0.872 on `20260911T094107Z`. `AUX_MODEL` stays `Ling-3.0-tiny`.

The harness's noise floor and resolution figures were measured with Ling and are re-measured with `gemma4:e4b` in the next PR; `harness/README.md` says to read them as Ling's until then.

## Test plan

- `ruff check .` clean; full `pytest`: 1216 passed, 2 skipped.
- `tests/unit/test_wiring_rag_sampling_cap.py` fails against -1.
- The re-measurement that follows is the gate's own confirmation that 4,096 moves no case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)