### PR TITLE
Tell the README reader how the corpora are fetched

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,8 +325,16 @@ an error instead of a quiz. A wrong key is the one failure here that would not
 look like one.
 Ollama is started automatically if it is installed but not running. Three fixed
 language stores — English, Castellano, Valencià — map to `rag/docs/{en,es,ca}/`.
-The `es` and `ca` stores ship with a few sample articles so a fresh clone has
-something to show; treat them as demo content and replace them with your own PDFs.
+Each holds 17 documents, but a fresh clone carries only the handful committed
+before the corpus grew: the rest are described in `rag/docs/corpus_manifest.json`
+and fetched once with
+
+```bash
+python tools/fetch_corpus.py       # --check reports what is missing without downloading
+```
+
+Treat them as demo content and replace them with your own PDFs; the evaluation
+gate is the one thing that needs all 17.
 
 The **desktop app** wraps the web interface in a Windows executable with
 [PyInstaller](https://pyinstaller.org/) and [pywebview](https://pywebview.flowrl.com/).


### PR DESCRIPTION
## Summary

The README's "Running it" section still said the `es`/`ca` stores ship a few samples. Since #213 each store holds 17 documents, most of them fetched from `rag/docs/corpus_manifest.json` by `python tools/fetch_corpus.py`; that was documented in `AGENTS.md` and `tests/eval/README.md` (#248) but not in the user-facing README.

## Test plan

Docs only. The command and flag exist (`tools/fetch_corpus.py --check`); the counts come from the manifest (11 + 12 + 12 fetched) plus the 13 committed PDFs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)