### PR TITLE
Re-measure the harness's noise floor and resolution with the product's generator

### DIFF
--- a/harness/README.md
+++ b/harness/README.md
@@ -180,22 +180,21 @@ fake evaluator that raises on a declared key makes startup fail loudly
   search-set subset) -- never from a proposer, which can only emit config
   overrides. Proven, not assumed: `harness/tests/test_evaluator.py` asserts
   the blind set is disjoint from both the search set and the fast tier.
-- **Fast tier** (25 fixed ids, `fast_tier.txt`) -- regression filter only, it
+- **Fast tier** (26 fixed ids, `fast_tier.txt`) -- regression filter only, it
   **never declares an improvement**. Re-derived on 2026-09-12 from the
-  search-set reference run by one rule (issue #247): every case that run
-  failed (16), plus the first passing case in `gold_cases.jsonl` order for
-  every `case_type` and every `source` the failures left uncovered (9). It
-  spans all seven case types and all three stores, and
-  `harness/tests/test_evaluator.py` asserts both, so the next corpus
-  expansion cannot strand a store here again as #213 did. Cost, from that
-  run's own per-case timings: about 8.5 min, of which 3 are one
-  `study_quiz` that exhausts the generation budget (kept: the deadline
-  #249 added bounds it, and the quiz path shows up here first). Its job is
-  rejecting a bad candidate before it can contaminate the ratchet, not the
-  minutes it happens to save against a ~31 min full search-set run. The
-  failures are here so the filter has signal on both sides: a candidate
-  that fixes one shows a gain the tier does not act on, a candidate that
-  breaks a passing one is rejected before the ratchet sees it.
+  search-set reference run with the product's generator by one rule (issue
+  #247): every case that run failed (17), plus the first passing case in
+  `gold_cases.jsonl` order for every `case_type` and every `source` the
+  failures left uncovered (9). It spans all seven case types and all three
+  stores, and `harness/tests/test_evaluator.py` asserts both, so the next
+  corpus expansion cannot strand a store here again as #213 did. Cost, from
+  that run's own per-case timings: about 7 min against ~30 min for a full
+  search-set run, no case near the generation budget. Its job is rejecting
+  a bad candidate before it can contaminate the ratchet, not the minutes it
+  happens to save. The failures are here so the filter has signal on both
+  sides: a candidate that fixes one shows a gain the tier does not act on,
+  a candidate that breaks a passing one is rejected before the ratchet sees
+  it.
 
 ## Objective, constraint, noise floor
 
@@ -206,20 +205,20 @@ default, unless `OLLAMA_RAG_MODEL` is set (decided 2026-09-12, issue #242;
 it was `Ling-3.0-tiny` before). A configuration the loop accepts is
 therefore measured on the generator a user runs. The auxiliary roles stay
 pinned to `AUX_MODEL` (`Ling-3.0-tiny`) as in every gate run. The noise
-floor and resolution figures below were measured with `Ling-3.0-tiny` and
-are being re-measured with `gemma4:e4b`; until that lands, read them as the
-Ling figures they are.
+floor and resolution figures below are measured with `gemma4:e4b`; the
+same three runs were made with `Ling-3.0-tiny` first, and where the two
+differ the text says so.
 
 **Objective:** `objective_adjusted` = passing cases on the search set, minus
 cases listed in `unreachable_cases.txt` (excluded from both numerator and
 denominator, not just discounted). `unreachable_cases.txt` starts **empty**
 and stays that way as of 2026-09-12: the reference run on the current
-123-case search set (`20260912T003549Z`, 107/123) fails 16 cases -- 11
-`factual_number`, 2 `factual_concept`, 2 `figure_retrieval`, 1 `study_quiz`
-that exhausted the generation budget -- and every one of them is a
-retrieval or generation outcome the declared search space can move, not a
-case no configuration could reach. Their ids are the first block of
-`fast_tier.txt`. `objective_raw` (unreachable cases included) is tracked
+123-case search set with the product's generator (`20260912T034029Z`,
+`gemma4:e4b`, 106/123) fails 17 cases -- 11 `factual_number`, 3
+`factual_concept`, 2 `figure_retrieval`, 1 `study_outline` -- and every one
+of them is a retrieval or generation outcome the declared search space can
+move, not a case no configuration could reach. Their ids are the first
+block of `fast_tier.txt`. `objective_raw` (unreachable cases included) is tracked
 alongside so the exclusion mechanism is auditable before it is ever
 needed — today `raw == adjusted`.
 
@@ -262,56 +261,66 @@ counts toward `--patience`) and raises `evaluator.InconclusiveEvaluationError`
 before the loop even starts if the **reference** measurement itself carries
 one — no ratchet baseline can be trusted in that case.
 
-**Noise floor: 3 cases.** Measured 2026-09-12 on the search set this loop
-evaluates and with the generator it runs (`Ling-3.0-tiny`): two
-`evaluate()` calls of the identical configuration, `conditions` equal field
-for field, `20260912T003549Z` (107/123) and `20260912T013552Z` (104/123);
-`compare_runs.py` over the pair: 0 flipped to PASS, 3 flipped to FAIL, 120
-unchanged. A candidate three cases up on the ratchet is rejected as
-`rejected_no_gain` (`loop.NOISE_FLOOR_CASES`); four is the smallest
-accepted gain. This replaces the 2026-07-29 figure of zero flips, which was
-measured on the 51-case set that preceded #213 and re-verified on the
-32-case search set of the time; the current 156-case set flips on sampling
-alone (`docs/model-history.md`, "How to read", item 1), and so does this
-subset of it (issue #243).
+**Noise floor: 2 cases.** Measured 2026-09-12 on the search set this loop
+evaluates and with the generator it runs (`gemma4:e4b`): two `evaluate()`
+calls of the identical configuration, `conditions` equal field for field,
+`20260912T034029Z` (106/123) and `20260912T043930Z` (106/123);
+`compare_runs.py` over the pair: 1 flipped to PASS, 1 flipped to FAIL, 121
+unchanged, both study artifacts over the attention paper. A candidate two
+cases up on the ratchet is rejected as `rejected_no_gain`
+(`loop.NOISE_FLOOR_CASES`); three is the smallest accepted gain. The same
+pair with `Ling-3.0-tiny`, the gate's default until #254
+(`20260912T003549Z` 107/123, `20260912T013552Z` 104/123), moved three
+cases, all to FAIL. This replaces the 2026-07-29 figure of zero flips,
+which was measured on the 51-case set that preceded #213 and re-verified
+on the 32-case search set of the time; the current 156-case set flips on
+sampling alone (`docs/model-history.md`, "How to read", item 1), and so
+does this subset of it (issue #243).
 
 ## Resolution warning
 
-Measured 2026-09-12 on the current 123-case search set, with the same three
-runs as the noise floor above (issue #243), replacing figures that had been
-measured on the 32-case set that preceded #213:
+Measured 2026-09-12 on the current 123-case search set with the product's
+generator, `gemma4:e4b`, in the same three runs as the noise floor above
+(issue #243), replacing figures measured on the 32-case set that preceded
+#213:
 
-- **Available failures: 16 of 123** (`20260912T003549Z`, 107/123). The old
+- **Available failures: 17 of 123** (`20260912T034029Z`, 106/123). The old
   figure was "at most 5" on 27/32.
-- **Net flips under the known-catastrophic sabotage: 10.** The criterion-2
+- **Net flips under the known-catastrophic sabotage: 6.** The criterion-2
   sabotage, `retrieval.top_k_final=1` passed through `evaluate()`'s
-  `config_overrides` (`20260912T010521Z`, 97/123), flipped 2 cases to PASS
-  and 12 to FAIL against the first reference, 4 and 11 against the second.
-  The old figure was 3 net on the 32-case set.
+  `config_overrides` (`20260912T040928Z`, 100/123), flipped 2 cases to PASS
+  and 8 to FAIL against the first reference, 3 and 9 against the second: 6
+  net both times. The old figure was 3 net on the 32-case set.
 - **Demonstrability threshold: ~6 net flips**, the design doc's (§3) fixed
   methodological constant, unchanged.
 
-So the resolution picture has changed for the better: a catastrophic
-single-field change now clears the threshold and is detectable on the
-search set. What the set still cannot do is demonstrate a *small*
-improvement. With a noise floor of 3, an accepted candidate is at least 4
-cases up on the ratchet, and 4 or 5 is above the floor but below the
-threshold -- a candidate for confirmation, not a demonstrated result. All
-of this is in `harness/loop.py`'s `RESOLUTION_WARNING` dict
+So a catastrophic single-field change now sits exactly at the threshold:
+detectable, but only just. With `Ling-3.0-tiny` the same sabotage moved 10
+net against 16 available failures (`20260912T010521Z` against
+`20260912T003549Z`); the shipped generator absorbs more of a retrieval
+collapse, which is a fact about the product, not a defect of the set. What
+the set still cannot do is demonstrate a *small* improvement. With a noise
+floor of 2, an accepted candidate is at least 3 cases up on the ratchet, and
+3 to 5 is above the floor but below the threshold -- a candidate for
+confirmation, not a demonstrated result. All of this is in
+`harness/loop.py`'s `RESOLUTION_WARNING` dict
 (`SEARCH_SET_AVAILABLE_FAILURES`, `SEARCH_SET_NET_FLIPS_UNDER_KNOWN_SABOTAGE`,
 `noise_floor_cases`) and attached verbatim, via `message`, to every real
 campaign's report.
 
 > [!NOTE]
-> The three 2026-09-12 artifacts (`tests/eval/runs/20260912T003549Z_...json`,
-> `...010521Z...`, `...013552Z...`), like every run artifact, are local and
-> gitignored -- cited, not shipped. They were produced by calling
-> `run_eval.evaluate()` exactly as `evaluator.real_evaluate()` does
-> (`models=run_eval.DEFAULT_MODELS`, `search_space.expand_overrides`,
-> `update_baseline=False`) with `write_report=True`, on `main` at `ee56ea9`,
-> 31 minutes each, no infrastructure errors, one budget exhaustion each.
-> The 2026-07-29 and 2026-08-12 runs the previous version of this section
-> cited (`20260729T020233Z`, `...040824Z`, `...081129Z`,
+> The 2026-09-12 artifacts (`tests/eval/runs/20260912T034029Z_...json`,
+> `...040928Z...`, `...043930Z...` for `gemma4:e4b`; `...003549Z...`,
+> `...010521Z...`, `...013552Z...` for `Ling-3.0-tiny`), like every run
+> artifact, are local and gitignored -- cited, not shipped. They were
+> produced by calling `run_eval.evaluate()` exactly as
+> `evaluator.real_evaluate()` does (`models=run_eval.DEFAULT_MODELS`,
+> `search_space.expand_overrides`, `update_baseline=False`) with
+> `write_report=True`, on `main` at `c0e9f17` (gemma4) and `ee56ea9` (Ling),
+> about 30 minutes each, no infrastructure errors; the gemma4 runs had no
+> budget exhaustion and no answer near the 4,096-token cap (longest: 129
+> tokens). The 2026-07-29 and 2026-08-12 runs the previous version of this
+> section cited (`20260729T020233Z`, `...040824Z`, `...081129Z`,
 > `20260812T194812Z`) remain the source of the per-bucket latency medians
 > above; nothing here retracts them, they simply described a smaller set.
 

--- a/harness/RUNBOOK.md
+++ b/harness/RUNBOOK.md
@@ -253,12 +253,12 @@ start without at least one; it is what guarantees termination.
 **Budget, and whose machine the number came from.** Quoting one GPU's timings
 as universal is how someone budgets a night for something that takes seven.
 
-| | reference GPU (2026-08-19) | RTX 4060 Laptop 8 GB (2026-09-01) | RTX 4060 Laptop 8 GB (2026-09-12, `20260912T003549Z`, 123 cases, `Ling-3.0-tiny`) |
+| | reference GPU (2026-08-19) | RTX 4060 Laptop 8 GB (2026-09-01) | RTX 4060 Laptop 8 GB (2026-09-12, `20260912T034029Z`, 123 cases, `gemma4:e4b`) |
 |---|---|---|---|
-| retrieval-only case | ~4.1 s | **~30 s** | ~8.3 s |
-| answered case | ~28.5 s | ~9-11 s | ~7.3 s generation, ~14.9 s with its retrieval |
-| full search-set evaluation | ~20 min | ~25 min (phase 1 dominates) | ~31 min (three runs, 31 min each) |
-| fast tier | ~4 min for 13 of the 16 then listed (issue #226) | not measured here | ~8.5 min for the 25 now listed, 3 of them one budget-exhausting `study_quiz` |
+| retrieval-only case | ~4.1 s | **~30 s** | ~7.9 s |
+| answered case | ~28.5 s | ~9-11 s | ~8.1 s generation, ~15.7 s with its retrieval |
+| full search-set evaluation | ~20 min | ~25 min (phase 1 dominates) | ~30 min (three runs, 29-30 min each) |
+| fast tier | ~4 min for 13 of the 16 then listed (issue #226) | not measured here | ~7 min for the 26 now listed, none near the generation budget |
 
 The 4060 figures are from a run with `OLLAMA_KEEP_ALIVE=0` (which the warning
 above now restricts to gate runs -- a campaign measured without it answers
@@ -329,14 +329,15 @@ red test.
 State these when reporting a campaign; they are not disclaimers, they are the
 measurement's actual resolution.
 
-- **The search-set figures were re-measured on 2026-09-12** (issue #243,
-  `harness/README.md`'s Resolution warning section): 16 available failures
-  of 123, a noise floor of 3 cases between two identical runs, and 10 net
-  flips under the known-catastrophic sabotage -- above the ~6-flip
-  threshold, so a catastrophic change is detectable now. An accepted gain
-  of 4 or 5 cases still reads as **a candidate for confirmation, not a
-  demonstrated result**; 6 or more is at the threshold. `harness/loop.py`
-  carries these numbers into every report's `resolution_warning`.
+- **The search-set figures were re-measured on 2026-09-12 with the
+  product's generator** (`gemma4:e4b`; issue #243, `harness/README.md`'s
+  Resolution warning section): 17 available failures of 123, a noise floor
+  of 2 cases between two identical runs, and 6 net flips under the
+  known-catastrophic sabotage -- exactly the ~6-flip threshold, so a
+  catastrophic change is detectable, but only just. An accepted gain of 3
+  to 5 cases reads as **a candidate for confirmation, not a demonstrated
+  result**; 6 or more is at the threshold. `harness/loop.py` carries these
+  numbers into every report's `resolution_warning`.
 - **Index-time knobs are still not searched, but the tier is now costed.**
   Chunking and the index-time flags force a full reindex, which no budget
   survives inside a search loop. Declaring one in `SEARCH_SPACE` is still a red

--- a/harness/fast_tier.txt
+++ b/harness/fast_tier.txt
@@ -1,11 +1,12 @@
 # Fast tier -- regression filter only (never declares an improvement).
-# Fixed, versioned subset of the search set: 25 cases, re-derived on
+# Fixed, versioned subset of the search set: 26 cases, re-derived on
 # 2026-09-12 from the search-set reference run
-# tests/eval/runs/20260912T003549Z_mineru-jina_clip-faiss.json (Ling-3.0-tiny,
-# 107/123, issue #243) by one rule, so it can be re-derived again the same
-# way after the next corpus change (issue #247):
+# tests/eval/runs/20260912T034029Z_mineru-jina_clip-faiss.json (gemma4:e4b,
+# the product's generator since #254; 106/123, issue #243) by one rule, so
+# it can be re-derived again the same way after the next corpus or
+# generator change (issue #247):
 #
-#   every case that run failed (16), plus the first passing case in
+#   every case that run failed (17), plus the first passing case in
 #   gold_cases.jsonl order for every case_type and every source that the
 #   failures alone did not cover (9).
 #
@@ -16,42 +17,41 @@
 # Its job is not to save minutes -- it is to reject a bad candidate without
 # contaminating the ratchet, before paying for the full search set. Cost,
 # from that run's own per-case elapsed_seconds (retrieval plus generation):
-# ~330 s for the 24 cases that finished, plus one study_quiz
-# (gw-study-quiz-ca) that exhausted the 180 s generation budget -- about
-# 8.5 min against ~31 min for the whole search set. The budget case stays:
-# the deadline that #249 added bounds it, and a candidate that fixes or
-# breaks the quiz path shows up here first.
+# ~400 s, about 7 min against ~30 min for the whole search set, with no
+# case near the 180 s generation budget (the rag role is capped at 4,096
+# tokens since #254, and the #249 deadline bounds the rest).
 #
 # The failing cases are here so the filter has signal on both sides: a
 # candidate that fixes one shows a gain the tier does not act on, a candidate
 # that breaks a passing one is rejected before the ratchet sees it. The
-# three figure failures cost ~9 s each and are the retrieval-side signal.
+# two figure failures cost ~9 s each and are the retrieval-side signal.
 
-# -- failed in the reference run (16) --
+# -- failed in the reference run (17) --
+dpo-no-sampling
 higgs-diphoton-figure
-planck-contours-figure
 planck-h0-tension
-gw-study-quiz-ca
-adam-beta2
+planck-contours-figure
+att-study-outline-ca
 adam-stepsize
 supernovae-lab
-photosynthesis-chloroplasts
-antarctica-ice-thickness
 antarctica-freshwater
 fotosintesis-carbono
+tabla-sintetizados
 machupicchu-restaurado
 acueducto-altura
 mediterrania-grecs
 basquet-naixement
 catala-llengua-habitual
+solar-constant
+solar-superficie
 
 # -- passing coverage: one per case_type / source not covered above (9) --
-att-bleu-ende
-att-bleu-table
-att-arch-figure
 dpo-acronym
+att-bleu-ende
+att-arch-figure
 att-study-outline
-att-study-summary
 att-study-quiz
-pitagoras-pruebas
+att-study-summary
+att-bleu-table
 gaudi-montserrat
+pitagoras-pruebas

--- a/harness/loop.py
+++ b/harness/loop.py
@@ -18,15 +18,15 @@ full numbers and why they cannot be re-derived from a fresh clone):
    ``_latency_breach`` checks each bucket against its own reference median
    independently.
 2. **``resolution_warning`` in the final report.** The search set (123
-   non-arXiv cases since #213) can win at most 16 cases today, resampling
-   moves 3 of them, and the most destructive single-field change anyone has
-   measured (``retrieval.top_k_final=1``) moves 10 net -- above the ~6-flip
+   non-arXiv cases since #213) can win at most 17 cases today, resampling
+   moves 2 of them, and the most destructive single-field change anyone has
+   measured (``retrieval.top_k_final=1``) moves 6 net -- exactly the ~6-flip
    threshold design doc section 3 sets for a paired difference not
-   attributable to chance, so a catastrophic change is now detectable
-   (measured 2026-09-12, issue #243). A gain of four or five cases clears
-   the noise floor but not that threshold. Every report says so, so an
-   accepted improvement of that size reads as a candidate for confirmation,
-   not a demonstrated result.
+   attributable to chance, so a catastrophic change is detectable, but only
+   just (measured 2026-09-12 with the product's generator, issue #243). A
+   gain of three to five cases clears the noise floor but not that
+   threshold. Every report says so, so an accepted improvement of that size
+   reads as a candidate for confirmation, not a demonstrated result.
 3. **A ``rejected_regression`` verdict also fires at the search-set stage**
    when the retrieval-only bucket loses cases net against the reference
    (paired by id), even if the blended ``objective_adjusted`` still went up.
@@ -111,24 +111,26 @@ from harness import search_space
 
 # Measured 2026-09-12 on the search set this harness actually evaluates
 # (the 123 non-arXiv cases, evaluator.search_set_case_ids()) with the
-# generator it actually runs (run_eval.DEFAULT_MODELS, Ling-3.0-tiny): two
-# evaluate() calls of the identical configuration, identical `conditions`
-# block field for field, 31 min each --
-# tests/eval/runs/20260912T003549Z_mineru-jina_clip-faiss.json (107/123) and
-# tests/eval/runs/20260912T013552Z_mineru-jina_clip-faiss.json (104/123), both
+# generator it actually runs (run_eval.DEFAULT_MODELS, gemma4:e4b, the
+# product's own since #254): two evaluate() calls of the identical
+# configuration, identical `conditions` block field for field, 30 min each --
+# tests/eval/runs/20260912T034029Z_mineru-jina_clip-faiss.json (106/123) and
+# tests/eval/runs/20260912T043930Z_mineru-jina_clip-faiss.json (106/123), both
 # local and gitignored (see harness/README.md). compare_runs.py over the
-# pair: 0 flipped to PASS, 3 flipped to FAIL, 120 unchanged. Three cases is
-# what resampling the same configuration moves, so a candidate three up on
-# the reference has shown nothing (issue #243).
+# pair: 1 flipped to PASS, 1 flipped to FAIL, 121 unchanged -- both study
+# artifacts over the attention paper. Two cases is what resampling the same
+# configuration moves, so a candidate two up on the reference has shown
+# nothing (issue #243). The same pair for Ling-3.0-tiny, the gate's default
+# until #254, moved three (20260912T003549Z / 20260912T013552Z).
 #
 # This replaces the 2026-07-29 figure of zero flips, measured on the 51-case
 # gold set that preceded #213 and re-verified then on the 32-case search set;
 # the 156-case set flips on sampling alone (docs/model-history.md, "How to
 # read", item 1) and so does this subset of it. If tests/eval/grade.py's
-# scoring rules or the gold set change, this floor must be remeasured -- it
-# is specific to that grader, that set and that generator, not a law of the
-# pipeline.
-NOISE_FLOOR_CASES = 3
+# scoring rules, the gold set or the default generator change, this floor
+# must be remeasured -- it is specific to that grader, that set and that
+# generator, not a law of the pipeline.
+NOISE_FLOOR_CASES = 2
 
 # The latency constraint's multiplier (design doc section 5).
 LATENCY_CEILING_MULTIPLIER = 1.20
@@ -136,23 +138,25 @@ LATENCY_CEILING_MULTIPLIER = 1.20
 # RESOLUTION LIMIT (see module docstring point 2)
 
 # Both from the same 2026-09-12 runs as the noise floor. Available failures:
-# the first reference run failed 16 of 123 (11 factual_number, 2
-# factual_concept, 2 figure_retrieval, 1 study_quiz that exhausted the 180 s
-# budget). Sensitivity: the criterion-2 sabotage, retrieval.top_k_final=1
-# through evaluate()'s config_overrides
-# (tests/eval/runs/20260912T010521Z_mineru-jina_clip-faiss.json, 97/123),
-# flipped 2 to PASS and 12 to FAIL against that reference -- 10 net -- and
-# 4 to PASS, 11 to FAIL against the second reference. Against the 32-case
-# set the same sabotage moved 3 net flips; on today's set it clears the
-# ~6-flip demonstrability threshold, so the set can now show a catastrophic
-# single-field change. What it still cannot do is show a *small* one: a
-# gain of four or five cases clears the noise floor but not the threshold.
-SEARCH_SET_AVAILABLE_FAILURES = 16
+# the first reference run failed 17 of 123 (11 factual_number, 3
+# factual_concept, 2 figure_retrieval, 1 study_outline). Sensitivity: the
+# criterion-2 sabotage, retrieval.top_k_final=1 through evaluate()'s
+# config_overrides (tests/eval/runs/20260912T040928Z_mineru-jina_clip-faiss.json,
+# 100/123), flipped 2 to PASS and 8 to FAIL against that reference -- 6 net
+# -- and 3 to PASS, 9 to FAIL against the second, 6 net again. Against the
+# 32-case set the same sabotage moved 3 net flips; on today's set it sits
+# exactly at the ~6-flip demonstrability threshold, so a catastrophic
+# single-field change is detectable but only just. What the set cannot do
+# is show a *small* one: a gain of three to five cases clears the noise
+# floor but not the threshold. (With Ling-3.0-tiny the same sabotage moved
+# 10 net against 16 available failures: the shipped generator absorbs more
+# of a retrieval collapse.)
+SEARCH_SET_AVAILABLE_FAILURES = 17
 DEMONSTRABILITY_FLIP_THRESHOLD = 6
-SEARCH_SET_NET_FLIPS_UNDER_KNOWN_SABOTAGE = 10
+SEARCH_SET_NET_FLIPS_UNDER_KNOWN_SABOTAGE = 6
 SEARCH_SET_SABOTAGE_DESCRIPTION = (
     "retrieval.top_k_final=1 (single fragment retrieved; criterion 2, 2026-09-12, "
-    "run 20260912T010521Z against reference 20260912T003549Z)"
+    "run 20260912T040928Z against reference 20260912T034029Z, gemma4:e4b)"
 )
 
 RESOLUTION_WARNING: Dict[str, Any] = {
@@ -162,15 +166,15 @@ RESOLUTION_WARNING: Dict[str, Any] = {
     "noise_floor_cases": NOISE_FLOOR_CASES,
     "sabotage_description": SEARCH_SET_SABOTAGE_DESCRIPTION,
     "message": (
-        "The search set can win at most 16 cases (2026-09-12 reference, 107/123). "
-        "Resampling the same configuration moves 3 of them, so an accepted "
-        "improvement is at least 4 cases up on the ratchet; the ~6-flip threshold "
-        "design doc section 3 sets for a demonstrable paired difference is what a "
-        "known-catastrophic single-field sabotage (retrieval.top_k_final=1) now "
-        "clears at 10 net flips. An accepted gain of 4 or 5 cases is therefore a "
-        "candidate for confirmation, not a demonstrated result; 6 or more is at "
-        "the threshold -- see docs/design/2026-07-28-loop-automejorable.md "
-        "section 3 and issue #243."
+        "The search set can win at most 17 cases (2026-09-12 reference, 106/123, "
+        "gemma4:e4b). Resampling the same configuration moves 2 of them, so an "
+        "accepted improvement is at least 3 cases up on the ratchet; the ~6-flip "
+        "threshold design doc section 3 sets for a demonstrable paired difference "
+        "is exactly what a known-catastrophic single-field sabotage "
+        "(retrieval.top_k_final=1) moves, 6 net. An accepted gain of 3 to 5 cases "
+        "is therefore a candidate for confirmation, not a demonstrated result; 6 "
+        "or more is at the threshold -- see "
+        "docs/design/2026-07-28-loop-automejorable.md section 3 and issue #243."
     ),
 }
 

--- a/harness/tests/test_loop.py
+++ b/harness/tests/test_loop.py
@@ -257,11 +257,11 @@ def test_fast_tier_regression_is_rejected_before_paying_for_the_full_set(tmp_pat
 
 def test_a_gain_equal_to_the_noise_floor_is_rejected_as_no_gain(tmp_path):
     """The floor is measured, not decorative: two runs of the same
-    configuration on the search set flipped three cases (#243), so a
-    candidate three cases up on the reference has shown nothing."""
+    configuration on the search set flipped two cases (#243), so a
+    candidate two cases up on the reference has shown nothing."""
     search_ids = ("a", "b", "c", "d", "e", "f", "g", "h")
     fast_ids = ("a",)
-    recovered = ("f", "g", "h")
+    recovered = ("g", "h")
     assert len(recovered) == loop.NOISE_FLOOR_CASES
 
     def evaluate(overrides, case_ids):
@@ -286,8 +286,8 @@ def test_a_gain_equal_to_the_noise_floor_is_rejected_as_no_gain(tmp_path):
 
     entry = report["iterations"][0]
     assert entry["verdict"] == "rejected_no_gain"
-    assert "noise floor (3)" in entry["reason"]
-    assert report["ratchet"] == 5
+    assert "noise floor (2)" in entry["reason"]
+    assert report["ratchet"] == 6
 
 
 def test_a_real_improvement_is_accepted_and_moves_the_ratchet(tmp_path):
@@ -295,8 +295,8 @@ def test_a_real_improvement_is_accepted_and_moves_the_ratchet(tmp_path):
     fast_ids = ("a",)
     recovered = ("g", "h", "i", "j", "k", "l")
     # Reference passes 6/12; the improved candidate passes all 12 -- a gain of
-    # six, past the measured noise floor of three (loop.NOISE_FLOOR_CASES) and
-    # at the design doc's ~6-flip demonstrability threshold.
+    # six, past the measured noise floor (loop.NOISE_FLOOR_CASES) and at the
+    # design doc's ~6-flip demonstrability threshold.
     assert len(recovered) > loop.NOISE_FLOOR_CASES
 
     def evaluate(overrides, case_ids):
@@ -345,9 +345,9 @@ def test_resolution_warning_is_always_present_in_the_report(tmp_path):
     assert report["resolution_warning"] == loop.RESOLUTION_WARNING
     # The measured figures of 2026-09-12 (#243), so a re-measurement that
     # forgets this dict shows up here rather than in a stale report.
-    assert report["resolution_warning"]["available_search_set_failures"] == 16
-    assert report["resolution_warning"]["net_flips_under_known_sabotage"] == 10
-    assert report["resolution_warning"]["noise_floor_cases"] == loop.NOISE_FLOOR_CASES == 3
+    assert report["resolution_warning"]["available_search_set_failures"] == 17
+    assert report["resolution_warning"]["net_flips_under_known_sabotage"] == 6
+    assert report["resolution_warning"]["noise_floor_cases"] == loop.NOISE_FLOOR_CASES == 2
     assert report["resolution_warning"]["demonstrability_flip_threshold"] == 6
 
 
@@ -599,7 +599,7 @@ def test_recovery_candidate_reaches_the_search_set_when_reference_is_degraded(tm
     fast_ids = ("lucky",)
     # High water (healthy): fails 'lucky', passes everything else -> 6. The
     # degraded reference passes only 'lucky' -> 1, so restoring health is a
-    # gain of five over the ratchet, past the noise floor of three.
+    # gain of five over the ratchet, past the noise floor.
     _seed_entry(
         tmp_path,
         1,
@@ -648,7 +648,7 @@ def test_recovery_candidate_reaches_the_search_set_when_reference_is_degraded(tm
     assert report["recovery_mode"]["baseline_objective_adjusted"] == 6
     entry = report["iterations"][0]
     assert entry["evaluated_case_set"] == "search_set"  # got past the fast tier
-    assert entry["verdict"] == "accepted"  # restored health: 6 > ratchet 1 + floor 3
+    assert entry["verdict"] == "accepted"  # restored health: 6 > ratchet 1 + floor
     assert entry["regression_baseline_iteration"] == 1
 
 


### PR DESCRIPTION
## Summary

Follow-up to #254: the loop now runs `gemma4:e4b`, so #252's figures (measured with `Ling-3.0-tiny`) are re-measured with the same three `evaluate()` calls on the same 123-case search set, `main` at `c0e9f17`:

| run | overrides | result |
|---|---|---|
| `20260912T034029Z` | none | 106/123 |
| `20260912T040928Z` | `retrieval.top_k_final=1` | 100/123 |
| `20260912T043930Z` | none | 106/123 |

No infrastructure errors, no budget exhaustion, longest answer 129 tokens (cap 4,096), every generation record `vram_fraction = 1.0`.

- **Noise floor 2** (1 up, 1 down); `NOISE_FLOOR_CASES = 2`, smallest accepted gain 3. Ling moved 3.
- **Resolution**: 17 available failures; the sabotage moves 6 net against either reference, exactly the threshold (Ling: 10 against 16). `RESOLUTION_WARNING`, `harness/README.md` and `harness/RUNBOOK.md` say so, with the Ling figures kept alongside, labelled.
- **Fast tier** re-derived from the gemma4 reference by #252's rule: 26 ids (17 failures + 9 coverage picks), ~7 min.

## Test plan

- `ruff check .` clean; full `pytest`: 1216 passed, 2 skipped (the tests that pin the figures updated to 17 / 6 / 2; the gain-equal-to-floor test now uses a gain of 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)